### PR TITLE
Cerberus pod/related configmaps specs to monitor Prow Controller Health

### DIFF
--- a/config/prow/cluster/cerberus_configmaps.yaml
+++ b/config/prow/cluster/cerberus_configmaps.yaml
@@ -1,0 +1,646 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cerberus-config
+  namespace: prow
+data:
+  kubernetes_config.yaml: |
+    cerberus:
+        distribution: kubernetes                             # Distribution can be kubernetes or openshift
+        kubeconfig_path: /root/.kube/config                      # Path to kubeconfig
+        watch_nodes: False                                    # Set to True for the cerberus to monitor the cluster nodes
+        watch_cluster_operators: False                       # Set to True for cerberus to monitor cluster operators. Enable it only when distribution is openshift
+        watch_url_routes:                                    # Route url's you want to monitor, this is a double array with the url and optional authorization parameter
+        cerberus_publish_status: True                        # When enabled, cerberus starts a light weight http server and publishes the status
+        inspect_components: False                            # Enable it only when OpenShift client is supported to run
+                                                             # When enabled, cerberus collects logs, events and metrics of failed components
+
+        prometheus_url:                                      # The prometheus url/route is automatically obtained in case of OpenShift, please set it when the distribution is Kubernetes.
+        prometheus_bearer_token:                             # The bearer token is automatically obtained in case of OpenShift, please set it when the distribution is Kubernetes. This is needed to authenticate with prometheus.
+                                                             # This enables Cerberus to query prometheus and alert on observing high Kube API Server latencies.
+
+        slack_integration: True                              # When enabled, cerberus reports the failed iterations in the slack channel
+                                                             # The following env vars needs to be set: SLACK_API_TOKEN ( Bot User OAuth Access Token ) and SLACK_CHANNEL ( channel to send notifications in case of failures )
+                                                             # When slack_integration is enabled, a watcher can be assigned for each day. The watcher of the day is tagged while reporting failures in the slack channel. Values are slack member ID's.
+        watcher_slack_ID:                                        # (NOTE: Defining the watcher id's is optional and when the watcher slack id's are not defined, the slack_team_alias tag is used if it is set else no tag is used while reporting failures in the slack channel.)
+            Monday:
+            Tuesday:
+            Wednesday:
+            Thursday:
+            Friday:
+            Saturday:
+            Sunday:
+        slack_team_alias: prow-job-alert                         # The slack team alias to be tagged while reporting failures in the slack channel when no watcher is assigned
+        custom_checks:
+            -   custom_checks/check_pod_controller_health.py
+
+    tunings:
+        iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled
+        sleep_time: 60                                       # Sleep duration between each iteration
+        daemon_mode: True                                    # Iterations are set to infinity which means that the cerberus will monitor the resources forever
+
+    database:
+        database_path: /tmp/cerberus.db                      # Path where cerberus database needs to be stored
+        reuse_database: False                                # When enabled, the database is reused to store the failures
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cerberus-custom-check
+  namespace: prow
+data:
+  check_pod_controller_health.py: |
+    import logging
+    import cerberus.invoke.command as runcommand
+
+
+    def check_name():
+        logging.info("Check health of prow controller\n")
+
+    def check():
+        pod_name =  runcommand.invoke("kubectl -n prow get pods -o custom-columns=\":metadata.name\" | grep controller")
+        pod_log = runcommand.invoke("kubectl -n prow logs %s" % (pod_name))
+
+        if ((pod_log.find("Failed to get API Group-Resources")) != -1):
+            message = "Prow controller Pod has Error"
+            logging.info(message)
+            return False, message
+        else:
+            message = "Prow controller Pod has No Error"
+            logging.info(message)
+            return True, message
+
+    def main():
+        check_name()
+        status, message = check()
+        return {'status':status, 'message':message}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cerberus-slack-client
+  namespace: prow
+data:
+  slack_client.py: |
+    import os
+    import slack
+    import logging
+    import datetime
+    import cerberus.invoke.command as runcommand
+
+
+    # Load env variables and initialize slack python client
+    def initialize_slack_client():
+        try:
+            global slack_reporter_token, slack_channel_ID, slack_client
+            slack_reporter_token = os.environ["SLACK_API_TOKEN"]
+            slack_channel_ID = os.environ["SLACK_CHANNEL"]
+            slack_client = slack.WebClient(token=slack_reporter_token)
+            logging.info("Slack integration has been enabled")
+            return True
+        except Exception as e:
+            logging.error("Couldn't create slack WebClient. Check if slack env "
+                          "varaibles are set. Exception: %s" % (e))
+            logging.info("Slack integration has been disabled")
+            return False
+
+
+    # Post messages and failures in slack
+    def post_message_in_slack(slack_message, thread_ts=None):
+        slack_client.chat_postMessage(
+            channel=slack_channel_ID,
+            link_names=True,
+            text=slack_message,
+            thread_ts=thread_ts
+        )
+
+
+    # Get members of a channel
+    def get_channel_members():
+        return slack_client.conversations_members(
+            channel=slack_channel_ID
+        )
+
+
+    # slack tag to be used while reporitng in slack channel
+    def slack_tagging(watcher_slack_member_ID, slack_team_alias):
+        global slack_tag, valid_watchers
+        valid_watchers = get_channel_members()['members']
+        if watcher_slack_member_ID in valid_watchers:
+            slack_tag = "<@" + watcher_slack_member_ID + ">"
+        elif slack_team_alias:
+            slack_tag = "@" + slack_team_alias + " "
+        else:
+            slack_tag = ""
+
+
+    # Report the start of cerberus cluster monitoring in slack channel
+    def slack_report_cerberus_start(cluster_info, weekday, watcher_slack_member_ID):
+        response = slack_client.chat_postMessage(channel=slack_channel_ID,
+                                                 link_names=True,
+                                                 text="%s Cerberus has started monitoring! "":skull_and_crossbones: %s" % (slack_tag, cluster_info)) # noqa
+        global thread_ts
+        thread_ts = response['ts']
+        if watcher_slack_member_ID in valid_watchers:
+            post_message_in_slack("Hi " + slack_tag + "! The watcher for " + weekday + "!\n", thread_ts)
+
+
+    # Report the nodes and namespace failures in slack channel
+    def slack_logging(cluster_info, iteration, watch_nodes_status, failed_nodes,
+                      watch_cluster_operators_status, failed_operators,
+                      watch_namespaces_status, failed_pods_components,
+                      custom_checks_status, custom_checks_fail_messages):
+        issues = []
+        cerberus_report_path = runcommand.invoke("pwd | tr -d '\n'")
+        if not watch_nodes_status:
+            issues.append("*nodes: " + ", ".join(failed_nodes) + "*")
+        if not watch_cluster_operators_status:
+            issues.append("*cluster operators: " + ", ".join(failed_operators) + "*")
+        if not watch_namespaces_status:
+            issues.append("*namespaces: " + ", ".join(list(failed_pods_components.keys())) + "*")
+        if not custom_checks_status:
+            issues.append("*custom_checks: " + ", ".join(custom_checks_fail_messages) + "*")
+        issues = "\n".join(issues)
+        post_message_in_slack(slack_tag + " %sIn iteration %d at %s, Cerberus "
+                              "found issues in: \n%s \nHence, setting the "
+                              "go/no-go signal to false. \nThe full report "
+                              "is at *%s* on the host cerberus is running."
+                              % (cluster_info, iteration,
+                                  datetime.datetime.now().replace(microsecond=0).isoformat(),
+                                  issues, cerberus_report_path), thread_ts)
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cerberus-start
+  namespace: prow
+data:
+  start_cerberus.py: |
+        #!/usr/bin/env python
+
+        import os
+        import sys
+        import yaml
+        import time
+        import json
+        import signal
+        import logging
+        import optparse
+        import pyfiglet
+        import functools
+        import importlib
+        import multiprocessing
+        from itertools import repeat
+        from datetime import datetime
+        from collections import defaultdict
+        import cerberus.server.server as server
+        import cerberus.inspect.inspect as inspect
+        import cerberus.invoke.command as runcommand
+        import cerberus.kubernetes.client as kubecli
+        import cerberus.slack.slack_client as slackcli
+        import cerberus.prometheus.client as promcli
+        import cerberus.database.client as dbcli
+
+
+        def smap(f):
+            return f()
+
+
+        def init_worker():
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
+        # Publish the cerberus status
+        def publish_cerberus_status(status):
+            with open('/tmp/cerberus_status', 'w+') as file:
+                file.write(str(status))
+
+
+        # Create a json file of operation timings
+        def record_time(time_tracker):
+            if time_tracker:
+                average = defaultdict(float)
+                for check in time_tracker["Iteration 1"]:
+                    iterations = 0
+                    for values in time_tracker.values():
+                        if check in values:
+                            average[check] += values[check]
+                            iterations += 1
+                    average[check] /= iterations
+                time_tracker["Average"] = average
+            with open('./time_tracker.json', 'w+') as file:
+                json.dump(time_tracker, file, indent=4, separators=(',', ': '))
+
+
+        # Main function
+        def main(cfg):
+            # Start cerberus
+            print(pyfiglet.figlet_format("cerberus"))
+            logging.info("Starting ceberus")
+
+            # Parse and read the config
+            if os.path.isfile(cfg):
+                with open(cfg, 'r') as f:
+                    config = yaml.full_load(f)
+                distribution = config["cerberus"].get("distribution", "openshift").lower()
+                kubeconfig_path = config["cerberus"].get("kubeconfig_path", "")
+                port = config["cerberus"].get("port", 8080)
+                watch_nodes = config["cerberus"].get("watch_nodes", False)
+                watch_cluster_operators = config["cerberus"].get("watch_cluster_operators", False)
+                watch_namespaces = config["cerberus"].get("watch_namespaces", [])
+                watch_url_routes = config["cerberus"].get("watch_url_routes", [])
+                cerberus_publish_status = config["cerberus"].get("cerberus_publish_status", False)
+                inspect_components = config["cerberus"].get("inspect_components", False)
+                slack_integration = config["cerberus"].get("slack_integration", False)
+                prometheus_url = config["cerberus"].get("prometheus_url", "")
+                prometheus_bearer_token = config["cerberus"].get("prometheus_bearer_token", "")
+                custom_checks = config["cerberus"].get("custom_checks", [])
+                iterations = config["tunings"].get("iterations", 0)
+                sleep_time = config["tunings"].get("sleep_time", 0)
+                request_chunk_size = config["tunings"].get("kube_api_request_chunk_size", 250)
+                daemon_mode = config["tunings"].get("daemon_mode", False)
+                cores_usage_percentage = config["tunings"].get("cores_usage_percentage", 0.5)
+                database_path = config["database"].get("database_path", "/tmp/cerberus.db")
+                reuse_database = config["database"].get("reuse_database", False)
+
+                # Initialize clients and set kube api request chunk size
+                if not os.path.isfile(kubeconfig_path):
+                    kubeconfig_path = None
+                logging.info("Initializing client to talk to the Kubernetes cluster")
+                kubecli.initialize_clients(kubeconfig_path, request_chunk_size)
+
+                if "openshift-sdn" in watch_namespaces:
+                    sdn_namespace = kubecli.check_sdn_namespace()
+                    watch_namespaces = [namespace.replace('openshift-sdn', sdn_namespace)
+                                        for namespace in watch_namespaces]
+
+                # Check if all the namespaces under watch_namespaces are valid
+                watch_namespaces = kubecli.check_namespaces(watch_namespaces)
+
+                # Cluster info
+                logging.info("Fetching cluster info")
+                if distribution == "openshift":
+                    cluster_version = runcommand.invoke("kubectl get clusterversion")
+                    logging.info("\n%s" % (cluster_version))
+                cluster_info = runcommand.invoke("kubectl cluster-info | awk 'NR==1' | sed -r "
+                                                 "'s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g'")  # noqa
+                logging.info("%s" % (cluster_info))
+
+                # Run http server using a separate thread if cerberus is asked
+                # to publish the status. It is served by the http server.
+                if cerberus_publish_status:
+                    if not 0 <= port <= 65535:
+                        logging.info("Using port 8080 as %s isn't a valid port number" % (port))
+                        port = 8080
+                    address = ("0.0.0.0", port)
+                    server_address = address[0]
+                    port = address[1]
+                    logging.info("Publishing cerberus status at http://%s:%s"
+                                 % (server_address, port))
+                    server.start_server(address)
+
+                dbcli.set_db_path(database_path)
+                if not os.path.isfile(database_path) or not reuse_database:
+                    dbcli.create_db()
+                    dbcli.create_table()
+
+                # Create slack WebCleint when slack intergation has been enabled
+                if slack_integration:
+                    slack_integration = slackcli.initialize_slack_client()
+
+                # Run inspection only when the distribution is openshift
+                if distribution == "openshift" and inspect_components:
+                    logging.info("Detailed inspection of failed components has been enabled")
+                    inspect.delete_inspect_directory()
+
+                # get list of all master nodes to verify scheduling
+                master_nodes = kubecli.list_nodes("node-role.kubernetes.io/master")
+
+                # Use cluster_info to get the api server url
+                api_server_url = cluster_info.split(" ")[-1].strip() + "/healthz"
+
+                # Counter for if api server is not ok
+                api_fail_count = 0
+
+                # Variables used for multiprocessing
+                global pool
+                pool = multiprocessing.Pool(int(cores_usage_percentage * multiprocessing.cpu_count()),
+                                            init_worker)
+                manager = multiprocessing.Manager()
+
+                # Track time taken for different checks in each iteration
+                global time_tracker
+                time_tracker = {}
+
+                # Initialize the start iteration to 0
+                iteration = 0
+
+                # Initialize the prometheus client
+                promcli.initialize_prom_client(distribution, prometheus_url, prometheus_bearer_token)
+
+                # Prometheus query to alert on high apiserver latencies
+                apiserver_latency_query = r"""ALERTS{alertname="KubeAPILatencyHigh", severity="warning"}"""
+                # Prometheus query to alert when etcd fync duration is high
+                etcd_leader_changes_query = r"""ALERTS{alertname="etcdHighNumberOfLeaderChanges", severity="warning"}""" # noqa
+
+                # Set the number of iterations to loop to infinity if daemon mode is
+                # enabled or else set it to the provided iterations count in the config
+                if daemon_mode:
+                    logging.info("Daemon mode enabled, cerberus will monitor forever")
+                    logging.info("Ignoring the iterations set\n")
+                    iterations = float('inf')
+                else:
+                    iterations = int(iterations)
+
+                # Loop to run the components status checks starts here
+                while (int(iteration) < iterations):
+                    try:
+                        # Initialize a dict to store the operations timings per iteration
+                        iter_track_time = manager.dict()
+
+                        # Capture the start time
+                        iteration_start_time = time.time()
+
+                        iteration += 1
+
+                        # Read the config for info when slack integration is enabled
+                        if slack_integration:
+                            weekday = runcommand.invoke("date '+%A'")[:-1]
+                            watcher_slack_member_ID = config["cerberus"]["watcher_slack_ID"].get(weekday, None)
+                            slack_team_alias = config["cerberus"].get("slack_team_alias", None)
+                            slackcli.slack_tagging(watcher_slack_member_ID, slack_team_alias)
+
+                            if iteration == 1:
+                                slackcli.slack_report_cerberus_start(cluster_info, weekday,
+                                                                     watcher_slack_member_ID)
+
+                        # Collect the initial creation_timestamp and restart_count of all the pods in all
+                        # the namespaces in watch_namespaces
+                        if iteration == 1:
+                            pods_tracker = manager.dict()
+                            pool.starmap(kubecli.namespace_sleep_tracker,
+                                         zip(watch_namespaces, repeat(pods_tracker)))
+
+                        # Execute the functions to check api_server_status, master_schedulable_status,
+                        # watch_nodes, watch_cluster_operators parallely
+                        (server_status), (schedulable_masters), (watch_nodes_status, failed_nodes), \
+                            (watch_cluster_operators_status, failed_operators), (failed_routes) = \
+                            pool.map(smap, [functools.partial(kubecli.is_url_available, api_server_url),
+                                            functools.partial(kubecli.process_master_taint,
+                                                              master_nodes, iteration, iter_track_time),
+                                            functools.partial(kubecli.process_nodes, watch_nodes,
+                                                              iteration, iter_track_time),
+                                            functools.partial(kubecli.process_cluster_operator,
+                                                              distribution, watch_cluster_operators,
+                                                              iteration, iter_track_time),
+                                            functools.partial(kubecli.process_routes, watch_url_routes,
+                                                              iter_track_time)])
+
+                        # Increment api_fail_count if api server url is not ok
+                        if not server_status:
+                            api_fail_count += 1
+
+                        # Initialize a shared_memory of type dict to share data between different processes
+                        failed_pods_components = manager.dict()
+                        failed_pod_containers = manager.dict()
+
+                        # Monitor all the namespaces parallely
+                        watch_namespaces_start_time = time.time()
+                        pool.starmap(kubecli.process_namespace, zip(repeat(iteration), watch_namespaces,
+                                     repeat(failed_pods_components), repeat(failed_pod_containers)))
+
+                        watch_namespaces_status = False if failed_pods_components else True
+                        iter_track_time['watch_namespaces'] = time.time() - watch_namespaces_start_time
+
+                        # Check for the number of hits
+                        if cerberus_publish_status:
+                            logging.info("HTTP requests served: %s \n"
+                                         % (server.SimpleHTTPRequestHandler.requests_served))
+
+                        if schedulable_masters:
+                            logging.warning("Iteration %s: Masters without NoSchedule taint: %s\n"
+                                            % (iteration, schedulable_masters))
+
+                        # Logging the failed components
+                        if not watch_nodes_status:
+                            logging.info("Iteration %s: Failed nodes" % (iteration))
+                            logging.info("%s\n" % (failed_nodes))
+                            dbcli.insert(datetime.now(), time.time(),
+                                         1, "not ready", failed_nodes, "node")
+
+                        if not watch_cluster_operators_status:
+                            logging.info("Iteration %s: Failed operators" % (iteration))
+                            logging.info("%s\n" % (failed_operators))
+                            dbcli.insert(datetime.now(), time.time(),
+                                         1, "degraded", failed_operators, "cluster operator")
+
+                        if not server_status:
+                            logging.info("Iteration %s: Api Server is not healthy as reported by %s\n"
+                                         % (iteration, api_server_url))
+                            dbcli.insert(datetime.now(), time.time(),
+                                         1, "unavailable", list(api_server_url), "api server")
+
+                        if not watch_namespaces_status:
+                            logging.info("Iteration %s: Failed pods and components" % (iteration))
+                            for namespace, failures in failed_pods_components.items():
+                                logging.info("%s: %s", namespace, failures)
+
+                                for pod, containers in failed_pod_containers[namespace].items():
+                                    logging.info("Failed containers in %s: %s", pod, containers)
+
+                                component = namespace.split("-")
+                                if component[0] == "openshift":
+                                    component = "-".join(component[1:])
+                                else:
+                                    component = "-".join(component)
+                                dbcli.insert(datetime.now(), time.time(),
+                                             1, "pod crash", failures, component)
+                            logging.info("")
+
+                        # Logging the failed checking of routes
+                        watch_routes_status = True
+                        if failed_routes:
+                            watch_routes_status = False
+                            logging.info("Iteration %s: Failed route monitoring" % iteration)
+                            for route in failed_routes:
+                                logging.info("Route url: %s" % route)
+                            logging.info("")
+                            dbcli.insert(datetime.now(), time.time(),
+                                         1, "unavailable", failed_routes, "route")
+
+                        # Aggregate the status and publish it
+                        cerberus_status = watch_nodes_status and watch_namespaces_status \
+                            and watch_cluster_operators_status and server_status \
+                            and watch_routes_status
+
+                        if distribution == "openshift":
+                            watch_csrs_start_time = time.time()
+                            csrs = kubecli.get_csrs()
+                            pending_csr = []
+                            for csr in csrs['items']:
+                                # find csr status
+                                if "Approved" not in csr['status']['conditions'][0]['type']:
+                                    pending_csr.append(csr['metadata']['name'])
+                            if pending_csr:
+                                logging.warning("There are CSR's that are currently not approved")
+                                logging.warning("Csr's that are not approved: " + str(pending_csr))
+                            iter_track_time['watch_csrs'] = time.time() - watch_csrs_start_time
+
+                        if custom_checks:
+                            if iteration == 1:
+                                custom_checks_imports = []
+                                for check in custom_checks:
+                                    my_check = ".".join(check.replace("/", ".").split(".")[:-1])
+                                    my_check_module = importlib.import_module(my_check)
+                                    custom_checks_imports.append(my_check_module)
+                            custom_checks_fail_messages = []
+                            custom_checks_status = True
+                            for check in custom_checks_imports:
+                                check_returns = check.main()
+                                if type(check_returns) == bool:
+                                    custom_checks_status = custom_checks_status and check_returns
+                                elif type(check_returns) == dict:
+                                    status = check_returns['status']
+                                    message = check_returns['message']
+                                    custom_checks_status = custom_checks_status and status
+                                    custom_checks_fail_messages.append(message)
+                            cerberus_status = cerberus_status and custom_checks_status
+
+                        if cerberus_publish_status:
+                            publish_cerberus_status(cerberus_status)
+
+                        # Report failures in a slack channel
+                        if not watch_nodes_status or not watch_namespaces_status or \
+                                not watch_cluster_operators_status or not custom_checks_status:
+                            if slack_integration:
+                                slackcli.slack_logging(cluster_info, iteration, watch_nodes_status,
+                                                       failed_nodes, watch_cluster_operators_status,
+                                                       failed_operators, watch_namespaces_status,
+                                                       failed_pods_components, custom_checks_status,
+                                                       custom_checks_fail_messages)
+
+                        # Run inspection only when the distribution is openshift
+                        if distribution == "openshift" and inspect_components:
+                            # Collect detailed logs for all the namespaces with failed
+                            # components parallely
+                            pool.map(inspect.inspect_component, failed_pods_components.keys())
+                            logging.info("")
+                        elif distribution == "kubernetes" and inspect_components:
+                            logging.info("Skipping the failed components inspection as "
+                                         "it's specific to OpenShift")
+
+                        # Alert on high latencies
+                        metrics = promcli.process_prom_query(apiserver_latency_query)
+                        if metrics:
+                            logging.warning("Kubernetes API server latency is high. "
+                                            "More than 99th percentile latency for given requests to the "
+                                            "kube-apiserver is above 1 second.\n")
+                            logging.info("%s\n" % (metrics))
+
+                        # Alert on high etcd fync duration
+                        metrics = promcli.process_prom_query(etcd_leader_changes_query)
+                        if metrics:
+                            logging.warning("Observed increase in number of etcd leader elections over the last "
+                                            "15 minutes. Frequent elections may be a sign of insufficient resources, "
+                                            "high network latency, or disruptions by other components and should be "
+                                            "investigated.\n")
+                        logging.info("%s\n" % (metrics))
+
+                        # Sleep for the specified duration
+                        logging.info("Sleeping for the specified duration: %s\n" % (sleep_time))
+                        time.sleep(float(sleep_time))
+
+                        sleep_tracker_start_time = time.time()
+
+                        # Track pod crashes/restarts during the sleep interval in all namespaces parallely
+                        multiprocessed_output = pool.starmap(kubecli.namespace_sleep_tracker,
+                                                             zip(watch_namespaces, repeat(pods_tracker)))
+
+                        crashed_restarted_pods = {}
+                        for item in multiprocessed_output:
+                            crashed_restarted_pods.update(item)
+
+                        iter_track_time['sleep_tracker'] = time.time() - sleep_tracker_start_time
+
+                        if crashed_restarted_pods:
+                            logging.info("Pods that were crashed/restarted during the sleep interval of "
+                                         "iteration %s" % (iteration))
+                            for namespace, pods in crashed_restarted_pods.items():
+                                distinct_pods = set(pod[0] for pod in pods)
+                                logging.info("%s: %s" % (namespace, distinct_pods))
+                                component = namespace.split("-")
+                                if component[0] == "openshift":
+                                    component = "-".join(component[1:])
+                                else:
+                                    component = "-".join(component)
+                                for pod in pods:
+                                    if pod[1] == "crash":
+                                        dbcli.insert(datetime.now(), time.time(),
+                                                     1, "pod crash", [pod[0]], component)
+                                    elif pod[1] == "restart":
+                                        dbcli.insert(datetime.now(), time.time(),
+                                                     pod[2], "pod restart", [pod[0]], component)
+                            logging.info("")
+
+                        # Capture total time taken by the iteration
+                        iter_track_time['entire_iteration'] = (time.time() - iteration_start_time) - sleep_time  # noqa
+
+                        time_tracker["Iteration " + str(iteration)] = iter_track_time.copy()
+
+                        # Print the captured timing for each operation
+                        logging.info("-------------------------- Iteration Stats ---------------------------")  # noqa
+                        for operation, timing in iter_track_time.items():
+                            logging.info("Time taken to run %s in iteration %s: %s seconds"
+                                         % (operation, iteration, timing))
+                        logging.info("----------------------------------------------------------------------\n")  # noqa
+
+                    except KeyboardInterrupt:
+                        pool.terminate()
+                        pool.join()
+                        logging.info("Terminating cerberus monitoring")
+                        record_time(time_tracker)
+                        sys.exit(1)
+
+                    except Exception as e:
+                        logging.info("Encountered issues in cluster. Hence, setting the go/no-go "
+                                     "signal to false")
+                        logging.info("Exception: %s\n" % (e))
+                        if cerberus_publish_status:
+                            publish_cerberus_status(False)
+                        continue
+
+                else:
+                    logging.info("Completed watching for the specified number of iterations: %s"
+                                 % (iterations))
+                    record_time(time_tracker)
+                    pool.close()
+                    pool.join()
+            else:
+                logging.error("Could not find a config at %s, please check" % (cfg))
+                sys.exit(1)
+
+
+        if __name__ == "__main__":
+            # Initialize the parser to read the config
+            parser = optparse.OptionParser()
+            parser.add_option(
+                "-c", "--config",
+                dest="cfg",
+                help="config location",
+                default="config/config.yaml",
+            )
+            (options, args) = parser.parse_args()
+            logging.basicConfig(
+                level=logging.INFO,
+                format="%(asctime)s [%(levelname)s] %(message)s",
+                handlers=[
+                    logging.FileHandler("cerberus.report", mode='w'),
+                    logging.StreamHandler()
+                ]
+            )
+            if (options.cfg is None):
+                logging.error("Please check if you have passed the config")
+                sys.exit(1)
+            else:
+                main(options.cfg)

--- a/config/prow/cluster/cerberus_deployment.yaml
+++ b/config/prow/cluster/cerberus_deployment.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cerberus-deployment
+  namespace: prow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      tool: Cerberus
+  template:
+    metadata:
+      labels:
+        tool: Cerberus
+    spec:
+      serviceAccountName: cerberus
+      containers:
+        - name: cerberus
+          securityContext:
+            privileged: true
+          image: quay.io/openshift-scale/cerberus
+          command:
+            - /bin/sh
+          env:
+          - name: SLACK_API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: slack-token
+                key: token
+          - name: SLACK_CHANNEL
+            value: C01DPA12NHJ
+          args:
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+              ca=$(base64 -w 0 /run/secrets/kubernetes.io/serviceaccount/ca.crt)
+              token=$(cat /run/secrets/kubernetes.io/serviceaccount/token)
+              namespace=$(cat /run/secrets/kubernetes.io/serviceaccount/namespace)
+              cat > /root/.kube/config <<EOL
+              apiVersion: v1
+              kind: Config
+              clusters:
+              - name: default-cluster
+                cluster:
+                  certificate-authority-data: ${ca}
+                  server: https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}
+              contexts:
+              - name: default-context
+                context:
+                  cluster: default-cluster
+                  namespace: ${namespace}
+                  user: default-user
+              current-context: default-context
+              users:
+              - name: default-user
+                user:
+                  token: ${token}
+              EOL
+              export KUBECONFIG=/root/.kube/config
+              cp /etc/cerberus-start/start_cerberus.py /root/cerberus/.
+              cp /etc/cerberus-slack-client/slack_client.py /root/cerberus/cerberus/slack/.
+              python3 start_cerberus.py -c config/kubernetes_config.yaml
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - mountPath: "/root/cerberus/config"
+              name: cerberus-config
+            - mountPath: "/etc/cerberus-start"
+              name: cerberus-start
+            - mountPath: "/root/cerberus/custom_checks"
+              name: custom-check
+            - mountPath: "/etc/cerberus-slack-client"
+              name: slack-client
+      volumes:
+        - name: cerberus-config
+          configMap:
+            name: cerberus-config
+        - name: cerberus-start
+          configMap:
+            name: cerberus-start
+        - name: custom-check
+          configMap:
+            name: cerberus-custom-check
+        - name: slack-client
+          configMap:
+            name: cerberus-slack-client

--- a/config/prow/cluster/cerberus_rbac.yaml
+++ b/config/prow/cluster/cerberus_rbac.yaml
@@ -1,0 +1,67 @@
+# This file contains all the required spec for service account, roles and role bindings for the cerberus deployment to get prow controller logs
+# Run via https://github.com/cloud-bulldozer/cerberus project.
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  namespace: prow
+  name: "cerberus"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: prow
+  name: "cerberus"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "cerberus"
+rules:
+  - apiGroups:
+      - ""
+    resources: ["namespaces", "nodes", "services"]
+    verbs:
+      - list
+      - get
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: prow
+  name: "cerberus"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "cerberus"
+subjects:
+  - kind: ServiceAccount
+    name: "cerberus"
+    namespace: prow
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "cerberus"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "cerberus"
+subjects:
+  - kind: ServiceAccount
+    name: "cerberus"
+    namespace: prow


### PR DESCRIPTION
This PR adds the spec files required for deploying Cerberus pod and the related config maps. 
Below are the config Map details:
`cerberus-config` : Kubernetes related configuration required by cerberus
`cerberus-custom-check` : File for checking Failed message in the prow controller log
`cerberus-start` : Contains the changes to start_cerberus.py to enable custom check notifications to slack
`cerberus-slack-client` : Changes to display custom check failure messages to slack.

Configmaps `cerberus-start` and `cerberus-slack-client` can be removed once the below PR merges:
https://github.com/cloud-bulldozer/cerberus/pull/119

_**Note:**_ **The pod spec is not having any configuration exported for the underlying cluster
It is assumed that pod run in-cluster using the `default` service account in the `prow` namespace will be able to access logs of other pods in `prow` namespace.**