### PR TITLE
Docker node-throughput job addition

### DIFF
--- a/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
@@ -77,3 +77,81 @@ periodics:
           --powervs-memory 32 \
           --extra-vars "kubelet_extra_args=--kube-api-qps=100 --kube-api-burst=100 --max-pods 140" \
           --test=clusterloader2 -- --test-configs=testing/node-throughput/config.yaml --test-overrides=testing/overrides/node_containerd.yaml --provider=local --nodes=1 --repo-root=$GOPATH/src/github.com/kubernetes/perf-tests/
+
+- name: periodic-kubernetes-docker-node-throughput-perf-test-ppc64le
+  tags:
+  - "perfDashPrefix: docker-node-throughput"
+  - "perfDashJobType: throughput"
+  cluster: k8s-ppc64le-cluster
+  decorate: true
+  decoration_config:
+    gcs_configuration:
+      bucket: ppc64le-kubernetes
+      path_strategy: explicit
+    gcs_credentials_secret: gcs-credentials
+  interval: 6h
+  extra_refs:
+  - base_ref: master
+    org: ppc64le-cloud
+    repo: kubetest2-plugins
+    workdir: true
+  - base_ref: master
+    org: kubernetes
+    repo: perf-tests
+  spec:
+    volumes:
+    - name: powercloud-bot-key
+      secret:
+        defaultMode: 256
+        secretName: bot-ssh-secret
+    containers:
+    - image: quay.io/powercloud/all-in-one:0.3
+      command:
+      - /bin/bash
+      volumeMounts:
+      - mountPath: /etc/secret-volume
+        name: powercloud-bot-key
+        readOnly: true
+      envFrom:
+      - secretRef:
+          name: ibm-cloud-credentials
+      args:
+      - -c
+      - |
+        set -o errexit
+        set -o nounset
+        set -o pipefail
+        set -o xtrace
+
+        export PATH=$GOPATH/bin:$PATH
+        export GO111MODULE=on
+
+        go install ./...
+
+        go get sigs.k8s.io/kubetest2@latest
+        go get sigs.k8s.io/kubetest2/...@latest
+
+        TIMESTAMP=$(date +%s)
+        K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
+        jq --arg key0 'k8s-build-version' --arg value0 $K8S_BUILD_VERSION '. | .[$key0]=$value0' <<<'{}' > $ARTIFACTS/metadata.json
+
+        # kubectl needed for the e2e tests
+        curl -sSL https://dl.k8s.io/ci/$K8S_BUILD_VERSION/bin/linux/`go env GOARCH`/kubectl > /usr/local/bin/kubectl
+        chmod +x /usr/local/bin/kubectl
+
+        kubetest2 tf --powervs-dns k8s-tests \
+          --powervs-image-name centos-84-07122021-tier1 \
+          --powervs-region lon --powervs-zone lon04 \
+          --powervs-service-id f57510e4-7109-45ab-9dbb-a9fd38529707 \
+          --powervs-ssh-key powercloud-bot-key \
+          --ssh-private-key /etc/secret-volume/ssh-privatekey \
+          --build-version $K8S_BUILD_VERSION \
+          --workers-count 1 \
+          --cluster-name perf-test-$TIMESTAMP \
+          --playbook "install-k8s-perf.yml" \
+          --up --down --auto-approve --retry-on-tf-failure 3 \
+          --break-kubetest-on-upfail true \
+          --ignore-destroy-errors \
+          --powervs-memory 32 \
+          --extra-vars "kubelet_extra_args=--kube-api-qps=100 --kube-api-burst=100 --max-pods 140" \
+          --test=clusterloader2 -- --test-configs=testing/node-throughput/config.yaml --test-overrides=testing/overrides/node_docker.yaml --provider=local --nodes=1 --repo-root=$GOPATH/src/github.com/kubernetes/perf-tests/


### PR DESCRIPTION
- Adding new job : docker-node-throughput
- frequency set at 6h
- Test run logs - https://storage.googleapis.com/ppc64le-kubernetes/logs/periodic-kubernetes-docker-node-throughput-perf-test-ppc64le/1437727193609277440/build-log.txt