### PR TITLE
Changed the wrong image name for k8s conformance jobs

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -101,7 +101,7 @@ periodics:
               chmod +x /usr/local/bin/kubectl
 
               kubetest2 tf --powervs-dns k8s-tests \
-                --powervs-image-name centos-83-12082020 \
+                --powervs-image-name centos-83-12142020 \
                 --powervs-region tok --powervs-zone tok04 \
                 --powervs-service-id e13a10d2-9c2b-4d7b-b2fc-7a2b9edf1abf \
                 --powervs-ssh-key powercloud-bot-key \
@@ -182,7 +182,7 @@ periodics:
               chmod +x /usr/local/bin/kubectl
 
               kubetest2 tf --powervs-dns k8s-tests \
-                --powervs-image-name centos-83-12082020 \
+                --powervs-image-name centos-83-12142020 \
                 --powervs-region tok --powervs-zone tok04 \
                 --powervs-service-id e13a10d2-9c2b-4d7b-b2fc-7a2b9edf1abf \
                 --powervs-ssh-key powercloud-bot-key \

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -157,7 +157,7 @@ postsubmits:
                 wget -qO- $URL/kubernetes-client-linux-ppc64le.tar.gz | tar xz -C /usr/local/bin --strip-components=3
 
                 kubetest2 tf --powervs-dns k8s-tests \
-                    --powervs-image-name centos-83-12082020 \
+                    --powervs-image-name centos-83-12142020 \
                     --powervs-region tok --powervs-zone tok04 \
                     --powervs-service-id e13a10d2-9c2b-4d7b-b2fc-7a2b9edf1abf \
                     --powervs-ssh-key powercloud-bot-key \


### PR DESCRIPTION
Changing the image name for below k8s conformance jobs to the available one `centos-83-12142020 `.

```
periodic-kubernetes-conformance-test-ppc64le
periodic-kubernetes-containerd-conformance-test-ppc64le
postsubmit-master-golang-kubernetes-conformance-test-ppc64le
```
