### PR TITLE
Modified pod-utilities Dockerfile and version in Makefile

### DIFF
--- a/images/pod-utilities/Dockerfile
+++ b/images/pod-utilities/Dockerfile
@@ -1,33 +1,15 @@
 ARG POD_UTILITY=clonerefs
-FROM ppc64le/ubuntu:18.04 as builder
+FROM golang:1.15 as builder
 
-ARG UBUNTU_VERSION=18.04
-ARG BAZEL_VERSION=3.1.0
-ARG DEBIAN_FRONTEND=noninteractive
 ARG POD_UTILITY
 ARG CO_COMMIT=master
 
-COPY nodejs.patch /tmp
-
-RUN apt-get update && apt-get install -y \
-    default-jdk \
-    g++ \
-    git \
-    python \
-    python3 \
-    python3-dev \
-    wget
-
-RUN wget --no-verbose https://oplab9.parqtec.unicamp.br/pub/ppc64el/bazel/ubuntu_${UBUNTU_VERSION}/bazel_bin_ppc64le_${BAZEL_VERSION} \
-    && mv bazel_bin_ppc64le_${BAZEL_VERSION} /usr/local/bin/bazel \
-    && chmod +x /usr/local/bin/bazel
+RUN apt-get update && apt-get install -y git
 
 RUN git clone https://github.com/kubernetes/test-infra.git \
     && cd test-infra \
     && git checkout ${CO_COMMIT} \
-    && patch -p1 < /tmp/nodejs.patch \
-    && bazel build //prow/cmd/${POD_UTILITY} \
-    && cp bazel-bin/prow/cmd/${POD_UTILITY}/linux_ppc64le_pure_stripped/${POD_UTILITY} /usr/local/bin/${POD_UTILITY}
+    && go build -o /usr/local/bin/${POD_UTILITY} ./prow/cmd/${POD_UTILITY}
 
 FROM alpine:latest
 ARG POD_UTILITY

--- a/images/pod-utilities/Makefile
+++ b/images/pod-utilities/Makefile
@@ -1,4 +1,4 @@
-VERSION?=v20201020-a5b49bc903
+VERSION?=v20210126-f0baa5f3d9
 UPSTREAM_REPO=gcr.io/k8s-prow
 PRIVATE_REPO=quay.io/powercloud
 ARCH?=amd64


### PR DESCRIPTION
Changing the Dockerfile for pod-utilities to use `go build` instead of the existing `bazel build`.
Bazel has not been offering stable output paths. Hence switching to go build.

Please view the below discussion to understand the issue faced while building images for pod-utilites using bazel:
https://ibm-systems.slack.com/archives/G01CH7AC8H1/p1611726443000700
