### PR TITLE
Restrict labels synch for the repos only

### DIFF
--- a/config/prow/cluster/label_sync_cron_job.yaml
+++ b/config/prow/cluster/label_sync_cron_job.yaml
@@ -20,7 +20,7 @@ spec:
               args:
                 - --config=/etc/config/labels.yaml
                 - --confirm=true
-                - --orgs=ppc64le-cloud,ocp-power-automation
+                - --only=ppc64le-cloud/test-infra,ocp-power-automation/ocp4-upi-powervs,ocp-power-automation/infra
                 - --token=/etc/github/token
               volumeMounts:
                 - name: oauth


### PR DESCRIPTION
Restrict only to the repos we are managing as of now to avoid unnecessary failures due to permissions issues.