### PR TITLE
Add gcs credentials to the crier Deployment

### DIFF
--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -25,6 +25,7 @@ spec:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml
             - --s3-credentials-file=/etc/s3-credentials/service-account.json
+            - --gcs-credentials-file=/etc/gcs-credentials/service-account.json
             - --github-host=github.com
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
@@ -51,6 +52,9 @@ spec:
             - name: s3-credentials
               mountPath: /etc/s3-credentials
               readOnly: true
+            - name: gcs-credentials
+              mountPath: /etc/gcs-credentials
+              readOnly: true
             - name: slack
               mountPath: /etc/slack
               readOnly: true
@@ -71,6 +75,9 @@ spec:
         - name: s3-credentials
           secret:
             secretName: s3-credentials
+        - name: gcs-credentials
+          secret:
+            secretName: gcs-credentials
         - name: slack
           secret:
             secretName: slack-token


### PR DESCRIPTION
There was a failure in the crier component of prow while trying to upload pod info to GCS.

```{"bucket":"ppc64le-kubernetes","component":"crier","error":"googleapi: Error 401: Anonymous caller does not have storage.objects.create access to the Google Cloud Storage object., required","file":"prow/crier/reporters/gcs/internal/util/util.go:72","func":"k8s.io/test-infra/prow/crier/reporters/gcs/internal/util.WriteContent","jobName":"periodic-kubernetes-conformance-test-ppc64le","jobStatus":"success","key":"prow/00eb5492-4e5f-11eb-b6c7-a6771cc2c24a","level":"warning","msg":"Uploading info to storage failed (close)","overwrite":true,"path":"logs/periodic-kubernetes-conformance-test-ppc64le/1345996513871925248/podinfo.json","prowjob":"00eb5492-4e5f-11eb-b6c7-a6771cc2c24a","reporter":"gcsk8sreporter","severity":"warning","time":"2021-01-06T08:12:31Z"}```

This access for crier to GCS is essential for pushing artifacts and Tearing down the test pods. This was causing the pods to be stuck in a Terminating state.
Once crier gained the access to GCS, the artifacts were successfully pushed, which leads to the Finalizer `prow.x-k8s.io/gcsk8sreporter` to be removed from pod metadata and hence the pod was Terminated successfully.

https://github.ibm.com/powercloud/container-dev/issues/1349
