### PR TITLE
Update Prow to v20201020-a5b49bc903 version

### DIFF
--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: gcr.io/k8s-prow/crier:v20200717-cf288082e1
+          image: gcr.io/k8s-prow/crier:v20201020-a5b49bc903
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: gcr.io/k8s-prow/deck:v20200717-cf288082e1
+          image: gcr.io/k8s-prow/deck:v20201020-a5b49bc903
           args:
             - --config-path=/etc/config/config.yaml
             - --plugin-config=/etc/plugins/plugins.yaml

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20200717-cf288082e1
+          image: gcr.io/k8s-prow/ghproxy:v20201020-a5b49bc903
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: gcr.io/k8s-prow/hook:v20200717-cf288082e1
+          image: gcr.io/k8s-prow/hook:v20201020-a5b49bc903
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: horologium
-          image: gcr.io/k8s-prow/horologium:v20200717-cf288082e1
+          image: gcr.io/k8s-prow/horologium:v20201020-a5b49bc903
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - --enable-controller=plank
             - --job-config-path=/etc/job-config
             - --kubeconfig=/etc/kubeconfig/config
-          image: gcr.io/k8s-prow/prow-controller-manager:v20200717-cf288082e1
+          image: gcr.io/k8s-prow/prow-controller-manager:v20201020-a5b49bc903
           volumeMounts:
             - name: github-token
               mountPath: /etc/github

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
         - name: sinker
-          image: gcr.io/k8s-prow/sinker:v20200717-cf288082e1
+          image: gcr.io/k8s-prow/sinker:v20201020-a5b49bc903
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20200717-cf288082e1
+          image: gcr.io/k8s-prow/status-reconciler:v20201020-a5b49bc903
           args:
             - --dry-run=false
             - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: gcr.io/k8s-prow/tide:v20200717-cf288082e1
+          image: gcr.io/k8s-prow/tide:v20201020-a5b49bc903
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/images/pod-utilities/Makefile
+++ b/images/pod-utilities/Makefile
@@ -1,4 +1,4 @@
-VERSION?=v20200723-4e866c62eb
+VERSION?=v20201020-a5b49bc903
 UPSTREAM_REPO=gcr.io/k8s-prow
 PRIVATE_REPO=quay.io/powercloud
 ARCH?=amd64


### PR DESCRIPTION
Update the prow to v20201020-a5b49bc903 version

To include the fix - https://github.com/kubernetes/test-infra/pull/18001

https://github.ibm.com/powercloud/container-dev/issues/1328