### PR TITLE
Change prow pod-utilities to build binaries statically

### DIFF
--- a/images/pod-utilities/Dockerfile
+++ b/images/pod-utilities/Dockerfile
@@ -1,15 +1,15 @@
 ARG POD_UTILITY=clonerefs
-FROM golang:1.15-alpine as builder
+FROM golang:1.15 as builder
 
 ARG POD_UTILITY
 ARG CO_COMMIT=master
 
-RUN apk update && apk add git cmake make gcc libtool musl-dev g++
+RUN apt-get update && apt-get install -y git
 
 RUN git clone https://github.com/kubernetes/test-infra.git \
     && cd test-infra \
     && git checkout ${CO_COMMIT} \
-    && go build -o /usr/local/bin/${POD_UTILITY} ./prow/cmd/${POD_UTILITY}
+    && CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /usr/local/bin/${POD_UTILITY} ./prow/cmd/${POD_UTILITY}
 
 FROM alpine:latest
 ARG POD_UTILITY


### PR DESCRIPTION
This PR is to change the Dockerfile for pod-utilities used by prow jobs.
It is now modified to build binaries statically using below command:
`CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /usr/local/bin/${POD_UTILITY} ./prow/cmd/${POD_UTILITY}`

Also rolling back the recent change of adopting alpine distro for the builder image.