### PR TITLE
conformance jobs to use TF_VERSION 0.13.0

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-gcs-logs-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-gcs-logs-periodics.yaml
@@ -8,7 +8,7 @@ periodics:
           secret:
             secretName: gcs-credentials
       containers:
-        - image: quay.io/powercloud/all-in-one:0.1
+        - image: quay.io/powercloud/all-in-one:0.3
           command:
             - /bin/bash
           volumeMounts:

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -56,7 +56,7 @@ periodics:
             defaultMode: 256
             secretName: bot-ssh-secret
       containers:
-        - image: quay.io/powercloud/all-in-one:0.1
+        - image: quay.io/powercloud/all-in-one:0.3
           command:
             - /bin/bash
           volumeMounts:
@@ -137,7 +137,7 @@ periodics:
             defaultMode: 256
             secretName: bot-ssh-secret
       containers:
-        - image: quay.io/powercloud/all-in-one:0.1
+        - image: quay.io/powercloud/all-in-one:0.3
           command:
             - /bin/bash
           volumeMounts:

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -106,7 +106,7 @@ postsubmits:
               defaultMode: 256
               secretName: bot-ssh-secret
         containers:
-          - image: quay.io/powercloud/all-in-one:0.1
+          - image: quay.io/powercloud/all-in-one:0.3
             command:
               - /bin/bash
             volumeMounts:


### PR DESCRIPTION
The conformance jobs will use the latest all-in-one image with tag 0.3 that uses TF_VERSION 0.13.0