### PR TITLE
Changing the pod-utilities image to use alpine distro for builder

### DIFF
--- a/images/pod-utilities/Dockerfile
+++ b/images/pod-utilities/Dockerfile
@@ -1,10 +1,10 @@
 ARG POD_UTILITY=clonerefs
-FROM golang:1.15 as builder
+FROM golang:1.15-alpine as builder
 
 ARG POD_UTILITY
 ARG CO_COMMIT=master
 
-RUN apt-get update && apt-get install -y git
+RUN apk update && apk add git cmake make gcc libtool musl-dev g++
 
 RUN git clone https://github.com/kubernetes/test-infra.git \
     && cd test-infra \


### PR DESCRIPTION
The prow jobs have been failing with the below error since they started using the latest upgraded pod-utilities:
PR that changed the Dockerfile: https://github.com/ppc64le-cloud/test-infra/pull/121
```
Terminated (Error - standard_init_linux.go:219: exec user process caused: no such file or directory ) at 2021-02-01 12:45:10 +0000 UTC with exit code 1
```
Below was the error in the container run with the latest pod-utility image:
```
/ # file entrypoint
entrypoint: ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), dynamically linked, interpreter /lib64/ld64.so.2, for GNU/Linux 3.10.0, Go BuildID=gJ7tMAtoMImlgIlJJL4U/AUcj39ZVBFhChtJDUtkX/AvvdNimJKONtJa8upcDH/9w4f2F-7V_TFYLTDHQrb, BuildID[sha1]=88f74bed2894e2ab363f287a1e780d1587cd99ee, not stripped
/ # ./entrypoint
/lib64/ld64.so.2: No such file or directory
/ #openshift-on-power 
```
Changing the builder image to alpine fixed this!