### PR TITLE
Presubmit Job for etcd repo

### DIFF
--- a/config/jobs/etcd-io/etcd/etcd-presubmit.yaml
+++ b/config/jobs/etcd-io/etcd/etcd-presubmit.yaml
@@ -1,0 +1,27 @@
+presubmits:
+  Rajalakshmi-Girish/etcd:
+  - name: pull-etcd-unit-integration-e2e-test-ppc64le
+    cluster: k8s-ppc64le-cluster
+    always_run: true
+    decorate: true
+    spec:
+      containers:
+        - image: quay.io/powercloud/all-in-one:0.3
+          command:
+            - /bin/bash
+          args:
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+
+              export PATH=$GOPATH/bin:$PATH
+              url="https://storage.googleapis.com/golang/go1.16.1.linux-ppc64le.tar.gz"
+              wget -O go.tgz "$url" --progress=dot:giga
+              rm -rf /usr/local/go
+              tar -C /usr/local -xzf go.tgz
+              go version
+              ./build.sh
+              GOARCH=`go env GOARCH` TEST_OPTS="PASSES='unit integration_e2e' RACE='true'" make test

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -18,6 +18,9 @@ triggers:
   - repos:
       - trigger-prow/test-trigger
     join_org_url: https://github.com/trigger-prow/test-trigger/blob/main/README.md
+  - repos:
+      - Rajalakshmi-Girish/etcd
+    join_org_url: https://github.com/Rajalakshmi-Girish/etcd/blob/main/README.md#contributing
 
 approve:
   - repos:
@@ -199,6 +202,34 @@ plugins:
       - yuks
 
   trigger-prow/test-trigger:
+    plugins:
+      - approve
+      - assign
+      - cat
+      - config-updater
+      - dog
+      - golint
+      - goose
+      - heart
+      - help
+      - hold
+      - label
+      - lgtm
+      - lifecycle
+      - mergecommitblocker
+      - owners-label
+      - pony
+      - retitle
+      - shrug
+      - size
+      - skip
+      - trigger
+      - verify-owners
+      - welcome
+      - wip
+      - yuks
+
+  Rajalakshmi-Girish/etcd:
     plugins:
       - approve
       - assign


### PR DESCRIPTION
This is a temporary test job added to prow infra as a prototype to the actually planned presubmits to upstream etcd. (https://github.com/etcd-io/etcd)
The repo `Rajalakshmi-Girish/etcd` has the Github App `PowerCloud CI` installed on it.
Thus addition of this job should trigger a presubmit job for new PRs or `retest` on `Rajalakshmi-Girish/etcd` repo.

https://prow.ppc64le-cloud.org/view/s3/prow-logs/pr-logs/pull/Rajalakshmi-Girish_etcd/1/pull-etcd-unit-intefration-e2e-test-ppc64le/1437687129432920064 is the test run with job in this PR. (Ignore the typo in job name)