### PR TITLE
Ignore the destroy errors if any

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -97,5 +97,6 @@ periodics:
                 --build-version $K8S_BUILD_VERSION \
                 --cluster-name k8s-cluster-$TIMESTAMP \
                 --up --down --auto-approve \
+                --ignore-destroy-errors \
                 --powervs-memory 32 \
                 --test=ginkgo -- --parallel 10 --test-package-bucket kubernetes-release-dev --test-package-dir ci --test-package-version $K8S_BUILD_VERSION --focus-regex='\[Conformance\]' --skip-regex='\[Disruptive\]|\[Serial\]'


### PR DESCRIPTION
Recently have seen terraform destroy failing in the IBM Cloud environment, this changeset is to allow the job pass if `terraform destroy` fails.