### PR TITLE
Added timeout to 600s for k8s unit tests job

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -23,6 +23,7 @@ periodics:
             - ../test-infra/hack/bazel.sh
           args:
             - test
+            - --test_timeout=600
             - --config=unit
             - --features=-race     # TO-DO: This need to be fixed!
             - --host_javabase=@local_jdk//:jdk


### PR DESCRIPTION
Ref: https://github.ibm.com/powercloud/container-dev/issues/1335