### PR TITLE
Add GOPATH/bin to PATH for etcd-postsubmit job

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
@@ -30,6 +30,7 @@ postsubmits:
                 rm -rf /usr/local/go
                 tar -C /usr/local -xzf /tmp/golang.tar.gz
                 export PATH=/usr/local/go/bin:$PATH
+                export PATH=$GOPATH/bin:$PATH
                 go version
                 ./build.sh
                 GOARCH=`go env GOARCH` TEST_OPTS="PASSES='unit integration_e2e'" make test


### PR DESCRIPTION
Missing $GOPATH/bin in PATH is causing failing `./scripts/test_lib.sh: line 240: gotestsum: command not found`
Hence the junit xml files are not being generated.