### PR TITLE
Restrict the terraform release to 0.12.x version

### DIFF
--- a/config/jobs/ocp-automation/ocp4-upi-powervs/ocp4-upi-powervs-presubmit.yaml
+++ b/config/jobs/ocp-automation/ocp4-upi-powervs/ocp4-upi-powervs-presubmit.yaml
@@ -6,7 +6,7 @@ presubmits:
       clone_uri: "git@github.com:ocp-power-automation/ocp4-upi-powervs.git"
       spec:
         containers:
-          - image: hashicorp/terraform:latest
+          - image: "hashicorp/terraform:0.12.29"
             command:
               - sh
             args:


### PR DESCRIPTION
To fix the failure for https://github.com/ocp-power-automation/ocp4-upi-powervs which is not compatible with 0.13.x release yet