### PR TITLE
Test if repo allows access for Prow job trigger

### DIFF
--- a/config/jobs/Rajalakshmi-Girish/test/test-prow-trigger.yaml
+++ b/config/jobs/Rajalakshmi-Girish/test/test-prow-trigger.yaml
@@ -1,0 +1,14 @@
+presubmits:
+  Rajalakshmi-Girish/test:
+  - name: pull-prow-trigger-test-ppc64le
+    cluster: k8s-ppc64le-cluster
+    always_run: true
+    decorate: true
+    spec:
+      containers:
+        - image: quay.io/powercloud/all-in-one:0.2
+          command:
+            - echo "Test on ppc64le"
+    annotations:
+      testgrid-dashboards: presubmits-rajalakshmi-girsih-test
+      testgrid-tab-name: verify-prow-trigger

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -15,6 +15,9 @@ triggers:
       - openshift-powervs
     join_org_url: https://github.com/ocp-power-automation/ocp4-upi-powervs#contributing
     only_org_members: true
+  - repos:
+      - Rajalakshmi-Girish/test
+    join_org_url: https://github.com/Rajalakshmi-Girish/test/blob/main/README.md
 
 approve:
   - repos:
@@ -162,6 +165,33 @@ plugins:
     - yuks
 
   openshift-powervs:
+    - approve
+    - assign
+    - cat
+    - config-updater
+    - dog
+    - golint
+    - goose
+    - heart
+    - help
+    - hold
+    - label
+    - lgtm
+    - lifecycle
+    - mergecommitblocker
+    - owners-label
+    - pony
+    - retitle
+    - shrug
+    - size
+    - skip
+    - trigger
+    - verify-owners
+    - welcome
+    - wip
+    - yuks
+
+  Rajalakshmi-Girish/test:
     - approve
     - assign
     - cat


### PR DESCRIPTION
This PR is to test if we are able to trigger a presubmt job for `Rajalakshmi-Girish/test` repo. 
The repo doesn't have write access to `ppc64le@in.ibm.com` GH account that our prow infrastructure uses.
