### PR TITLE
Disable periodic-powervs-cleanup job to debug VM SSH failure

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
@@ -23,4 +23,4 @@ periodics:
               chmod +x /usr/local/bin/pvsadm
 
               # delete all the vms created before 4hrs
-              pvsadm purge vms --instance-id 083d5bf8-c41a-4f3c-8713-f5fdfb4d4b5b --before 4h --ignore-errors --no-prompt
+              pvsadm purge vms --instance-id 083d5bf8-c41a-4f3c-8713-f5fdfb4d4b5b --dry-run --before 4h --ignore-errors --no-prompt


### PR DESCRIPTION
Disabling the cleanup job by passing the flag --dry-run to pvsadm purge command.