### PR TITLE
Correct update-github-pages-submodule postsubmit job

### DIFF
--- a/config/jobs/ocp-automation/ocp-powervm-faq/ocp-powervm-faq-postsubmit.yaml
+++ b/config/jobs/ocp-automation/ocp-powervm-faq/ocp-powervm-faq-postsubmit.yaml
@@ -3,7 +3,6 @@ postsubmits:
     - name: update-github-pages-submodule
       decorate: true
       run_if_changed: 'docs'
-      always_run: true
       branches:
         - ^master$
       spec:

--- a/config/jobs/ocp-automation/ocp4-upi-kvm/ocp4-upi-kvm-postsubmit.yaml
+++ b/config/jobs/ocp-automation/ocp4-upi-kvm/ocp4-upi-kvm-postsubmit.yaml
@@ -3,7 +3,6 @@ postsubmits:
     - name: update-github-pages-submodule
       decorate: true
       run_if_changed: 'docs'
-      always_run: true
       branches:
         - ^master$
       spec:

--- a/config/jobs/ocp-automation/ocp4-upi-powervm/ocp4-upi-powervm-postsubmit.yaml
+++ b/config/jobs/ocp-automation/ocp4-upi-powervm/ocp4-upi-powervm-postsubmit.yaml
@@ -3,7 +3,6 @@ postsubmits:
     - name: update-github-pages-submodule
       decorate: true
       run_if_changed: 'docs'
-      always_run: true
       branches:
         - ^master$
       spec:

--- a/config/jobs/ocp-automation/ocp4-upi-powervs/ocp4-upi-powervs-postsubmit.yaml
+++ b/config/jobs/ocp-automation/ocp4-upi-powervs/ocp4-upi-powervs-postsubmit.yaml
@@ -3,7 +3,6 @@ postsubmits:
     - name: update-github-pages-submodule
       decorate: true
       run_if_changed: 'docs'
-      always_run: true
       branches:
         - ^master$
       spec:

--- a/config/jobs/ocp-automation/openshift-install-power/openshift-install-power-postsubmit.yaml
+++ b/config/jobs/ocp-automation/openshift-install-power/openshift-install-power-postsubmit.yaml
@@ -3,7 +3,6 @@ postsubmits:
     - name: update-github-pages-submodule
       decorate: true
       run_if_changed: 'docs'
-      always_run: true
       branches:
         - ^master$
       spec:


### PR DESCRIPTION
Prow components are throwing below error after upgrade to `v20210830-fcbb70627f`
```
{"component":"prow-controller-manager","error":"job update-github-pages-submodule is set to always run but also declares run_if_changed targets, which are mutually exclusive","file":"prow/cmd/prow-controller-manager/main.go:122","func":"main.main","level":"fatal","msg":"Error starting config agent.","severity":"fatal","time":"2021-09-01T08:42:45Z"}
```
The postsubmit job `update-github-pages-submodule` is wrongly defined by mentioning both `always_run` and `run_if_changed`.
The job is supposed to have either of these. This PR is to remove the `always_run` from job yamls as it is not appropriate.
@sudeeshjohn ^^