### PR TITLE
Add service account detail to mkdocs post-submit job container

### DIFF
--- a/config/jobs/ppc64le-cloud/mkdocs/mkdocs-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/mkdocs/mkdocs-postsubmit.yaml
@@ -10,6 +10,7 @@ postsubmits:
           org: vmware-tanzu
           repo: buildkit-cli-for-kubectl
       spec:
+        serviceAccountName: build-img
         containers:
           - image: quay.io/powercloud/all-in-one:0.2
             command:
@@ -18,7 +19,6 @@ postsubmits:
               - -c
               - |
                 export PATH=$PATH:/usr/local/bin
-                export KUBECONFIG=/etc/kubeconfig/config
                 pushd $GOPATH/src/github.com/vmware-tanzu/buildkit-cli-for-kubectl
                 make build install
                 popd


### PR DESCRIPTION
Adding the service account details to container spec of mkdocs post-submit job.
Also removing the extra `export KUBECONFIG` command.
Below job failed due to missing service account detail to container:
https://prow.ppc64le-cloud.org/view/s3/prow-logs/logs/postsubmit-mkdocs-job/1371410784722096128