### PR TITLE
Change the instance id of periodic-powervs-cleanup job to osa21 from tok04

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
@@ -23,4 +23,4 @@ periodics:
               chmod +x /usr/local/bin/pvsadm
 
               # delete all the vms created before 4hrs
-              pvsadm purge vms --instance-id e13a10d2-9c2b-4d7b-b2fc-7a2b9edf1abf --before 4h --ignore-errors --no-prompt
+              pvsadm purge vms --instance-id 083d5bf8-c41a-4f3c-8713-f5fdfb4d4b5b --before 4h --ignore-errors --no-prompt


### PR DESCRIPTION
To comply with new guidelines of PowerVS infra, the DC for Prow conformance jobs is changed from tok04 to osa12.
i.e from `prow-testbed-tok04` to `prow-testbed-osa12`. https://github.com/ppc64le-cloud/test-infra/pull/182

Hence the `periodic-powervs-cleanup` job has to change the instance-id.