### PR TITLE
Fix flaky tests in periodic-kubernetes-containerd-conformance-test-ppc64le prow job

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -101,11 +101,23 @@ periodics:
                 --powervs-ssh-key powercloud-bot-key \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \
                 --build-version $K8S_BUILD_VERSION \
-                --runtime containerd \
                 --cluster-name config1-$TIMESTAMP \
                 --workers-count 2 \
-                --up --down --auto-approve --retry-on-tf-failure 3 \
+                --up --auto-approve --retry-on-tf-failure 3 \
                 --break-kubetest-on-upfail true \
-                --ignore-destroy-errors \
                 --powervs-memory 32 \
-                --test=ginkgo -- --parallel 10 --flake-attempts 2 --test-package-bucket k8s-release-dev --test-package-dir ci --test-package-version $K8S_BUILD_VERSION --focus-regex='\[Conformance\]'
+                --test=ginkgo -- --parallel 10 --flake-attempts 2 --test-package-bucket k8s-release-dev --test-package-dir ci --test-package-version $K8S_BUILD_VERSION --focus-regex='\[Conformance\]' --skip-regex='\[Serial\]'
+              #Workaround for kubetest2 failure to run twice
+              #https://github.com/kubernetes-sigs/kubetest2/issues/176
+              rm metadata.json
+              export KUBECONFIG="$(pwd)/config1-$TIMESTAMP/kubeconfig"
+              export ARTIFACTS=$ARTIFACTS/serial_tests_artifacts
+              #Run Serial Conformance tests
+              kubetest2 tf --powervs-region lon --powervs-zone lon04 \
+                --powervs-service-id f57510e4-7109-45ab-9dbb-a9fd38529707 \
+                --ignore-cluster-dir true \
+                --cluster-name config1-$TIMESTAMP \
+                --down --auto-approve --ignore-destroy-errors \
+                --test=ginkgo -- --flake-attempts 2 \
+                --test-package-bucket k8s-release-dev --test-package-dir ci \
+                --test-package-version $K8S_BUILD_VERSION --focus-regex='\[Serial\].*\[Conformance\]'


### PR DESCRIPTION
This change splits the `kubetest2` command in `periodic-kubernetes-containerd-conformance-test-ppc64le` prow job into two.
The First kubetest2 call is to run `non-serial` conformance tests in parallel and then do serial run of the `serial` conformance tests.
There is an [issue](https://github.com/kubernetes-sigs/kubetest2/issues/176) to run `kubetest2` command twice from the same path. It throws:
```
root@kubetest2:/workspace# kubetest2 tf --test=ginkgo -- --flake-attempts 2 --focus-regex='ariable Expansion should verify that a failing subpath expansion can be modified during the lifecycle of a container'
F1210 11:00:28.745660   14208 ginkgo.go:205] failed to run ginkgo tester: key tester-version already exists in the metadata
Error: exit status 255
root@kubetest2:/workspace#
```
Hence the `metadata.json` file that is causing this is [being removed](https://github.com/Rajalakshmi-Girish/test-infra/blob/eaea197dbc795bda109ae26945cae35d0104b6aa/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml#L112) before running the second `kubetest2` command.

Note: This metadata.json is different from the [one](https://github.com/Rajalakshmi-Girish/test-infra/blob/eaea197dbc795bda109ae26945cae35d0104b6aa/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml#L91) which we write into the ARTIFACTS folder for the sake of K8S_BUILD_VERSION display in [test-grid](https://k8s-testgrid.appspot.com/ibm-conformance-ppc64le#Periodic%20Conformance%20on%20ppc64le%20with%20containerd%20as%20runtime).

Also, the ARTIFACTS folder for the second command is being changed to `$ARTIFACTS/serial_tests_artifacts` so as to avoid overwriting the junit XML files from the first run!

Below is the link for job that was tested with this change
https://prow.ppc64le-cloud.org/view/gs/ppc64le-kubernetes/logs/test-periodic-kubernetes-containerd-conformance-test-ppc64le/1473595804110295040

Also shall submit the change for `postsubmit-master-golang-kubernetes-conformance-test-ppc64le` once it is tested. Currently unable to test this, due to frequent errors in Provisioning VM from IBMcloud PowerVS.
Errors of the below kind from PowerVS hence unable to run `test-pj.sh`.
```
[1m[31mError: [0m[0m[1mfailed to provision Failed to Create PVM Instance :unknown error (status 504): {}[0m
```
Ref https://prow.ppc64le-cloud.org/job-history/s3/prow-logs/logs/test-postsubmit-master-golang-kubernetes-conformance-test-ppc64le
