### PR TITLE
Change build.sh path in postsubmit-master-golang-etcd-build-test-ppc64le job

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
@@ -32,5 +32,5 @@ postsubmits:
                 export PATH=/usr/local/go/bin:$PATH
                 export PATH=$GOPATH/bin:$PATH
                 go version
-                ./build.sh
+                ./scripts/build.sh
                 GOARCH=`go env GOARCH` TEST_OPTS="PASSES='unit integration_e2e'" make test


### PR DESCRIPTION
After the below change in upstream etcd repo, the path of build.sh is moved into the scripts folder.
https://github.com/etcd-io/etcd/pull/13649
Thus the `postsubmit-master-golang-etcd-build-test-ppc64le` job started failing with below error:
```
+ PATH=/home/prow/go/bin:/usr/local/go/bin:/google-cloud-sdk/bin:/workspace:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ go version
go version devel go1.18-f14ad78e84 Sat Feb 12 05:44:16 2022 +0000 linux/ppc64le
+ ./build.sh
/bin/bash: line 13: ./build.sh: No such file or directory
```
Reference job: https://prow.ppc64le-cloud.org/view/s3/prow-logs/logs/postsubmit-master-golang-etcd-build-test-ppc64le/1492375461605412864