### PR TITLE
Change to test image-builder kubeconfig on new ppc build cluster

### DIFF
--- a/images/all-in-one/README.md
+++ b/images/all-in-one/README.md
@@ -13,7 +13,7 @@ This is an image which contains following content:
 ## How to build
 
 ```shell script
-# On both x86 and ppc64le platforms
+# On both x86 and ppc64le platforms.
 $ docker build -t quay.io/powercloud/all-in-one:`cat version.txt`-`uname -p | sed 's/x86_64/amd64/'` .
 
 $ docker push quay.io/powercloud/all-in-one:`cat version.txt`-`uname -p | sed 's/x86_64/amd64/'`


### PR DESCRIPTION
This PR is to trigger the `postsubmit-allinone-job` and see if the new `image-builder-ppc-kubeconfig` secret is working fine for the newly added ppc build cluster.