### PR TITLE
Sunset the bazel run in the prow CI

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-gcs-logs-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-gcs-logs-periodics.yaml
@@ -24,7 +24,7 @@ periodics:
               set -o xtrace
               go get  github.com/ppc64le-cloud/gcs-cleaner
               cat >config.yml <<EOL
-              - dir: logs/periodic-kubernetes-bazel-test-ppc64le
+              - dir: logs/periodic-kubernetes-unit-test-ppc64le
                 daysLimit: 15
               - dir: logs/periodic-kubernetes-conformance-test-ppc64le
                 daysLimit: 7

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -1,5 +1,5 @@
 periodics:
-  - name: periodic-kubernetes-bazel-test-ppc64le
+  - name: periodic-kubernetes-unit-test-ppc64le
     cluster: k8s-ppc64le-cluster
     decorate: true
     decoration_config:
@@ -13,25 +13,32 @@ periodics:
         org: kubernetes
         repo: kubernetes
         workdir: true
-      - base_ref: master
-        org: kubernetes
-        repo: test-infra
     spec:
       containers:
-        - image: quay.io/powercloud/bazel:3.4.1
+        - image: quay.io/powercloud/all-in-one:0.2
           command:
-            - ../test-infra/hack/bazel.sh
+            - /bin/bash
           args:
-            - test
-            - --test_timeout=600
-            - --config=unit
-            - --features=-race     # TO-DO: This need to be fixed!
-            - --host_javabase=@local_jdk//:jdk
-            - --test_verbose_timeout_warnings
-            - //...
-            - --
-            - -//build/...
-            - -//vendor/...
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+
+              export KUBE_TIMEOUT='--timeout=600s'
+              export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
+              export LOG_LEVEL=4
+              wget -q -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_ppc64le
+              chmod +x /usr/local/bin/yq
+              pushd ./build/
+              GOLANG_VERSION=`yq read dependencies.yaml 'dependencies(name==golang: upstream*).version'`
+              popd
+              url="https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-ppc64le.tar.gz"
+              wget -O go.tgz "$url" --progress=dot:giga
+              rm -rf /usr/local/go
+              tar -C /usr/local -xzf go.tgz
+              make test KUBE_RACE=-race
   - name: periodic-kubernetes-conformance-test-ppc64le
     cluster: k8s-ppc64le-cluster
     decorate: true


### PR DESCRIPTION
This PR is to switch the existing CI job `periodic-kubernetes-bazel-test-ppc64le` from using Bazel to `make test` as with recent changes here - https://github.com/kubernetes/kubernetes/pull/99561, now k8s does not use Bazel thing anymore.

The tool `yq` is being downloaded from https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_ppc64le for getting the value of dependent golang version for k8s from `dependencies.yaml `file.

Also modifying the cleanup job `periodic-gcs-logs-cleanup` that deletes the log folders from GCS.