### PR TITLE
Adding namespace flag to kubectl build command

### DIFF
--- a/config/jobs/ppc64le-cloud/all-in-one/allinone-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/all-in-one/allinone-postsubmit.yaml
@@ -61,8 +61,8 @@ postsubmits:
                 export KUBECONFIG=$(pwd)/kubeconfig
                 pushd images/all-in-one
                 export version=`cat version.txt`
-                kubectl build --push --registry-secret quay-powercloud-regcred -t quay.io/powercloud/all-in-one:$version-amd64 -f Dockerfile ./
-                kubectl build --push --registry-secret quay-powercloud-regcred --kubeconfig /etc/kubeconfig/config -t quay.io/powercloud/all-in-one:$version-ppc64le -f Dockerfile ./
+                kubectl build --push --registry-secret quay-powercloud-regcred --namespace image-builder -t quay.io/powercloud/all-in-one:$version-amd64 -f Dockerfile ./
+                kubectl build --push --registry-secret quay-powercloud-regcred --namespace image-builder --kubeconfig /etc/kubeconfig/config -t quay.io/powercloud/all-in-one:$version-ppc64le -f Dockerfile ./
                 popd
                 cat > config.json << EOL
                 $DOCKER_CONFIG


### PR DESCRIPTION
Below failure is observed while postsubmit-allinone-job  is run:
```
#1 [internal] booting buildkit
#1 ERROR: error while calling configMap.Create for "buildkit": configmaps is forbidden: User "system:serviceaccount:test-pods:build-img" cannot create resource "configmaps" in API group "" in the namespace "test-pods"
------
 > [internal] booting buildkit:
------
Error: error while calling configMap.Create for "buildkit": configmaps is forbidden: User "system:serviceaccount:test-pods:build-img" cannot create resource "configmaps" in API group "" in the namespace "test-pods"
```
If no namespace is passed while running `kubectl build` command,  namespace test-pods from kubeconfig and hence the error.
I could get over this error by passing `--namespace image-builder` and testing through test-pj
**Note:** Have observed passing namespace as image-builder in other postsubmit image building jobs:
https://github.com/ppc64le-cloud/test-infra/blob/master/config/jobs/ppc64le-cloud/ibm-cloud/ibmcloud-postsubmit.yaml#L56
