### PR TITLE
Increase TIMEOUT value to 600s for k8s UT using master golang

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -68,7 +68,7 @@ postsubmits:
                 set -o pipefail
                 set -o xtrace
 
-                export KUBE_TIMEOUT='--timeout=300s'
+                export KUBE_TIMEOUT='--timeout=600s'
                 export KUBE_COVER="n"
                 export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
                 export LOG_LEVEL=4


### PR DESCRIPTION
This PR is to increase the KUBE_TIMEOUT value of postsubmit-master-golang-kubernetes-unit-test-ppc64le job.

Have observed the test `k8s.io/kubernetes/pkg/controlplane` is passing when run locally. Moreover, all the prow job runs, mention time of execution of this test as 300s though there isnt any explicit mention of timed out failure, I suspect this consistent failure wouldn't occur on increasing the timeout value.

https://github.ibm.com/powercloud/container-dev/issues/1365