### PR TITLE
Restricting test nodes to 1

### DIFF
--- a/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
@@ -75,4 +75,4 @@ periodics:
           --ignore-destroy-errors \
           --powervs-memory 32 \
           --extra-vars "kubelet_extra_args=--kube-api-qps=100 --kube-api-burst=100 --max-pods 130" \
-          --test=exec -- $GOPATH/src/github.com/kubernetes/perf-tests/clusterloader2/run-e2e.sh --testconfig=$GOPATH/src/github.com/kubernetes/perf-tests/clusterloader2/testing/node-throughput/config.yaml --provider=local --report-dir=/logs/artifacts
+          --test=exec -- $GOPATH/src/github.com/kubernetes/perf-tests/clusterloader2/run-e2e.sh --testconfig=$GOPATH/src/github.com/kubernetes/perf-tests/clusterloader2/testing/node-throughput/config.yaml --provider=local --nodes=1 --report-dir=/logs/artifacts


### PR DESCRIPTION
Default value is number of schedulable nodes which in our case is setting to 2 (should have been 1). The test needs to be performed only on 1 node and this will restrict that value.