### PR TITLE
Adopt the upstream k8s ingress controller

### DIFF
--- a/config/prow/cluster/prow_ingress.yaml
+++ b/config/prow/cluster/prow_ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     # Change this to your issuer when using cert-manager. Does
     # nothing when not using cert-manager.
     cert-manager.io/cluster-issuer: letsencrypt-staging
+    kubernetes.io/ingress.class: public-iks-k8s-nginx
 spec:
   backend:
     # specify the default backend for `ingress-gce` (https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#prow_backend)


### PR DESCRIPTION
With the latest IKS adoption of upstream ingress controller, this annotation is required to create the right entry in the ingress