### PR TITLE
Change base_ref to main from master for etcd-io/etcd repo in job

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
@@ -7,7 +7,7 @@ postsubmits:
         - master
       run_if_changed: '^golang/master/'
       extra_refs:
-        - base_ref: master
+        - base_ref: main
           org: etcd-io
           repo: etcd
           workdir: true


### PR DESCRIPTION
The `postsubmit-master-golang-etcd-build-test-ppc64le`  prow job has been failing due to below error:
```
 $ git fetch https://github.com/etcd-io/etcd.git master
fatal: couldn't find remote ref master
# Error: exit status 128
```
https://prow.ppc64le-cloud.org/view/s3/prow-logs/logs/postsubmit-master-golang-etcd-build-test-ppc64le/1393400899220541440
Hence changing the branch to main from master.
Ref: https://github.com/etcd-io/etcd/pull/12956