### PR TITLE
Adopt new centos 8.3 image for all the testing

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -100,7 +100,7 @@ periodics:
               chmod +x /usr/local/bin/kubectl
 
               kubetest2 tf --powervs-dns k8s-tests \
-                --powervs-image-name centos-82-09232020 \
+                --powervs-image-name centos-83-12082020 \
                 --powervs-region syd --powervs-zone syd04 \
                 --powervs-service-id 013b8948-6cf4-4fae-9b70-71ddadd4f91a \
                 --powervs-ssh-key powercloud-bot-key \
@@ -179,7 +179,7 @@ periodics:
               chmod +x /usr/local/bin/kubectl
 
               kubetest2 tf --powervs-dns k8s-tests \
-                --powervs-image-name centos-82-09232020 \
+                --powervs-image-name centos-83-12082020 \
                 --powervs-region syd --powervs-zone syd04 \
                 --powervs-service-id 013b8948-6cf4-4fae-9b70-71ddadd4f91a \
                 --powervs-ssh-key powercloud-bot-key \

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -157,7 +157,7 @@ postsubmits:
                 wget -qO- $URL/kubernetes-client-linux-ppc64le.tar.gz | tar xz -C /usr/local/bin --strip-components=3
 
                 kubetest2 tf --powervs-dns k8s-tests \
-                    --powervs-image-name centos-82-09232020 \
+                    --powervs-image-name centos-83-12082020 \
                     --powervs-region syd --powervs-zone syd04 \
                     --powervs-service-id 013b8948-6cf4-4fae-9b70-71ddadd4f91a \
                     --powervs-ssh-key powercloud-bot-key \


### PR DESCRIPTION
https://github.ibm.com/powercloud/container-dev/issues/1357

Changing k8s conformance prow jobs to use centos 8.3 images for test cluster creation.