### PR TITLE
Add spec for cherry-picker endpoint deployment

### DIFF
--- a/config/prow/cluster/cherrypick_deployment.yaml
+++ b/config/prow/cluster/cherrypick_deployment.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cherrypick
+  namespace: prow
+spec:
+  selector:
+    app: prow
+    component: cherrypick
+  ports:
+  - port: 80
+    targetPort: 8888
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cherrypick
+  labels:
+    app: prow
+    component: cherrypick
+  namespace: prow
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: prow
+      component: cherrypick
+  template:
+    metadata:
+      labels:
+        app: prow
+        component: cherrypick
+    spec:
+      containers:
+      - name: cherrypick
+        image: gcr.io/k8s-prow/cherrypicker:v20210305-64a6d4d83a
+        args:
+        - --github-token-path=/etc/github/token
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        - --dry-run=false
+        ports:
+          - name: http
+            containerPort: 8888
+        volumeMounts:
+        - name: hmac
+          mountPath: /etc/webhook
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+        resources:
+          requests:
+            memory: "300Mi"
+            cpu: "50m"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 20
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+      volumes:
+      - name: hmac
+        secret:
+          secretName: hmac-token
+      - name: oauth
+        secret:
+          secretName: github-token
+      - name: tmp
+        emptyDir: {}


### PR DESCRIPTION
This PR is to add spec for `cherry-picker `endpoint deployment in IKS Prow .
cherry-pick bot is to created PRs on required release branch once master PR is merged for `ocp4-upi-power{vm|vs}` repos .