### PR TITLE
Change Presubmit job for Prow Trigger to a new org

### DIFF
--- a/config/jobs/trigger-prow/test-trigger/test-prow-trigger.yaml
+++ b/config/jobs/trigger-prow/test-trigger/test-prow-trigger.yaml
@@ -1,5 +1,5 @@
 presubmits:
-  Rajalakshmi-Girish/test:
+  trigger-prow/test-trigger:
   - name: pull-prow-trigger-test-ppc64le
     cluster: k8s-ppc64le-cluster
     always_run: true
@@ -8,7 +8,11 @@ presubmits:
       containers:
         - image: quay.io/powercloud/all-in-one:0.2
           command:
-            - echo "Test on ppc64le"
+            - /bin/bash
+          args:
+            - -c
+            - |
+              echo "Test Prow Trigger"
     annotations:
-      testgrid-dashboards: presubmits-rajalakshmi-girsih-test
+      testgrid-dashboards: presubmits-trigger-prow-test
       testgrid-tab-name: verify-prow-trigger

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -16,8 +16,8 @@ triggers:
     join_org_url: https://github.com/ocp-power-automation/ocp4-upi-powervs#contributing
     only_org_members: true
   - repos:
-      - Rajalakshmi-Girish/test
-    join_org_url: https://github.com/Rajalakshmi-Girish/test/blob/main/README.md
+      - trigger-prow/test-trigger
+    join_org_url: https://github.com/trigger-prow/test-trigger/blob/main/README.md
 
 approve:
   - repos:
@@ -191,7 +191,7 @@ plugins:
     - wip
     - yuks
 
-  Rajalakshmi-Girish/test:
+  trigger-prow/test-trigger:
     - approve
     - assign
     - cat


### PR DESCRIPTION
Changing the presubmit job to test Prow Trigger from repo without write access to `ppc64le-cloud-bot`.
Replacing the ` Rajalakshmi-Girish/test` with `trigger-prow/test-trigger`