### PR TITLE
removing kubectl gcloud component

### DIFF
--- a/images/all-in-one/Dockerfile
+++ b/images/all-in-one/Dockerfile
@@ -119,7 +119,7 @@ ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz && \
     tar xzf google-cloud-sdk.tar.gz -C / && \
     rm google-cloud-sdk.tar.gz && \
-    gcloud components install alpha beta kubectl gsutil && \
+    gcloud components install alpha beta gsutil && \
     gcloud info | tee /workspace/gcloud-info.txt
 
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/`go env GOARCH`/kubectl && \


### PR DESCRIPTION
We are getting this error while building all-in-one image on ppc architecture:

```
 > [stage-1  9/10] RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz &&     tar xzf google-cloud-sdk.tar.gz -C / &&     rm google-cloud-sdk.tar.gz &&     gcloud components install alpha beta kubectl gsutil &&     gcloud info | tee /workspace/gcloud-info.txt:
------
Error: failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz &&     tar xzf google-cloud-sdk.tar.gz -C / &&     rm google-cloud-sdk.tar.gz &&     gcloud components install alpha beta kubectl gsutil &&     gcloud info | tee /workspace/gcloud-info.txt]: exit code: 1
{"component":"unset","error":"wrapped process failed: exit status 1","file":"/go/test-infra/prow/entrypoint/run.go:80","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2021-03-31T11:14:52Z"}
```
This error is coming up  for kubectl component only., alpha,beta and gsutil are getting installed but not  kubectl via gcloud (for ppc).

As we are using the below commands to install kubectl, we can remove kubectl from gcloud component to avoid this error.
```
RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/`go env GOARCH`/kubectl && \
chmod +x ./kubectl && \
mv ./kubectl /usr/local/bin/kubectl
```
