### PR TITLE
Disable periodic-powervs-cleanup job to debug VM deployment failure

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
@@ -23,4 +23,4 @@ periodics:
               chmod +x /usr/local/bin/pvsadm
 
               # delete all the vms created before 4hrs
-              pvsadm purge vms --instance-id e13a10d2-9c2b-4d7b-b2fc-7a2b9edf1abf --before 4h --ignore-errors --no-prompt
+              pvsadm purge vms --instance-id e13a10d2-9c2b-4d7b-b2fc-7a2b9edf1abf --dry-run --before 4h --ignore-errors --no-prompt


### PR DESCRIPTION
Disabling the cleanup job by passing the flag `--dry-run` to `pvsadm purge` command.