### PR TITLE
Enable censoring-of-secret-data in prow setup

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -64,6 +64,7 @@ plank:
     "*":
       timeout: 2h
       grace_period: 15s
+      censor_secrets: true
       gcs_configuration:
         bucket: s3://prow-logs
         path_strategy: explicit


### PR DESCRIPTION
Have verified if secrets mounted to `test-pod` are getting censored if `censor_secrets` flag is set to true in configuration for prow setup.
- Checked with both the storage GCS and IBM COS s3 storage.
- Compared the test execution time of k8s conformance job with and without censoring. There isn't much difference.
Note: unable to check this by running a job with test-pj by adding the detail to job-specific YAML.
Ref: https://github.com/ppc64le-cloud/test-infra/issues/227

