### PR TITLE
Remove host entry

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -89,4 +89,4 @@ periodics:
                 --cluster-name k8s-cluster-$TIMESTAMP \
                 --up --down --auto-approve \
                 --powervs-memory 32 \
-                --test=ginkgo -- --parallel 10 --test-package-bucket kubernetes-release-dev --test-package-dir ci --test-package-version $K8S_BUILD_VERSION --test-args -host=https://k8s-cluster-$TIMESTAMP-master.k8s.test:992 --focus-regex='\[Conformance\]' --skip-regex='\[Disruptive\]|\[Serial\]'
+                --test=ginkgo -- --parallel 10 --test-package-bucket kubernetes-release-dev --test-package-dir ci --test-package-version $K8S_BUILD_VERSION --test-args --focus-regex='\[Conformance\]' --skip-regex='\[Disruptive\]|\[Serial\]'


### PR DESCRIPTION
As we are updating the server URL in the kubeconfig in the kubetest2-plugins, so host entry is not required anymore.