### PR TITLE
Validate on TF 0.13 for PowerVM and PowerVS

### DIFF
--- a/config/jobs/ocp-automation/ocp4-upi-powervm/ocp4-upi-powervm-presubmit.yaml
+++ b/config/jobs/ocp-automation/ocp4-upi-powervm/ocp4-upi-powervm-presubmit.yaml
@@ -5,13 +5,15 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: hashicorp/terraform:0.12.29
+          - image: hashicorp/terraform:latest
             command:
               - sh
             args:
               - -c
               - |
                 set -o errexit
+                mkdir -p $HOME/.local/share/terraform/plugins/registry.terraform.io/terraform-providers/ignition/
+                wget https://github.com/community-terraform-providers/terraform-provider-ignition/releases/download/v2.1.0/terraform-provider-ignition_2.1.0_linux_amd64.zip -P $_
                 terraform init
                 terraform validate
       annotations:

--- a/config/jobs/ocp-automation/ocp4-upi-powervs/ocp4-upi-powervs-presubmit.yaml
+++ b/config/jobs/ocp-automation/ocp4-upi-powervs/ocp4-upi-powervs-presubmit.yaml
@@ -6,16 +6,15 @@ presubmits:
       clone_uri: "git@github.com:ocp-power-automation/ocp4-upi-powervs.git"
       spec:
         containers:
-          - image: hashicorp/terraform:0.12.29
+          - image: hashicorp/terraform:latest
             command:
               - sh
             args:
               - -c
               - |
                 set -o errexit
-                wget https://github.com/IBM-Cloud/terraform-provider-ibm/releases/download/v1.9.0/linux_amd64.zip
-                mkdir -p $HOME/.terraform.d/plugins
-                unzip linux_amd64.zip -d $HOME/.terraform.d/plugins
+                mkdir -p $HOME/.local/share/terraform/plugins/registry.terraform.io/terraform-providers/ignition/
+                wget https://github.com/community-terraform-providers/terraform-provider-ignition/releases/download/v2.1.0/terraform-provider-ignition_2.1.0_linux_amd64.zip -P $_
                 terraform init
                 terraform validate
       annotations:


### PR DESCRIPTION
- Use the latest terraform version 0.13.
- Handle ignition provider plugin (not part of TF registry) and use v2.

Fixes #48
Signed-off-by: Yussuf Shaikh <yussuf@us.ibm.com>