### PR TITLE
Change health job to run once in 6hrs

### DIFF
--- a/config/jobs/ppc64le-cloud/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/ppc64le-cloud/test-infra/test-infra-periodics.yaml
@@ -1,5 +1,5 @@
 periodics:
-  - interval: 15m
+  - interval: 6h
     cluster: k8s-ppc64le-cluster
     name: k8s-ppc64le-cluster-health-check
     decorate: true


### PR DESCRIPTION
Previously we were running every 15mins which is not really required and making job now to run once in 6hrs