### PR TITLE
Remove clone_uri

### DIFF
--- a/config/jobs/ocp-automation/ocp4-upi-powervs/ocp4-upi-powervs-presubmit.yaml
+++ b/config/jobs/ocp-automation/ocp4-upi-powervs/ocp4-upi-powervs-presubmit.yaml
@@ -3,7 +3,6 @@ presubmits:
     - name: pull-ocp4-upi-powervs-terraform-validate
       always_run: true
       decorate: true
-      clone_uri: "git@github.com:ocp-power-automation/ocp4-upi-powervs.git"
       spec:
         containers:
           - image: hashicorp/terraform:0.13.5


### PR DESCRIPTION
This is not required anymore because this repo is public now and does not need ssh way of closing it.

/assign @yussufsh @Rajalakshmi-Girish 