### PR TITLE
Fixing 141 error - SIGPIPE caused by head command in prow job `periodic-gcs-logs-cleanup`

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-gcs-logs-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-gcs-logs-periodics.yaml
@@ -43,7 +43,7 @@ periodics:
                 rows=$(gsutil ls gs://ppc64le-kubernetes/logs/$job | wc -l)
                 while [ $rows -gt $n ]
                 do
-                        LOG_PATH=$(gsutil ls gs://ppc64le-kubernetes/logs/$job | sort | head -1)
+                        LOG_PATH=$(head -1 <(gsutil ls gs://ppc64le-kubernetes/logs/$job | sort))
                         gsutil -m mv -r $LOG_PATH .
                         LOG_FOLDER=`basename $LOG_PATH`
                         FILENAMES=`find $LOG_FOLDER -type f`


### PR DESCRIPTION
Fixing the below error caused by periodic job `periodic-gcs-logs-cleanup`:
```{"component":"entrypoint","error":"wrapped process failed: exit status 141","file":"prow/entrypoint/run.go:80","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2021-01-21T09:09:00Z"}```

Sources:
https://github.com/stedolan/jq/issues/1017
http://www.greenend.org.uk/rjk/tech/shellmistakes.html#pipeerrors
https://stackoverflow.com/questions/41516177/bash-zcat-head-causes-pipefail
https://github.com/openshift/assisted-test-infra/pull/157

[fail_job.log](https://github.com/ppc64le-cloud/test-infra/files/5866836/fail_job.log)
[pass.log](https://github.com/ppc64le-cloud/test-infra/files/5866838/pass.log)

