### PR TITLE
Add missing packages

### DIFF
--- a/images/bazel/Dockerfile
+++ b/images/bazel/Dockerfile
@@ -5,7 +5,7 @@ ARG BAZEL_VERSION=2.2.0
 ARG UBUNTU_VERSION
 
 RUN apt-get update \
-    && apt-get install -y default-jdk gcc python python3 wget
+    && apt-get install -y default-jdk gcc git patch python python3 wget
 
 RUN wget --no-verbose https://oplab9.parqtec.unicamp.br/pub/ppc64el/bazel/ubuntu_${UBUNTU_VERSION}/bazel_bin_ppc64le_${BAZEL_VERSION} \
     && mv bazel_bin_ppc64le_${BAZEL_VERSION} /usr/local/bin/bazel \


### PR DESCRIPTION
These 2 packages were required for running the k8s tests, internal k8s hack script uses these commands for the getting the GIT version and for patching the code