### PR TITLE
Make ibm-cloud image more generic

### DIFF
--- a/images/ibm-cloud/Dockerfile
+++ b/images/ibm-cloud/Dockerfile
@@ -1,17 +1,9 @@
 FROM ubuntu:18.04
 
 RUN apt-get update \
-  && apt-get install -y python3-pip python3-dev curl\
-  && cd /usr/local/bin \
-  && ln -s /usr/bin/python3 python \
-  && pip3 install --upgrade pip
-
-COPY requirements.txt /tmp/
-
-RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
-
-RUN curl -s -L https://clis.ng.bluemix.net/download/bluemix-cli/1.1.0/linux64 -o ibmcloud-linux64.tar.gz && \
-  tar -xf ibmcloud-linux64.tar.gz && \
-  ./Bluemix_CLI/install && \
-  rm -Rf ibmcloud-linux64.tar.gz && \
-  ibmcloud plugin install power-iaas
+    && apt-get install -y curl \
+    && curl -s -L https://clis.ng.bluemix.net/download/bluemix-cli/1.1.0/linux64 -o ibmcloud-linux64.tar.gz \
+    && tar -xf ibmcloud-linux64.tar.gz \
+    && ./Bluemix_CLI/install \
+    && rm -Rf ibmcloud-linux64.tar.gz \
+    && ibmcloud plugin install power-iaas

--- a/images/ibm-cloud/README.md
+++ b/images/ibm-cloud/README.md
@@ -5,8 +5,6 @@ This is an image which is used for accessing the IBM cloud, includes following c
 - ibmcloud command
 - ibmcloud plugins
     - powervs
-- python
-- python modules for ibm cloud
 
 ## How to build
 
@@ -17,6 +15,6 @@ $ docker push quay.io/powercloud/ibm-cloud:latest
 ```
 
 <!--
-TODO: Build logic not to install the missing libraries on ppc64le platform
+TODO: Build logic not to install the missing libraries on ppc64le platform and make this image multi-arch
 -->
 > Note: This is supported only on x86 platform because few of the required python libraries are available only in x86 platform 

--- a/images/ibm-cloud/requirements.txt
+++ b/images/ibm-cloud/requirements.txt
@@ -1,3 +1,0 @@
-ibm-cos-sdk
-cos-aspera
-PyYAML


### PR DESCRIPTION
Making this image generic so that we can extend it further anywhere needed.