### PR TITLE
Typo in 'periodic kubernetes unit tests'  and 'periodic golang build' job

### DIFF
--- a/config/jobs/periodic/golang/build-golang-periodics.yaml
+++ b/config/jobs/periodic/golang/build-golang-periodics.yaml
@@ -1,5 +1,5 @@
 periodics:
-  - name: periodics-golang-master-build-ppc64le
+  - name: periodic-golang-master-build-ppc64le
     cluster: k8s-ppc64le-cluster
     decorate: true
     interval: 1h

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -1,5 +1,5 @@
 periodics:
-  - name: periodics-kubernetes-bazel-test-ppc64le
+  - name: periodic-kubernetes-bazel-test-ppc64le
     cluster: k8s-ppc64le-cluster
     decorate: true
     decoration_config:


### PR DESCRIPTION
Typo: The Periodic prow job for kubernetes unit tests has an extra s in the name. Hence changing job name from "periodics-kubernetes-bazel-test-ppc64le" to "periodic-kubernetes-bazel-test-ppc64le".
Also the typo in "periodics-golang-master-build-ppc64le " is fixed.