### PR TITLE
Change pvsadm version in periodic-powervs-cleanup job

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
@@ -19,7 +19,7 @@ periodics:
               set -o pipefail
               set -o xtrace
 
-              wget -q -O /usr/local/bin/pvsadm https://github.com/ppc64le-cloud/pvsadm/releases/download/v0.1-alpha.12/pvsadm-linux-ppc64le
+              wget -q -O /usr/local/bin/pvsadm https://github.com/ppc64le-cloud/pvsadm/releases/download/v0.1.1-alpha.7/pvsadm-linux-ppc64le
               chmod +x /usr/local/bin/pvsadm
 
               # delete all the vms created before 4hrs


### PR DESCRIPTION
`pvsadm-version-cleanup-job` is failing with below error since the change of instance id in job to `prow-testbed-osa21`

```
Error: region not found for the zone, talk to the developer to add the support into the tool: osa21
```
Need the latest binary for fixing this. Hence switching the version of pvsadm to `v0.1.1-alpha.6`