### PR TITLE
Enable the cleanup job in Prow

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
@@ -23,4 +23,4 @@ periodics:
               chmod +x /usr/local/bin/pvsadm
 
               # delete all the vms created before 4hrs
-              pvsadm purge vms --instance-id e13a10d2-9c2b-4d7b-b2fc-7a2b9edf1abf --dry-run --before 4h --ignore-errors --no-prompt
+              pvsadm purge vms --instance-id e13a10d2-9c2b-4d7b-b2fc-7a2b9edf1abf --before 4h --ignore-errors --no-prompt


### PR DESCRIPTION
This PR is to enable the cleanup job that was disabled earlier because of the debugging purpose.
Also adding the cleanup for networks older than 4hours.