### PR TITLE
Change the pod utility images to private ones

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -54,10 +54,10 @@ plank:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20200717-cf288082e1
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20200717-cf288082e1
-        initupload: gcr.io/k8s-prow/initupload:v20200717-cf288082e1
-        sidecar: gcr.io/k8s-prow/sidecar:v20200717-cf288082e1
+        clonerefs: quay.io/powercloud/clonerefs:v20200723-4e866c62eb
+        entrypoint: quay.io/powercloud/entrypoint:v20200723-4e866c62eb
+        initupload: quay.io/powercloud/initupload:v20200723-4e866c62eb1
+        sidecar: quay.io/powercloud/sidecar:v20200723-4e866c62eb
       ssh_key_secrets:
         - bot-ssh-secret
 


### PR DESCRIPTION
This will support running the prow job's pods on multi-arch like ppc64le architecture