### PR TITLE
Adding k8s-build-version as metadata information to finished.json

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -94,6 +94,7 @@ periodics:
 
               TIMESTAMP=$(date +%s)
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt)
+              jq --arg key0 'k8s-build-version' --arg value0 $K8S_BUILD_VERSION '. | .[$key0]=$value0' <<<'{}' > $ARTIFACTS/metadata.json
 
               # kubectl needed for the e2e tests
               curl -sSL https://dl.k8s.io/ci/$K8S_BUILD_VERSION/bin/linux/`go env GOARCH`/kubectl > /usr/local/bin/kubectl
@@ -174,6 +175,7 @@ periodics:
 
               TIMESTAMP=$(date +%s)
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt)
+              jq --arg key0 'k8s-build-version' --arg value0 $K8S_BUILD_VERSION '. | .[$key0]=$value0' <<<'{}' > $ARTIFACTS/metadata.json
 
               # kubectl needed for the e2e tests
               curl -sSL https://dl.k8s.io/ci/$K8S_BUILD_VERSION/bin/linux/`go env GOARCH`/kubectl > /usr/local/bin/kubectl


### PR DESCRIPTION
This PR is to add a `metadata.json` file, to artifacts folder in logs with the information about `k8s-build-version` used for periodic ppc64le conformance jobs.

The podutils takecare of merging the` metadata.json` file into `finished.json`.

This new key in `finished.json` enables us to customize column header in test-grid with `k8s-build-version` and its value.
https://github.com/kubernetes/test-infra/blob/master/testgrid/config.md#column-headers