### PR TITLE
Use e2e test binary from the CI bucket

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -74,4 +74,4 @@ periodics:
                 --cluster-name k8s-cluster-$TIMESTAMP \;
                 --up --down --auto-approve \;
                 --powervs-memory 32 \;
-                --test=ginkgo -- --parallel 10 --test-args -host=https://k8s-cluster-$TIMESTAMP-master.k8s.test:992 --focus-regex='\[Conformance\]' --skip-regex='\[Disruptive\]|\[Serial\]';
+                --test=ginkgo -- --parallel 10 --test-package-bucket kubernetes-release-dev --test-package-dir ci --test-package-version $K8S_BUILD_VERSION --test-args -host=https://k8s-cluster-$TIMESTAMP-master.k8s.test:992 --focus-regex='\[Conformance\]' --skip-regex='\[Disruptive\]|\[Serial\]';


### PR DESCRIPTION
Now kubetest2 ginkgo tester can pull the e2e binary from the https://gcsweb.k8s.io/gcs/kubernetes-release-dev/ci/ via https://github.com/kubernetes-sigs/kubetest2/pull/49, use the same for testing now.