### PR TITLE
Golang version bump in the images/pod-utilities/Dockerfile file

### DIFF
--- a/images/pod-utilities/Dockerfile
+++ b/images/pod-utilities/Dockerfile
@@ -1,5 +1,5 @@
 ARG POD_UTILITY=clonerefs
-FROM golang:1.15 as builder
+FROM golang:1.17 as builder
 
 ARG POD_UTILITY
 ARG CO_COMMIT=master


### PR DESCRIPTION
Fixes: #239

Building of pod-utility is throwing an error due to underlying Golang version:
```
#9 103.6 # k8s.io/test-infra/ghproxy/ghcache
#9 103.6 ghproxy/ghcache/ghcache.go:276:36: undefined: os.ReadDir
#9 103.6 note: module requires Go 1.16
#9 ERROR: process "/bin/sh -c git clone https://github.com/kubernetes/test-infra.git     && cd test-infra     && git checkout ${CO_COMMIT}     && CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w -extldflags \"-static\"' -o /usr/local/bin/${POD_UTILITY} ./prow/cmd/${POD_UTILITY}" did not complete successfully: exit code: 2
------
```