### PR TITLE
Specs for the ci-search tool exposed for internal prow ci

### DIFF
--- a/config/prow/cluster/cisearch_deployment.yaml
+++ b/config/prow/cluster/cisearch_deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ci-search
+  namespace: prow
+  labels:
+    app: ci-search
+spec:
+  replicas: 1 # Do not scale up.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ci-search
+  template:
+    metadata:
+      labels:
+        app: ci-search
+    spec:
+      serviceAccountName: ci-search
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: ci-search
+        image: quay.io/powercloud/ci-search:latest
+        ports:
+        - containerPort: 8080

--- a/config/prow/cluster/cisearch_ingress.yaml
+++ b/config/prow/cluster/cisearch_ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: prow
+  name: ci-search
+  annotations:
+    # Change this to your issuer when using cert-manager. Does
+    # nothing when not using cert-manager.
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+    kubernetes.io/ingress.class: public-iks-k8s-nginx
+spec:
+  rules:
+    - host: search.ppc64le-cloud.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ci-search
+                port:
+                  number: 8080
+  tls:
+    - hosts:
+        - search.ppc64le-cloud.org
+      secretName: ppc64le-cloud

--- a/config/prow/cluster/cisearch_rbac.yaml
+++ b/config/prow/cluster/cisearch_rbac.yaml
@@ -1,0 +1,27 @@
+# This file contains all the required spec for service account, roles and role bindings for the ci-search deployment
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  namespace: prow
+  name: "ci-search"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: prow
+  name: "ci-search"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: prow
+  name: "ci-search"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "ci-search"
+subjects:
+  - kind: ServiceAccount
+    name: "ci-search"
+    namespace: prow

--- a/config/prow/cluster/cisearch_service.yaml
+++ b/config/prow/cluster/cisearch_service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: prow
+  name: ci-search
+spec:
+  selector:
+    app: ci-search
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/images/ci-search/Dockerfile
+++ b/images/ci-search/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang
+WORKDIR /go/src/github.com/openshift
+RUN git clone https://github.com/openshift/ci-search \
+    && cd ci-search \
+    && grep -rl origin-ci-test . | xargs sed -i 's/origin-ci-test/ppc64le-kubernetes/g' \
+    && grep -rl "OpenShift" . | xargs sed -i 's/OpenShift/Kubernetes-ppc64le/g' \
+    && grep -rl "prow\.ci\.openshift" . | xargs sed -i 's/prow\.ci\.openshift/prow\.ppc64le-cloud/g' \
+    && make build
+
+FROM centos:7
+COPY --from=0 /go/src/github.com/openshift/ci-search/search /usr/bin/
+RUN curl -L https://github.com/BurntSushi/ripgrep/releases/download/12.0.1/ripgrep-12.0.1-x86_64-unknown-linux-musl.tar.gz | \
+    tar xvzf - --wildcards --no-same-owner --strip-components=1  -C /usr/bin '*/rg'
+RUN mkdir /var/lib/ci-search && chown 1000:1000 /var/lib/ci-search && chmod 1777 /var/lib/ci-search
+USER 1000:1000
+ENTRYPOINT ["search"]
+CMD ["--path=/var/lib/ci-search/", "--deck-uri=https://prow.ppc64le-cloud.org"]
+EXPOSE 8080

--- a/images/ci-search/README.md
+++ b/images/ci-search/README.md
@@ -1,0 +1,13 @@
+# ci-search
+
+> Reference: https://github.com/openshift/ci-search/blob/master/Dockerfile
+This is an image used for bringing up openshift's ci-search tool for our internal Prow infra that runs jobs on ppc64le architecture, includes following content:
+
+## How to build
+
+```shell script
+$ docker build -t quay.io/powercloud/ci-search:latest .
+
+$ docker push quay.io/powercloud/ci-search:latest
+```
+> Note: This tool is tested only on x86 platform.


### PR DESCRIPTION
The image is built and pushed https://quay.io/repository/powercloud/ci-search?tab=tags
Also these specs were applied in IKS cluster.
The tool is running at https://search.ppc64le-cloud.org/