### PR TITLE
Change of periodic-gcs-logs-cleanup to use googlecloudstorageclient instead of gsutil

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-gcs-logs-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-gcs-logs-periodics.yaml
@@ -4,9 +4,6 @@ periodics:
     interval: 12h
     spec:
       volumes:
-        - name: s3-cred
-          secret:
-            secretName: s3-credentials
         - name: gcs-cred
           secret:
             secretName: gcs-credentials
@@ -15,9 +12,6 @@ periodics:
           command:
             - /bin/bash
           volumeMounts:
-            - name: s3-cred
-              mountPath: /etc/s3-cred
-              readOnly: true
             - name: gcs-cred
               mountPath: /etc/gcs-cred
               readOnly: true
@@ -28,40 +22,13 @@ periodics:
               set -o nounset
               set -o pipefail
               set -o xtrace
-
-              Jobs=("periodic-kubernetes-bazel-test-ppc64le" "periodic-kubernetes-conformance-test-ppc64le" "periodic-kubernetes-containerd-conformance-test-ppc64le")
-              #No. of Days for which result to be displayed in test-grid
-              Days=("15" "7" "7")
-              interval=3
-              NooJobs=${#Jobs[@]}
-              declare -A n
-              for ((i=0; i<$NooJobs; i++))
-              do
-                runs_per_day[i]=$((24/$interval))
-                total_runs=$((${runs_per_day[i]}*${Days[i]}))
-                #No. of entries to be left in GCS.
-                #Additional 20 folders are left due to dummy builds stuck in Pending state.
-                n[${Jobs[i]}]=$(($total_runs+20))
-              done
-              pip install awscli
-              gcloud auth activate-service-account --key-file /etc/gcs-cred/service-account.json
-              access_key=$(jq -r .access_key /etc/s3-cred/service-account.json)
-              secret_key=$(jq -r .secret_key /etc/s3-cred/service-account.json)
-              export AWS_ACCESS_KEY_ID=$access_key
-              export AWS_SECRET_ACCESS_KEY=$secret_key
-              s3_url="https://s3.us-south.cloud-object-storage.appdomain.cloud"
-              for job in ${Jobs[@]}; do
-                rows=$(gsutil ls gs://ppc64le-kubernetes/logs/$job | wc -l)
-                while [ $rows -gt ${n[$job]} ]
-                do
-                        LOG_PATH=$(head -1 <(gsutil ls gs://ppc64le-kubernetes/logs/$job | sort))
-                        gsutil -m mv -r $LOG_PATH .
-                        LOG_FOLDER=`basename $LOG_PATH`
-                        FILENAMES=`find $LOG_FOLDER -type f`
-                        for eachfile in $FILENAMES;do
-                                aws s3 --endpoint $s3_url cp ./$eachfile s3://prow-logs/logs/$job/$eachfile
-                        done
-                        rm -r ./$LOG_FOLDER
-                        rows=$(gsutil ls gs://ppc64le-kubernetes/logs/$job/ | wc -l)
-                done
-              done
+              go get  github.com/ppc64le-cloud/gcs-cleaner
+              cat >config.yml <<EOL
+              - dir: logs/periodic-kubernetes-bazel-test-ppc64le
+                daysLimit: 15
+              - dir: logs/periodic-kubernetes-conformance-test-ppc64le
+                daysLimit: 7
+              - dir: logs/periodic-kubernetes-containerd-conformance-test-ppc64le
+                daysLimit: 7
+              EOL
+              $(go env GOPATH)/bin/gcs-cleaner


### PR DESCRIPTION
Changing the existing periodic job `periodic-gcs-logs-cleanup` to use googlecloudstorageclient instead of gsutil to delete the objects older than the specified no. of days in the config file.
Removing the current logic of moving the logs to IBM COS s3 storage as per the below comment:
https://github.ibm.com/powercloud/container-dev/issues/1375#issuecomment-27545024