### PR TITLE
Escape the angle brackets in CLUSTERCONFIGS.md for proper cluster names

### DIFF
--- a/config/jobs/CLUSTERCONFIGS.md
+++ b/config/jobs/CLUSTERCONFIGS.md
@@ -2,7 +2,7 @@
 
 | Cluster Name        | Job that created                                             | K8S_BUILD_VERSION                                                  | runtime    |
 |---------------------|--------------------------------------------------------------|--------------------------------------------------------------------|------------|
-| config1-<Timestamp> | periodic-kubernetes-conformance-test-ppc64le                 | latest nightly build from upstream                                 | docker     |
-| config2-<Timestamp> | periodic-kubernetes-containerd-conformance-test-ppc64le      | latest nightly build from upstream                                 | containerd |
-| config3-<Timestamp> | postsubmit-master-golang-kubernetes-conformance-test-ppc64le | k8s built by job postsubmit-kubernetes-build-golang-master-ppc64le | docker     |
+| config1-\<Timestamp\> | periodic-kubernetes-conformance-test-ppc64le                 | latest nightly build from upstream                                 | docker     |
+| config2-\<Timestamp\> | periodic-kubernetes-containerd-conformance-test-ppc64le      | latest nightly build from upstream                                 | containerd |
+| config3-\<Timestamp\> | postsubmit-master-golang-kubernetes-conformance-test-ppc64le | k8s built by job postsubmit-kubernetes-build-golang-master-ppc64le | docker     |
 


### PR DESCRIPTION
The intended cluster name `config1-<Timestamp>` is wrongly displayed as `config1-` in the UI.
Thus escaping the angle brackets for appropriate names.