### PR TITLE
Remove ibm terraform provider download

### DIFF
--- a/config/jobs/ppc64le-cloud/kubetest2-plugins/kubetest2-plugins-presubmit.yaml
+++ b/config/jobs/ppc64le-cloud/kubetest2-plugins/kubetest2-plugins-presubmit.yaml
@@ -12,9 +12,6 @@ presubmits:
               - -c
               - |
                 set -o errexit
-                wget https://github.com/IBM-Cloud/terraform-provider-ibm/releases/download/v1.9.0/linux_amd64.zip
-                mkdir -p $HOME/.terraform.d/plugins
-                unzip linux_amd64.zip -d $HOME/.terraform.d/plugins
                 terraform init data/data/powervs
                 terraform validate data/data/powervs
       annotations:


### PR DESCRIPTION
Now we have the provider registered in the terraform registry, hence no more download required. https://registry.terraform.io/providers/IBM-Cloud/ibm/latest