### PR TITLE
Changing k8s cluster names deployed by conformance jobs

### DIFF
--- a/config/jobs/CLUSTERCONFIGS.md
+++ b/config/jobs/CLUSTERCONFIGS.md
@@ -1,0 +1,8 @@
+# These are the config details of the k8s clusters deployed on powervs by the conformance prow jobs.
+
+| Cluster Name        | Job that created                                             | K8S_BUILD_VERSION                                                  | runtime    |
+|---------------------|--------------------------------------------------------------|--------------------------------------------------------------------|------------|
+| config1-<Timestamp> | periodic-kubernetes-conformance-test-ppc64le                 | latest nightly build from upstream                                 | docker     |
+| config2-<Timestamp> | periodic-kubernetes-containerd-conformance-test-ppc64le      | latest nightly build from upstream                                 | containerd |
+| config3-<Timestamp> | postsubmit-master-golang-kubernetes-conformance-test-ppc64le | k8s built by job postsubmit-kubernetes-build-golang-master-ppc64le | docker     |
+

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -107,7 +107,7 @@ periodics:
                 --powervs-ssh-key powercloud-bot-key \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \
                 --build-version $K8S_BUILD_VERSION \
-                --cluster-name k8s-cluster-$TIMESTAMP \
+                --cluster-name config1-$TIMESTAMP \
                 --up --down --auto-approve --retry-on-tf-failure 3 \
                 --break-kubetest-on-upfail true \
                 --ignore-destroy-errors \
@@ -189,7 +189,7 @@ periodics:
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \
                 --build-version $K8S_BUILD_VERSION \
                 --runtime containerd \
-                --cluster-name k8s-cluster-$TIMESTAMP \
+                --cluster-name config2-$TIMESTAMP \
                 --up --down --auto-approve --retry-on-tf-failure 3 \
                 --break-kubetest-on-upfail true \
                 --ignore-destroy-errors \

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -164,7 +164,7 @@ postsubmits:
                     --ssh-private-key /etc/secret-volume/ssh-privatekey \
                     --build-version $K8S_BUILD_VERSION \
                     --s3-server $S3_SERVER --bucket $BUCKET  --directory $DIRECTORY \
-                    --cluster-name k8s-cluster-$TIMESTAMP \
+                    --cluster-name config3-$TIMESTAMP \
                     --up --down --auto-approve --retry-on-tf-failure 3 \
                     --break-kubetest-on-upfail true \
                     --ignore-destroy-errors \
@@ -172,4 +172,4 @@ postsubmits:
                     --test=exec -- /usr/local/bin/ginkgo --nodes=10 /usr/local/bin/e2e.test \
                     -- --ginkgo.focus='\[Conformance\]' \
                     --ginkgo.skip='\[Disruptive\]|\[Serial\]' --report-dir=$ARTIFACTS \
-                    --kubeconfig="$(pwd)/k8s-cluster-$TIMESTAMP/kubeconfig"
+                    --kubeconfig="$(pwd)/config3-$TIMESTAMP/kubeconfig"


### PR DESCRIPTION
This PR is to change the cluster-name from k8s-cluster-$TIMESTAMP to the below names:

`periodic-kubernetes-conformance-test-ppc64le` - config1-$TIMESTAMP
`periodic-kubernetes-containerd-conformance-test-ppc64le`- config2-$TIMESTAMP
`postsubmit-master-golang-kubernetes-conformance-test-ppc64le` - config3-$TIMESTAMP

Also adding a file to have the configuration details for the clusters created.