### PR TITLE
Configure liveness and readiness probes for prow-controller-manager

### DIFF
--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -8,6 +8,12 @@ metadata:
     app: prow-controller-manager
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: prow-controller-manager
@@ -46,6 +52,18 @@ spec:
             - name: kubeconfig
               mountPath: /etc/kubeconfig
               readOnly: true
+          livenessProbe: # Pod is killed if this fails 3 times.
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          readinessProbe: # Pod is not considered ready (for rolling deploy and request routing) if this fails 3 times.
+            httpGet:
+              path: /healthz/ready
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 3
       volumes:
         - name: github-token
           secret:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -70,10 +70,10 @@ plank:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
       utility_images:
-        clonerefs: quay.io/powercloud/clonerefs:v20211029-f2e5351ee3
-        entrypoint: quay.io/powercloud/entrypoint:v20211029-f2e5351ee3
-        initupload: quay.io/powercloud/initupload:v20211029-f2e5351ee3
-        sidecar: quay.io/powercloud/sidecar:v20211029-f2e5351ee3
+        clonerefs: quay.io/powercloud/clonerefs:v20211203-281e29a97a
+        entrypoint: quay.io/powercloud/entrypoint:v20211203-281e29a97a
+        initupload: quay.io/powercloud/initupload:v20211203-281e29a97a
+        sidecar: quay.io/powercloud/sidecar:v20211203-281e29a97a
       ssh_key_secrets:
         - bot-ssh-secret
 


### PR DESCRIPTION
As part of prow infra upgrade to v20211203-281e29a97a, https://github.com/kubernetes/test-infra/pull/24340 needs to be added.
