### PR TITLE
Fix the Error in Cerberus Custom checks

### DIFF
--- a/config/prow/cluster/cerberus_configmaps.yaml
+++ b/config/prow/cluster/cerberus_configmaps.yaml
@@ -62,15 +62,14 @@ data:
         logging.info("Check health of prow controller\n")
 
     def check():
-        pod_name =  runcommand.invoke("kubectl -n prow get pods -o custom-columns=\":metadata.name\" | grep controller")
-        pod_log = runcommand.invoke("kubectl -n prow logs %s" % (pod_name))
+        pod_log = runcommand.invoke("kubectl logs deploy/prow-controller-manager -n prow")
 
         if ((pod_log.find("Failed to get API Group-Resources")) != -1):
-            message = "Prow controller Pod has Error"
+            message = "Prow controller Pod has Error. Wait for monitor-prow-controller pod to fix"
             logging.info(message)
             return False, message
         else:
-            message = "Prow controller Pod has No Error"
+            message = "Prow controller Pod has No Error related to getting API Group-Resources"
             logging.info(message)
             return True, message
 

--- a/config/prow/cluster/cerberus_rbac.yaml
+++ b/config/prow/cluster/cerberus_rbac.yaml
@@ -14,6 +14,12 @@ metadata:
   name: "cerberus"
 rules:
   - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+    verbs:
+      - get
+  - apiGroups:
       - ""
     resources:
       - pods


### PR DESCRIPTION
This is to fix the below error in Cerberus pod:
```
2022-01-03 09:33:58,765 [INFO] Check health of prow controller

/bin/sh: line 1: prow-controller-manager-7ccd954fc7-6tx58: command not found
2022-01-03 09:33:59,350 [ERROR] Failed to run kubectl -n prow logs monitor-prow-controller-6775b7c5d9-7shzb
prow-controller-manager-7ccd954fc7-6tx58
```