### PR TITLE
Change the k8s cluster creation jobs to use centos-8-stream image

### DIFF
--- a/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
@@ -61,7 +61,7 @@ periodics:
         chmod +x /usr/local/bin/kubectl
 
         kubetest2 tf --powervs-dns k8s-tests \
-          --powervs-image-name centos-84-07122021-tier1 \
+          --powervs-image-name centos-8-stream-20gb \
           --powervs-region lon --powervs-zone lon04 \
           --powervs-service-id f57510e4-7109-45ab-9dbb-a9fd38529707 \
           --powervs-ssh-key powercloud-bot-key \
@@ -140,7 +140,7 @@ periodics:
         chmod +x /usr/local/bin/kubectl
 
         kubetest2 tf --powervs-dns k8s-tests \
-          --powervs-image-name centos-84-07122021-tier1 \
+          --powervs-image-name centos-8-stream-20gb \
           --powervs-region lon --powervs-zone lon04 \
           --powervs-service-id f57510e4-7109-45ab-9dbb-a9fd38529707 \
           --powervs-ssh-key powercloud-bot-key \

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -95,7 +95,7 @@ periodics:
               chmod +x /usr/local/bin/kubectl
 
               kubetest2 tf --powervs-dns k8s-tests \
-                --powervs-image-name centos-84-07122021-tier1 \
+                --powervs-image-name centos-8-stream-20gb \
                 --powervs-region lon --powervs-zone lon04 \
                 --powervs-service-id f57510e4-7109-45ab-9dbb-a9fd38529707 \
                 --powervs-ssh-key powercloud-bot-key \

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -144,7 +144,7 @@ postsubmits:
                 wget -qO- $URL/kubernetes-client-linux-ppc64le.tar.gz | tar xz -C /usr/local/bin --strip-components=3
 
                 kubetest2 tf --powervs-dns k8s-tests \
-                    --powervs-image-name centos-84-07122021-tier1 \
+                    --powervs-image-name centos-8-stream-20gb \
                     --powervs-region lon --powervs-zone lon04 \
                     --powervs-service-id f57510e4-7109-45ab-9dbb-a9fd38529707 \
                     --powervs-ssh-key powercloud-bot-key \


### PR DESCRIPTION
The k8s cluster creation jobs in Prow CI were failing with below error:
```
TASK [runtime : Install iptables] **********************************************
fatal: [158.175.163.170]: FAILED! => {"changed": false, "msg": "Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist", "rc": 1, "results": []}
fatal: [158.175.163.174]: FAILED! => {"changed": false, "msg": "Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist", "rc": 1, "results": []}
```
centos8 has come to EOL on Jan31st https://www.centos.org/centos-linux-eol/
Thus moving the jobs to use centos8-stream image.
https://prow.ppc64le-cloud.org/view/gs/ppc64le-kubernetes/logs/periodic-kubernetes-containerd-conformance-test-ppc64le/1488427293700263936 is the passing job with new image.
