### PR TITLE
Spec changes for upgrade prow infra to v20220201-d251d8b00d

### DIFF
--- a/config/prow/cluster/cherrypick_deployment.yaml
+++ b/config/prow/cluster/cherrypick_deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: cherrypick
-        image: gcr.io/k8s-prow/cherrypicker:v20211229-d20cd1c87e
+        image: gcr.io/k8s-prow/cherrypicker:v20220201-d251d8b00d
         args:
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: gcr.io/k8s-prow/crier:v20211229-d20cd1c87e
+          image: gcr.io/k8s-prow/crier:v20220201-d251d8b00d
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/crier_github_app_deployment.yaml
+++ b/config/prow/cluster/crier_github_app_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier2
-          image: gcr.io/k8s-prow/crier:v20211229-d20cd1c87e
+          image: gcr.io/k8s-prow/crier:v20220201-d251d8b00d
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: gcr.io/k8s-prow/deck:v20211229-d20cd1c87e
+          image: gcr.io/k8s-prow/deck:v20220201-d251d8b00d
           args:
             - --config-path=/etc/config/config.yaml
             - --plugin-config=/etc/plugins/plugins.yaml

--- a/config/prow/cluster/deck_ingress.yaml
+++ b/config/prow/cluster/deck_ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: prow
@@ -19,9 +19,12 @@ spec:
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: deck
-              servicePort: 80
+              service:
+                name: deck
+                port:
+                  number: 80
   tls:
     - hosts:
         - prow.ppc64le-cloud.org

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20211229-d20cd1c87e
+          image: gcr.io/k8s-prow/ghproxy:v20220201-d251d8b00d
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: gcr.io/k8s-prow/hook:v20211229-d20cd1c87e
+          image: gcr.io/k8s-prow/hook:v20220201-d251d8b00d
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/hook_github_app_deployment.yaml
+++ b/config/prow/cluster/hook_github_app_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook2
-          image: gcr.io/k8s-prow/hook:v20211229-d20cd1c87e
+          image: gcr.io/k8s-prow/hook:v20220201-d251d8b00d
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/hook_ingress.yaml
+++ b/config/prow/cluster/hook_ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: prow
@@ -20,13 +20,19 @@ spec:
       http:
         paths:
           - path: /hook
+            pathType: ImplementationSpecific
             backend:
-              serviceName: hook
-              servicePort: 8888
+              service:
+                name: hook
+                port:
+                  number: 8888
           - path: /hook2
+            pathType: ImplementationSpecific
             backend:
-              serviceName: hook2
-              servicePort: 8888
+              service:
+                name: hook2
+                port:
+                  number: 8888
   tls:
     - hosts:
         - prow.ppc64le-cloud.org

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: horologium
-          image: gcr.io/k8s-prow/horologium:v20211229-d20cd1c87e
+          image: gcr.io/k8s-prow/horologium:v20220201-d251d8b00d
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/label_sync_cron_job.yaml
+++ b/config/prow/cluster/label_sync_cron_job.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20211229-d20cd1c87e
+              image: gcr.io/k8s-prow/label_sync:v20220201-d251d8b00d
               args:
                 - --config=/etc/config/labels.yaml
                 - --confirm=true

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - --github-endpoint=https://api.github.com
             - --enable-controller=plank
             - --job-config-path=/etc/job-config
-          image: gcr.io/k8s-prow/prow-controller-manager:v20211229-d20cd1c87e
+          image: gcr.io/k8s-prow/prow-controller-manager:v20220201-d251d8b00d
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG

--- a/config/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -8,6 +8,7 @@ metadata:
   creationTimestamp: null
   name: prowjobs.prow.k8s.io
 spec:
+  preserveUnknownFields: false
   group: prow.k8s.io
   names:
     kind: ProwJob
@@ -1297,12 +1298,14 @@ spec:
                                           is not provided. Variable references $(VAR_NAME)
                                           are expanded using the container''s environment.
                                           If a variable cannot be resolved, the reference
-                                          in the input string will be unchanged. The
-                                          $(VAR_NAME) syntax can be escaped with a
-                                          double $$, ie: $$(VAR_NAME). Escaped references
-                                          will never be expanded, regardless of whether
-                                          the variable exists or not. Cannot be updated.
-                                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                          in the input string will be unchanged. Double
+                                          $$ are reduced to a single $, which allows
+                                          for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal
+                                          "$(VAR_NAME)". Escaped references will never
+                                          be expanded, regardless of whether the variable
+                                          exists or not. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                         items:
                                           type: string
                                         type: array
@@ -1313,12 +1316,14 @@ spec:
                                           references $(VAR_NAME) are expanded using
                                           the container''s environment. If a variable
                                           cannot be resolved, the reference in the
-                                          input string will be unchanged. The $(VAR_NAME)
-                                          syntax can be escaped with a double $$,
-                                          ie: $$(VAR_NAME). Escaped references will
-                                          never be expanded, regardless of whether
-                                          the variable exists or not. Cannot be updated.
-                                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                          input string will be unchanged. Double $$
+                                          are reduced to a single $, which allows
+                                          for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal
+                                          "$(VAR_NAME)". Escaped references will never
+                                          be expanded, regardless of whether the variable
+                                          exists or not. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                         items:
                                           type: string
                                         type: array
@@ -1335,17 +1340,19 @@ spec:
                                               type: string
                                             value:
                                               description: 'Variable references $(VAR_NAME)
-                                                are expanded using the previous defined
-                                                environment variables in the container
-                                                and any service environment variables.
-                                                If a variable cannot be resolved,
-                                                the reference in the input string
-                                                will be unchanged. The $(VAR_NAME)
-                                                syntax can be escaped with a double
-                                                $$, ie: $$(VAR_NAME). Escaped references
-                                                will never be expanded, regardless
-                                                of whether the variable exists or
-                                                not. Defaults to "".'
+                                                are expanded using the previously
+                                                defined environment variables in the
+                                                container and any service environment
+                                                variables. If a variable cannot be
+                                                resolved, the reference in the input
+                                                string will be unchanged. Double $$
+                                                are reduced to a single $, which allows
+                                                for escaping the $(VAR_NAME) syntax:
+                                                i.e. "$$(VAR_NAME)" will produce the
+                                                string literal "$(VAR_NAME)". Escaped
+                                                references will never be expanded,
+                                                regardless of whether the variable
+                                                exists or not. Defaults to "".'
                                               type: string
                                             valueFrom:
                                               description: Source for the environment
@@ -1904,9 +1911,10 @@ spec:
                                               Value must be non-negative integer.
                                               The value zero indicates stop immediately
                                               via the kill signal (no opportunity
-                                              to shut down). This is an alpha field
+                                              to shut down). This is a beta field
                                               and requires enabling ProbeTerminationGracePeriod
-                                              feature gate.
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
                                             format: int64
                                             type: integer
                                           timeoutSeconds:
@@ -2125,9 +2133,10 @@ spec:
                                               Value must be non-negative integer.
                                               The value zero indicates stop immediately
                                               via the kill signal (no opportunity
-                                              to shut down). This is an alpha field
+                                              to shut down). This is a beta field
                                               and requires enabling ProbeTerminationGracePeriod
-                                              feature gate.
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
                                             format: int64
                                             type: integer
                                           timeoutSeconds:
@@ -2176,8 +2185,10 @@ spec:
                                           or Args."
                                         type: string
                                       securityContext:
-                                        description: 'Security options the pod should
-                                          run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                        description: 'SecurityContext defines the
+                                          security options the container should be
+                                          run with. If set, the fields of SecurityContext
+                                          override the equivalent fields of PodSecurityContext.
                                           More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                         properties:
                                           allowPrivilegeEscalation:
@@ -2342,6 +2353,24 @@ spec:
                                                   is the name of the GMSA credential
                                                   spec to use.
                                                 type: string
+                                              hostProcess:
+                                                description: HostProcess determines
+                                                  if a container should be run as
+                                                  a 'Host Process' container. This
+                                                  field is alpha-level and will only
+                                                  be honored by components that enable
+                                                  the WindowsHostProcessContainers
+                                                  feature flag. Setting this field
+                                                  without the feature flag will result
+                                                  in errors when validating the Pod.
+                                                  All of a Pod's containers must have
+                                                  the same effective HostProcess value
+                                                  (it is not allowed to have a mix
+                                                  of HostProcess containers and non-HostProcess
+                                                  containers).  In addition, if HostProcess
+                                                  is true then HostNetwork must also
+                                                  be set to true.
+                                                type: boolean
                                               runAsUserName:
                                                 description: The UserName in Windows
                                                   to run the entrypoint of the container
@@ -2508,9 +2537,10 @@ spec:
                                               Value must be non-negative integer.
                                               The value zero indicates stop immediately
                                               via the kill signal (no opportunity
-                                              to shut down). This is an alpha field
+                                              to shut down). This is a beta field
                                               and requires enabling ProbeTerminationGracePeriod
-                                              feature gate.
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
                                             format: int64
                                             type: integer
                                           timeoutSeconds:
@@ -2666,12 +2696,14 @@ spec:
                                         provided. Variable references $(VAR_NAME)
                                         are expanded using the container''s environment.
                                         If a variable cannot be resolved, the reference
-                                        in the input string will be unchanged. The
-                                        $(VAR_NAME) syntax can be escaped with a double
-                                        $$, ie: $$(VAR_NAME). Escaped references will
-                                        never be expanded, regardless of whether the
-                                        variable exists or not. Cannot be updated.
-                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                        in the input string will be unchanged. Double
+                                        $$ are reduced to a single $, which allows
+                                        for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal
+                                        "$(VAR_NAME)". Escaped references will never
+                                        be expanded, regardless of whether the variable
+                                        exists or not. Cannot be updated. More info:
+                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                       items:
                                         type: string
                                       type: array
@@ -2682,12 +2714,13 @@ spec:
                                         references $(VAR_NAME) are expanded using
                                         the container''s environment. If a variable
                                         cannot be resolved, the reference in the input
-                                        string will be unchanged. The $(VAR_NAME)
-                                        syntax can be escaped with a double $$, ie:
-                                        $$(VAR_NAME). Escaped references will never
-                                        be expanded, regardless of whether the variable
-                                        exists or not. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                        string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the
+                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded,
+                                        regardless of whether the variable exists
+                                        or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                       items:
                                         type: string
                                       type: array
@@ -2704,13 +2737,15 @@ spec:
                                             type: string
                                           value:
                                             description: 'Variable references $(VAR_NAME)
-                                              are expanded using the previous defined
+                                              are expanded using the previously defined
                                               environment variables in the container
                                               and any service environment variables.
                                               If a variable cannot be resolved, the
                                               reference in the input string will be
-                                              unchanged. The $(VAR_NAME) syntax can
-                                              be escaped with a double $$, ie: $$(VAR_NAME).
+                                              unchanged. Double $$ are reduced to
+                                              a single $, which allows for escaping
+                                              the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                              will produce the string literal "$(VAR_NAME)".
                                               Escaped references will never be expanded,
                                               regardless of whether the variable exists
                                               or not. Defaults to "".'
@@ -3252,8 +3287,10 @@ spec:
                                             must be non-negative integer. The value
                                             zero indicates stop immediately via the
                                             kill signal (no opportunity to shut down).
-                                            This is an alpha field and requires enabling
+                                            This is a beta field and requires enabling
                                             ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
@@ -3467,8 +3504,10 @@ spec:
                                             must be non-negative integer. The value
                                             zero indicates stop immediately via the
                                             kill signal (no opportunity to shut down).
-                                            This is an alpha field and requires enabling
+                                            This is a beta field and requires enabling
                                             ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
@@ -3510,8 +3549,10 @@ spec:
                                           type: object
                                       type: object
                                     securityContext:
-                                      description: 'Security options the pod should
-                                        run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                      description: 'SecurityContext defines the security
+                                        options the container should be run with.
+                                        If set, the fields of SecurityContext override
+                                        the equivalent fields of PodSecurityContext.
                                         More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                       properties:
                                         allowPrivilegeEscalation:
@@ -3673,6 +3714,22 @@ spec:
                                                 is the name of the GMSA credential
                                                 spec to use.
                                               type: string
+                                            hostProcess:
+                                              description: HostProcess determines
+                                                if a container should be run as a
+                                                'Host Process' container. This field
+                                                is alpha-level and will only be honored
+                                                by components that enable the WindowsHostProcessContainers
+                                                feature flag. Setting this field without
+                                                the feature flag will result in errors
+                                                when validating the Pod. All of a
+                                                Pod's containers must have the same
+                                                effective HostProcess value (it is
+                                                not allowed to have a mix of HostProcess
+                                                containers and non-HostProcess containers).  In
+                                                addition, if HostProcess is true then
+                                                HostNetwork must also be set to true.
+                                              type: boolean
                                             runAsUserName:
                                               description: The UserName in Windows
                                                 to run the entrypoint of the container
@@ -3836,8 +3893,10 @@ spec:
                                             must be non-negative integer. The value
                                             zero indicates stop immediately via the
                                             kill signal (no opportunity to shut down).
-                                            This is an alpha field and requires enabling
+                                            This is a beta field and requires enabling
                                             ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
@@ -3992,12 +4051,14 @@ spec:
                                           is not provided. Variable references $(VAR_NAME)
                                           are expanded using the container''s environment.
                                           If a variable cannot be resolved, the reference
-                                          in the input string will be unchanged. The
-                                          $(VAR_NAME) syntax can be escaped with a
-                                          double $$, ie: $$(VAR_NAME). Escaped references
-                                          will never be expanded, regardless of whether
-                                          the variable exists or not. Cannot be updated.
-                                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                          in the input string will be unchanged. Double
+                                          $$ are reduced to a single $, which allows
+                                          for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal
+                                          "$(VAR_NAME)". Escaped references will never
+                                          be expanded, regardless of whether the variable
+                                          exists or not. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                         items:
                                           type: string
                                         type: array
@@ -4008,12 +4069,14 @@ spec:
                                           references $(VAR_NAME) are expanded using
                                           the container''s environment. If a variable
                                           cannot be resolved, the reference in the
-                                          input string will be unchanged. The $(VAR_NAME)
-                                          syntax can be escaped with a double $$,
-                                          ie: $$(VAR_NAME). Escaped references will
-                                          never be expanded, regardless of whether
-                                          the variable exists or not. Cannot be updated.
-                                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                          input string will be unchanged. Double $$
+                                          are reduced to a single $, which allows
+                                          for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal
+                                          "$(VAR_NAME)". Escaped references will never
+                                          be expanded, regardless of whether the variable
+                                          exists or not. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                         items:
                                           type: string
                                         type: array
@@ -4030,17 +4093,19 @@ spec:
                                               type: string
                                             value:
                                               description: 'Variable references $(VAR_NAME)
-                                                are expanded using the previous defined
-                                                environment variables in the container
-                                                and any service environment variables.
-                                                If a variable cannot be resolved,
-                                                the reference in the input string
-                                                will be unchanged. The $(VAR_NAME)
-                                                syntax can be escaped with a double
-                                                $$, ie: $$(VAR_NAME). Escaped references
-                                                will never be expanded, regardless
-                                                of whether the variable exists or
-                                                not. Defaults to "".'
+                                                are expanded using the previously
+                                                defined environment variables in the
+                                                container and any service environment
+                                                variables. If a variable cannot be
+                                                resolved, the reference in the input
+                                                string will be unchanged. Double $$
+                                                are reduced to a single $, which allows
+                                                for escaping the $(VAR_NAME) syntax:
+                                                i.e. "$$(VAR_NAME)" will produce the
+                                                string literal "$(VAR_NAME)". Escaped
+                                                references will never be expanded,
+                                                regardless of whether the variable
+                                                exists or not. Defaults to "".'
                                               type: string
                                             valueFrom:
                                               description: Source for the environment
@@ -4599,9 +4664,10 @@ spec:
                                               Value must be non-negative integer.
                                               The value zero indicates stop immediately
                                               via the kill signal (no opportunity
-                                              to shut down). This is an alpha field
+                                              to shut down). This is a beta field
                                               and requires enabling ProbeTerminationGracePeriod
-                                              feature gate.
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
                                             format: int64
                                             type: integer
                                           timeoutSeconds:
@@ -4820,9 +4886,10 @@ spec:
                                               Value must be non-negative integer.
                                               The value zero indicates stop immediately
                                               via the kill signal (no opportunity
-                                              to shut down). This is an alpha field
+                                              to shut down). This is a beta field
                                               and requires enabling ProbeTerminationGracePeriod
-                                              feature gate.
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
                                             format: int64
                                             type: integer
                                           timeoutSeconds:
@@ -4871,8 +4938,10 @@ spec:
                                           or Args."
                                         type: string
                                       securityContext:
-                                        description: 'Security options the pod should
-                                          run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                        description: 'SecurityContext defines the
+                                          security options the container should be
+                                          run with. If set, the fields of SecurityContext
+                                          override the equivalent fields of PodSecurityContext.
                                           More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                         properties:
                                           allowPrivilegeEscalation:
@@ -5037,6 +5106,24 @@ spec:
                                                   is the name of the GMSA credential
                                                   spec to use.
                                                 type: string
+                                              hostProcess:
+                                                description: HostProcess determines
+                                                  if a container should be run as
+                                                  a 'Host Process' container. This
+                                                  field is alpha-level and will only
+                                                  be honored by components that enable
+                                                  the WindowsHostProcessContainers
+                                                  feature flag. Setting this field
+                                                  without the feature flag will result
+                                                  in errors when validating the Pod.
+                                                  All of a Pod's containers must have
+                                                  the same effective HostProcess value
+                                                  (it is not allowed to have a mix
+                                                  of HostProcess containers and non-HostProcess
+                                                  containers).  In addition, if HostProcess
+                                                  is true then HostNetwork must also
+                                                  be set to true.
+                                                type: boolean
                                               runAsUserName:
                                                 description: The UserName in Windows
                                                   to run the entrypoint of the container
@@ -5203,9 +5290,10 @@ spec:
                                               Value must be non-negative integer.
                                               The value zero indicates stop immediately
                                               via the kill signal (no opportunity
-                                              to shut down). This is an alpha field
+                                              to shut down). This is a beta field
                                               and requires enabling ProbeTerminationGracePeriod
-                                              feature gate.
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
                                             format: int64
                                             type: integer
                                           timeoutSeconds:
@@ -5905,17 +5993,76 @@ spec:
                                                       existing VolumeSnapshot object
                                                       (snapshot.storage.k8s.io/VolumeSnapshot)
                                                       * An existing PVC (PersistentVolumeClaim)
-                                                      * An existing custom resource
-                                                      that implements data population
-                                                      (Alpha) In order to use custom
-                                                      resource types that implement
-                                                      data population, the AnyVolumeDataSource
-                                                      feature gate must be enabled.
                                                       If the provisioner or an external
                                                       controller can support the specified
                                                       data source, it will create
                                                       a new volume based on the contents
-                                                      of the specified data source.'
+                                                      of the specified data source.
+                                                      If the AnyVolumeDataSource feature
+                                                      gate is enabled, this field
+                                                      will always have the same contents
+                                                      as the DataSourceRef field.'
+                                                    properties:
+                                                      apiGroup:
+                                                        description: APIGroup is the
+                                                          group for the resource being
+                                                          referenced. If APIGroup
+                                                          is not specified, the specified
+                                                          Kind must be in the core
+                                                          API group. For any other
+                                                          third-party types, APIGroup
+                                                          is required.
+                                                        type: string
+                                                      kind:
+                                                        description: Kind is the type
+                                                          of resource being referenced
+                                                        type: string
+                                                      name:
+                                                        description: Name is the name
+                                                          of resource being referenced
+                                                        type: string
+                                                    required:
+                                                    - kind
+                                                    - name
+                                                    type: object
+                                                  dataSourceRef:
+                                                    description: 'Specifies the object
+                                                      from which to populate the volume
+                                                      with data, if a non-empty volume
+                                                      is desired. This may be any
+                                                      local object from a non-empty
+                                                      API group (non core object)
+                                                      or a PersistentVolumeClaim object.
+                                                      When this field is specified,
+                                                      volume binding will only succeed
+                                                      if the type of the specified
+                                                      object matches some installed
+                                                      volume populator or dynamic
+                                                      provisioner. This field will
+                                                      replace the functionality of
+                                                      the DataSource field and as
+                                                      such if both fields are non-empty,
+                                                      they must have the same value.
+                                                      For backwards compatibility,
+                                                      both fields (DataSource and
+                                                      DataSourceRef) will be set to
+                                                      the same value automatically
+                                                      if one of them is empty and
+                                                      the other is non-empty. There
+                                                      are two important differences
+                                                      between DataSource and DataSourceRef:
+                                                      * While DataSource only allows
+                                                      two specific types of objects,
+                                                      DataSourceRef   allows any non-core
+                                                      object, as well as PersistentVolumeClaim
+                                                      objects. * While DataSource
+                                                      ignores disallowed values (dropping
+                                                      them), DataSourceRef   preserves
+                                                      all values, and generates an
+                                                      error if a disallowed value
+                                                      is   specified. (Alpha) Using
+                                                      this field requires the AnyVolumeDataSource
+                                                      feature gate to be enabled.'
                                                     properties:
                                                       apiGroup:
                                                         description: APIGroup is the
@@ -7520,9 +7667,9 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is alpha-level and is only
-                                            honored when PodAffinityNamespaceSelector
-                                            feature is enabled.
+                                            This field is beta-level and is only honored
+                                            when PodAffinityNamespaceSelector feature
+                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -7692,7 +7839,7 @@ spec:
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
                                         selector ({}) matches all namespaces. This
-                                        field is alpha-level and is only honored when
+                                        field is beta-level and is only honored when
                                         PodAffinityNamespaceSelector feature is enabled.
                                       properties:
                                         matchExpressions:
@@ -7861,9 +8008,9 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is alpha-level and is only
-                                            honored when PodAffinityNamespaceSelector
-                                            feature is enabled.
+                                            This field is beta-level and is only honored
+                                            when PodAffinityNamespaceSelector feature
+                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -8033,7 +8180,7 @@ spec:
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
                                         selector ({}) matches all namespaces. This
-                                        field is alpha-level and is only honored when
+                                        field is beta-level and is only honored when
                                         PodAffinityNamespaceSelector feature is enabled.
                                       properties:
                                         matchExpressions:
@@ -8362,6 +8509,19 @@ spec:
                                 description: GMSACredentialSpecName is the name of
                                   the GMSA credential spec to use.
                                 type: string
+                              hostProcess:
+                                description: HostProcess determines if a container
+                                  should be run as a 'Host Process' container. This
+                                  field is alpha-level and will only be honored by
+                                  components that enable the WindowsHostProcessContainers
+                                  feature flag. Setting this field without the feature
+                                  flag will result in errors when validating the Pod.
+                                  All of a Pod's containers must have the same effective
+                                  HostProcess value (it is not allowed to have a mix
+                                  of HostProcess containers and non-HostProcess containers).  In
+                                  addition, if HostProcess is true then HostNetwork
+                                  must also be set to true.
+                                type: boolean
                               runAsUserName:
                                 description: The UserName in Windows to run the entrypoint
                                   of the container process. Defaults to the user specified
@@ -8898,15 +9058,64 @@ spec:
                                             specify either: * An existing VolumeSnapshot
                                             object (snapshot.storage.k8s.io/VolumeSnapshot)
                                             * An existing PVC (PersistentVolumeClaim)
-                                            * An existing custom resource that implements
-                                            data population (Alpha) In order to use
-                                            custom resource types that implement data
-                                            population, the AnyVolumeDataSource feature
-                                            gate must be enabled. If the provisioner
-                                            or an external controller can support
-                                            the specified data source, it will create
-                                            a new volume based on the contents of
-                                            the specified data source.'
+                                            If the provisioner or an external controller
+                                            can support the specified data source,
+                                            it will create a new volume based on the
+                                            contents of the specified data source.
+                                            If the AnyVolumeDataSource feature gate
+                                            is enabled, this field will always have
+                                            the same contents as the DataSourceRef
+                                            field.'
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced. If
+                                                APIGroup is not specified, the specified
+                                                Kind must be in the core API group.
+                                                For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        dataSourceRef:
+                                          description: 'Specifies the object from
+                                            which to populate the volume with data,
+                                            if a non-empty volume is desired. This
+                                            may be any local object from a non-empty
+                                            API group (non core object) or a PersistentVolumeClaim
+                                            object. When this field is specified,
+                                            volume binding will only succeed if the
+                                            type of the specified object matches some
+                                            installed volume populator or dynamic
+                                            provisioner. This field will replace the
+                                            functionality of the DataSource field
+                                            and as such if both fields are non-empty,
+                                            they must have the same value. For backwards
+                                            compatibility, both fields (DataSource
+                                            and DataSourceRef) will be set to the
+                                            same value automatically if one of them
+                                            is empty and the other is non-empty. There
+                                            are two important differences between
+                                            DataSource and DataSourceRef: * While
+                                            DataSource only allows two specific types
+                                            of objects, DataSourceRef   allows any
+                                            non-core object, as well as PersistentVolumeClaim
+                                            objects. * While DataSource ignores disallowed
+                                            values (dropping them), DataSourceRef   preserves
+                                            all values, and generates an error if
+                                            a disallowed value is   specified. (Alpha)
+                                            Using this field requires the AnyVolumeDataSource
+                                            feature gate to be enabled.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for
@@ -10408,7 +10617,7 @@ spec:
                                                   and null or empty namespaces list
                                                   means "this pod's namespace". An
                                                   empty selector ({}) matches all
-                                                  namespaces. This field is alpha-level
+                                                  namespaces. This field is beta-level
                                                   and is only honored when PodAffinityNamespaceSelector
                                                   feature is enabled.
                                                 properties:
@@ -10597,7 +10806,7 @@ spec:
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
-                                              This field is alpha-level and is only
+                                              This field is beta-level and is only
                                               honored when PodAffinityNamespaceSelector
                                               feature is enabled.
                                             properties:
@@ -10784,7 +10993,7 @@ spec:
                                                   and null or empty namespaces list
                                                   means "this pod's namespace". An
                                                   empty selector ({}) matches all
-                                                  namespaces. This field is alpha-level
+                                                  namespaces. This field is beta-level
                                                   and is only honored when PodAffinityNamespaceSelector
                                                   feature is enabled.
                                                 properties:
@@ -10973,7 +11182,7 @@ spec:
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
-                                              This field is alpha-level and is only
+                                              This field is beta-level and is only
                                               honored when PodAffinityNamespaceSelector
                                               feature is enabled.
                                             properties:
@@ -11319,6 +11528,20 @@ spec:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
                                     runAsUserName:
                                       description: The UserName in Windows to run
                                         the entrypoint of the container process. Defaults
@@ -11899,16 +12122,71 @@ spec:
                                                   to specify either: * An existing
                                                   VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                                   * An existing PVC (PersistentVolumeClaim)
-                                                  * An existing custom resource that
-                                                  implements data population (Alpha)
-                                                  In order to use custom resource
-                                                  types that implement data population,
+                                                  If the provisioner or an external
+                                                  controller can support the specified
+                                                  data source, it will create a new
+                                                  volume based on the contents of
+                                                  the specified data source. If the
+                                                  AnyVolumeDataSource feature gate
+                                                  is enabled, this field will always
+                                                  have the same contents as the DataSourceRef
+                                                  field.'
+                                                properties:
+                                                  apiGroup:
+                                                    description: APIGroup is the group
+                                                      for the resource being referenced.
+                                                      If APIGroup is not specified,
+                                                      the specified Kind must be in
+                                                      the core API group. For any
+                                                      other third-party types, APIGroup
+                                                      is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                              dataSourceRef:
+                                                description: 'Specifies the object
+                                                  from which to populate the volume
+                                                  with data, if a non-empty volume
+                                                  is desired. This may be any local
+                                                  object from a non-empty API group
+                                                  (non core object) or a PersistentVolumeClaim
+                                                  object. When this field is specified,
+                                                  volume binding will only succeed
+                                                  if the type of the specified object
+                                                  matches some installed volume populator
+                                                  or dynamic provisioner. This field
+                                                  will replace the functionality of
+                                                  the DataSource field and as such
+                                                  if both fields are non-empty, they
+                                                  must have the same value. For backwards
+                                                  compatibility, both fields (DataSource
+                                                  and DataSourceRef) will be set to
+                                                  the same value automatically if
+                                                  one of them is empty and the other
+                                                  is non-empty. There are two important
+                                                  differences between DataSource and
+                                                  DataSourceRef: * While DataSource
+                                                  only allows two specific types of
+                                                  objects, DataSourceRef   allows
+                                                  any non-core object, as well as
+                                                  PersistentVolumeClaim objects. *
+                                                  While DataSource ignores disallowed
+                                                  values (dropping them), DataSourceRef   preserves
+                                                  all values, and generates an error
+                                                  if a disallowed value is   specified.
+                                                  (Alpha) Using this field requires
                                                   the AnyVolumeDataSource feature
-                                                  gate must be enabled. If the provisioner
-                                                  or an external controller can support
-                                                  the specified data source, it will
-                                                  create a new volume based on the
-                                                  contents of the specified data source.'
+                                                  gate to be enabled.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -13277,14 +13555,58 @@ spec:
                                 dataSource:
                                   description: 'This field can be used to specify
                                     either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim) * An
-                                    existing custom resource that implements data
-                                    population (Alpha) In order to use custom resource
-                                    types that implement data population, the AnyVolumeDataSource
-                                    feature gate must be enabled. If the provisioner
-                                    or an external controller can support the specified
-                                    data source, it will create a new volume based
-                                    on the contents of the specified data source.'
+                                    * An existing PVC (PersistentVolumeClaim) If the
+                                    provisioner or an external controller can support
+                                    the specified data source, it will create a new
+                                    volume based on the contents of the specified
+                                    data source. If the AnyVolumeDataSource feature
+                                    gate is enabled, this field will always have the
+                                    same contents as the DataSourceRef field.'
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced. If APIGroup is not specified,
+                                        the specified Kind must be in the core API
+                                        group. For any other third-party types, APIGroup
+                                        is required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                dataSourceRef:
+                                  description: 'Specifies the object from which to
+                                    populate the volume with data, if a non-empty
+                                    volume is desired. This may be any local object
+                                    from a non-empty API group (non core object) or
+                                    a PersistentVolumeClaim object. When this field
+                                    is specified, volume binding will only succeed
+                                    if the type of the specified object matches some
+                                    installed volume populator or dynamic provisioner.
+                                    This field will replace the functionality of the
+                                    DataSource field and as such if both fields are
+                                    non-empty, they must have the same value. For
+                                    backwards compatibility, both fields (DataSource
+                                    and DataSourceRef) will be set to the same value
+                                    automatically if one of them is empty and the
+                                    other is non-empty. There are two important differences
+                                    between DataSource and DataSourceRef: * While
+                                    DataSource only allows two specific types of objects,
+                                    DataSourceRef   allows any non-core object, as
+                                    well as PersistentVolumeClaim objects. * While
+                                    DataSource ignores disallowed values (dropping
+                                    them), DataSourceRef   preserves all values, and
+                                    generates an error if a disallowed value is   specified.
+                                    (Alpha) Using this field requires the AnyVolumeDataSource
+                                    feature gate to be enabled.'
                                   properties:
                                     apiGroup:
                                       description: APIGroup is the group for the resource
@@ -13786,7 +14108,7 @@ spec:
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
                                         selector ({}) matches all namespaces. This
-                                        field is alpha-level and is only honored when
+                                        field is beta-level and is only honored when
                                         PodAffinityNamespaceSelector feature is enabled.
                                       properties:
                                         matchExpressions:
@@ -13948,7 +14270,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is alpha-level
+                                    ({}) matches all namespaces. This field is beta-level
                                     and is only honored when PodAffinityNamespaceSelector
                                     feature is enabled.
                                   properties:
@@ -14110,7 +14432,7 @@ spec:
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
                                         selector ({}) matches all namespaces. This
-                                        field is alpha-level and is only honored when
+                                        field is beta-level and is only honored when
                                         PodAffinityNamespaceSelector feature is enabled.
                                       properties:
                                         matchExpressions:
@@ -14272,7 +14594,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is alpha-level
+                                    ({}) matches all namespaces. This field is beta-level
                                     and is only honored when PodAffinityNamespaceSelector
                                     feature is enabled.
                                   properties:
@@ -14365,11 +14687,12 @@ spec:
                             CMD is used if this is not provided. Variable references
                             $(VAR_NAME) are expanded using the container''s environment.
                             If a variable cannot be resolved, the reference in the
-                            input string will be unchanged. The $(VAR_NAME) syntax
-                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                            references will never be expanded, regardless of whether
-                            the variable exists or not. Cannot be updated. More info:
-                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
@@ -14379,10 +14702,12 @@ spec:
                             provided. Variable references $(VAR_NAME) are expanded
                             using the container''s environment. If a variable cannot
                             be resolved, the reference in the input string will be
-                            unchanged. The $(VAR_NAME) syntax can be escaped with
-                            a double $$, ie: $$(VAR_NAME). Escaped references will
-                            never be expanded, regardless of whether the variable
-                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
@@ -14399,14 +14724,16 @@ spec:
                                 type: string
                               value:
                                 description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
+                                  expanded using the previously defined environment
                                   variables in the container and any service environment
                                   variables. If a variable cannot be resolved, the
                                   reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
                                 type: string
                               valueFrom:
                                 description: Source for the environment variable's
@@ -14876,8 +15203,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -15066,8 +15394,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -15106,8 +15435,9 @@ spec:
                               type: object
                           type: object
                         securityContext:
-                          description: 'Security options the pod should run with.
-                            More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                          description: 'SecurityContext defines the security options
+                            the container should be run with. If set, the fields of
+                            SecurityContext override the equivalent fields of PodSecurityContext.
                             More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                           properties:
                             allowPrivilegeEscalation:
@@ -15247,6 +15577,19 @@ spec:
                                   description: GMSACredentialSpecName is the name
                                     of the GMSA credential spec to use.
                                   type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
                                 runAsUserName:
                                   description: The UserName in Windows to run the
                                     entrypoint of the container process. Defaults
@@ -15387,8 +15730,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -15589,11 +15933,12 @@ spec:
                             CMD is used if this is not provided. Variable references
                             $(VAR_NAME) are expanded using the container''s environment.
                             If a variable cannot be resolved, the reference in the
-                            input string will be unchanged. The $(VAR_NAME) syntax
-                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                            references will never be expanded, regardless of whether
-                            the variable exists or not. Cannot be updated. More info:
-                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
@@ -15603,10 +15948,12 @@ spec:
                             provided. Variable references $(VAR_NAME) are expanded
                             using the container''s environment. If a variable cannot
                             be resolved, the reference in the input string will be
-                            unchanged. The $(VAR_NAME) syntax can be escaped with
-                            a double $$, ie: $$(VAR_NAME). Escaped references will
-                            never be expanded, regardless of whether the variable
-                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
@@ -15623,14 +15970,16 @@ spec:
                                 type: string
                               value:
                                 description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
+                                  expanded using the previously defined environment
                                   variables in the container and any service environment
                                   variables. If a variable cannot be resolved, the
                                   reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
                                 type: string
                               valueFrom:
                                 description: Source for the environment variable's
@@ -16094,8 +16443,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -16271,8 +16621,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -16312,8 +16663,10 @@ spec:
                               type: object
                           type: object
                         securityContext:
-                          description: SecurityContext is not allowed for ephemeral
-                            containers.
+                          description: 'Optional: SecurityContext defines the security
+                            options the ephemeral container should be run with. If
+                            set, the fields of SecurityContext override the equivalent
+                            fields of PodSecurityContext.'
                           properties:
                             allowPrivilegeEscalation:
                               description: 'AllowPrivilegeEscalation controls whether
@@ -16452,6 +16805,19 @@ spec:
                                   description: GMSACredentialSpecName is the name
                                     of the GMSA credential spec to use.
                                   type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
                                 runAsUserName:
                                   description: The UserName in Windows to run the
                                     entrypoint of the container process. Defaults
@@ -16584,8 +16950,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -16793,11 +17160,12 @@ spec:
                             CMD is used if this is not provided. Variable references
                             $(VAR_NAME) are expanded using the container''s environment.
                             If a variable cannot be resolved, the reference in the
-                            input string will be unchanged. The $(VAR_NAME) syntax
-                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                            references will never be expanded, regardless of whether
-                            the variable exists or not. Cannot be updated. More info:
-                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
@@ -16807,10 +17175,12 @@ spec:
                             provided. Variable references $(VAR_NAME) are expanded
                             using the container''s environment. If a variable cannot
                             be resolved, the reference in the input string will be
-                            unchanged. The $(VAR_NAME) syntax can be escaped with
-                            a double $$, ie: $$(VAR_NAME). Escaped references will
-                            never be expanded, regardless of whether the variable
-                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
@@ -16827,14 +17197,16 @@ spec:
                                 type: string
                               value:
                                 description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
+                                  expanded using the previously defined environment
                                   variables in the container and any service environment
                                   variables. If a variable cannot be resolved, the
                                   reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
                                 type: string
                               valueFrom:
                                 description: Source for the environment variable's
@@ -17304,8 +17676,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -17494,8 +17867,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -17534,8 +17908,9 @@ spec:
                               type: object
                           type: object
                         securityContext:
-                          description: 'Security options the pod should run with.
-                            More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                          description: 'SecurityContext defines the security options
+                            the container should be run with. If set, the fields of
+                            SecurityContext override the equivalent fields of PodSecurityContext.
                             More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                           properties:
                             allowPrivilegeEscalation:
@@ -17675,6 +18050,19 @@ spec:
                                   description: GMSACredentialSpecName is the name
                                     of the GMSA credential spec to use.
                                   type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
                                 runAsUserName:
                                   description: The UserName in Windows to run the
                                     entrypoint of the container process. Defaults
@@ -17815,8 +18203,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -17954,6 +18343,7 @@ spec:
                       labels for the pod to be scheduled on that node. More info:
                       https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                     type: object
+                    x-kubernetes-map-type: atomic
                   overhead:
                     additionalProperties:
                       anyOf:
@@ -17970,8 +18360,8 @@ spec:
                       the overhead already set. If RuntimeClass is configured and
                       selected in the PodSpec, Overhead will be set to the value defined
                       in the corresponding RuntimeClass, otherwise it will remain
-                      unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
-                      This field is alpha-level as of Kubernetes v1.16, and is only
+                      unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+                      This field is beta-level as of Kubernetes v1.18, and is only
                       honored by servers that enable the PodOverhead feature.'
                     type: object
                   preemptionPolicy:
@@ -18000,7 +18390,7 @@ spec:
                     description: 'If specified, all readiness gates will be evaluated
                       for pod readiness. A pod is ready when all its containers are
                       ready AND all conditions specified in the readiness gates have
-                      status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                      status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
                     items:
                       description: PodReadinessGate contains the reference to a pod
                         condition
@@ -18024,7 +18414,7 @@ spec:
                       no RuntimeClass resource matches the named class, the pod will
                       not be run. If unset or empty, the "legacy" RuntimeClass will
                       be used, which is an implicit class with an empty definition
-                      that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+                      that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
                       This is a beta feature as of Kubernetes v1.14.'
                     type: string
                   schedulerName:
@@ -18171,6 +18561,18 @@ spec:
                             description: GMSACredentialSpecName is the name of the
                               GMSA credential spec to use.
                             type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. This field is
+                              alpha-level and will only be honored by components that
+                              enable the WindowsHostProcessContainers feature flag.
+                              Setting this field without the feature flag will result
+                              in errors when validating the Pod. All of a Pod's containers
+                              must have the same effective HostProcess value (it is
+                              not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).  In addition, if HostProcess
+                              is true then HostNetwork must also be set to true.
+                            type: boolean
                           runAsUserName:
                             description: The UserName in Windows to run the entrypoint
                               of the container process. Defaults to the user specified
@@ -18840,15 +19242,61 @@ spec:
                                       description: 'This field can be used to specify
                                         either: * An existing VolumeSnapshot object
                                         (snapshot.storage.k8s.io/VolumeSnapshot) *
-                                        An existing PVC (PersistentVolumeClaim) *
-                                        An existing custom resource that implements
-                                        data population (Alpha) In order to use custom
-                                        resource types that implement data population,
-                                        the AnyVolumeDataSource feature gate must
-                                        be enabled. If the provisioner or an external
-                                        controller can support the specified data
-                                        source, it will create a new volume based
-                                        on the contents of the specified data source.'
+                                        An existing PVC (PersistentVolumeClaim) If
+                                        the provisioner or an external controller
+                                        can support the specified data source, it
+                                        will create a new volume based on the contents
+                                        of the specified data source. If the AnyVolumeDataSource
+                                        feature gate is enabled, this field will always
+                                        have the same contents as the DataSourceRef
+                                        field.'
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced. If APIGroup
+                                            is not specified, the specified Kind must
+                                            be in the core API group. For any other
+                                            third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    dataSourceRef:
+                                      description: 'Specifies the object from which
+                                        to populate the volume with data, if a non-empty
+                                        volume is desired. This may be any local object
+                                        from a non-empty API group (non core object)
+                                        or a PersistentVolumeClaim object. When this
+                                        field is specified, volume binding will only
+                                        succeed if the type of the specified object
+                                        matches some installed volume populator or
+                                        dynamic provisioner. This field will replace
+                                        the functionality of the DataSource field
+                                        and as such if both fields are non-empty,
+                                        they must have the same value. For backwards
+                                        compatibility, both fields (DataSource and
+                                        DataSourceRef) will be set to the same value
+                                        automatically if one of them is empty and
+                                        the other is non-empty. There are two important
+                                        differences between DataSource and DataSourceRef:
+                                        * While DataSource only allows two specific
+                                        types of objects, DataSourceRef   allows any
+                                        non-core object, as well as PersistentVolumeClaim
+                                        objects. * While DataSource ignores disallowed
+                                        values (dropping them), DataSourceRef   preserves
+                                        all values, and generates an error if a disallowed
+                                        value is   specified. (Alpha) Using this field
+                                        requires the AnyVolumeDataSource feature gate
+                                        to be enabled.'
                                       properties:
                                         apiGroup:
                                           description: APIGroup is the group for the

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
         - name: sinker
-          image: gcr.io/k8s-prow/sinker:v20211229-d20cd1c87e
+          image: gcr.io/k8s-prow/sinker:v20220201-d251d8b00d
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20211229-d20cd1c87e
+          image: gcr.io/k8s-prow/status-reconciler:v20220201-d251d8b00d
           args:
             - --dry-run=false
             - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: gcr.io/k8s-prow/tide:v20211229-d20cd1c87e
+          image: gcr.io/k8s-prow/tide:v20220201-d251d8b00d
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -70,10 +70,10 @@ plank:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
       utility_images:
-        clonerefs: quay.io/powercloud/clonerefs:v20211229-d20cd1c87e
-        entrypoint: quay.io/powercloud/entrypoint:v20211229-d20cd1c87e
-        initupload: quay.io/powercloud/initupload:v20211229-d20cd1c87e
-        sidecar: quay.io/powercloud/sidecar:v20211229-d20cd1c87e
+        clonerefs: quay.io/powercloud/clonerefs:v20220201-d251d8b00d
+        entrypoint: quay.io/powercloud/entrypoint:v20220201-d251d8b00d
+        initupload: quay.io/powercloud/initupload:v20220201-d251d8b00d
+        sidecar: quay.io/powercloud/sidecar:v20220201-d251d8b00d
       ssh_key_secrets:
         - bot-ssh-secret
 


### PR DESCRIPTION
Following are the changes that need to be added to our prow specs as part of upgrade to v20220201-d251d8b00d:

https://github.com/kubernetes/test-infra/pull/25010 - Verify-codegen includes prowjob CRD
https://github.com/kubernetes/test-infra/pull/25019 - Add preserveUnknowFields: false in prowjob schema CRD
https://github.com/kubernetes/test-infra/pull/25037 - Upgrade ingresses to networking.k8s.io/v1

These changes are yet to be applied on IKS.