### PR TITLE
Add Docker build jobs

### DIFF
--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-build-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-build-docker.yaml
@@ -1,0 +1,281 @@
+postsubmits:
+ ppc64le-cloud/docker-ce-build:
+    - name: postsubmit-build-docker
+      cluster: k8s-ppc64le-cluster
+      decorate: true
+      decoration_config:
+        timeout: 3h
+      branches:
+          - main
+      run_if_changed: 'env/env.list'
+      reporter_config:
+        slack:
+          channel: 'prow-job-notifications'
+          job_states_to_report:
+           - success
+           - failure
+           - error
+          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
+      spec:
+        nodeSelector:
+          dedicated: runtimesTeam
+        tolerations:
+        - key: dedicated
+          operator: "Equal"
+          value: runtimesTeam
+          effect: "NoSchedule"
+        containers:
+        - image: quay.io/powercloud/docker-ce-build
+          command:
+          - /bin/bash
+          args:
+          - -c
+          - |
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+            set -o xtrace
+
+            # Set the SSH key for git from the secret 'git-ssh-docker-ce-build'
+            echo "* Set up the ssh key for git *"
+            mkdir -p ~/.ssh
+            cp /etc/ssh-key/ssh-privatekey  ~/.ssh/id_rsa
+            chmod 600 ~/.ssh/id_rsa
+            ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+
+            echo "* Start prow-build-docker *"
+            ./prow-build-docker.sh
+            rc=$?
+            [ $rc != 0 ] && echo "ERROR: prow-build-docker exited with code:$rc"
+            exit $rc
+
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: docker-root
+            mountPath: /var/lib/docker
+          - name: ssh-key
+            readOnly: true
+            mountPath: /etc/ssh-key
+          env:
+            - name: S3_SECRET_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: docker-s3-credentials
+                  key: password
+        volumes:
+        - name: docker-root
+          emptyDir: {}
+        - name: ssh-key
+          secret:
+           secretName: git-ssh-docker-ce-build
+
+    - name: postsubmit-build-containerd
+      cluster: k8s-ppc64le-cluster
+      decorate: true
+      decoration_config:
+        timeout: 3h
+      run_if_changed: 'job/postsubmit-build-docker'
+      branches:
+        - prow-job-tracking
+      reporter_config:
+        slack:
+          channel: 'prow-job-notifications'
+          job_states_to_report:
+           - success
+           - failure
+           - error
+          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
+      spec:
+        nodeSelector:
+          dedicated: runtimesTeam
+        tolerations:
+        - key: dedicated
+          operator: "Equal"
+          value: runtimesTeam
+          effect: "NoSchedule"
+        containers:
+        - image: quay.io/powercloud/docker-ce-build
+          command:
+          - /bin/bash
+          args:
+          - -c
+          - |
+            ##
+            # This job is populated with the files from the 'prow-job-tracking' branch.
+            # We switch to the 'main' branch, as it contains the scripts used by this job.
+            ###
+
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+            set -o xtrace
+
+            #Set this to your dev branch for testing
+            WORK_BRANCH=main
+
+            #Timestamp file from the tracking branch (required to access the proper s3 directory)
+            TIMESTAMP_FILE=postsubmit-build-docker
+
+            echo "* Setup the files from git *"
+
+            echo "* Backup timestamp file from the previous job *"
+            cp job/${TIMESTAMP_FILE} /tmp
+
+            echo "* Switch back to the git branch: ${REPO_OWNER}/${REPO_NAME}/${WORK_BRANCH} *"
+            git fetch https://github.com/${REPO_OWNER}/${REPO_NAME} ${WORK_BRANCH}
+            git branch --force ${WORK_BRANCH} FETCH_HEAD
+            git checkout ${WORK_BRANCH}
+
+            echo "* Restore back to the time stamp file from the tracking branch *"
+            cp /tmp/${TIMESTAMP_FILE} env/date.list
+            cat env/date.list
+
+            echo "* Start prow-build-containerd *"
+            ./prow-build-containerd.sh
+            rc=$?
+            [ $rc != 0 ] && echo "ERROR: prow-build-containerd exited with code:$rc"
+            exit $rc
+
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: docker-root
+            mountPath: /var/lib/docker
+          env:
+            - name: S3_SECRET_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: docker-s3-credentials
+                  key: password
+        volumes:
+        - name: docker-root
+          emptyDir: {}
+
+    - name: postsubmit-test-docker-staging
+      cluster: k8s-ppc64le-cluster
+      decorate: true
+      run_if_changed: 'env/test-staging.list'
+      branches:
+        - main
+      reporter_config:
+        slack:
+          channel: 'prow-job-notifications'
+          job_states_to_report:
+           - success
+           - failure
+           - error
+          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
+      spec:
+        nodeSelector:
+          dedicated: runtimesTeam
+        tolerations:
+        - key: dedicated
+          operator: "Equal"
+          value: runtimesTeam
+          effect: "NoSchedule"
+        containers:
+        - image: quay.io/powercloud/docker-ce-build
+          command:
+          - /bin/bash
+          args:
+          - -c
+          - |
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+            set -o xtrace
+
+            #Timestamp file from the tracking branch (required to access the proper s3 directory)
+            TIMESTAMP_FILE=postsubmit-build-docker
+
+            FILE_URL="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/prow-job-tracking/job/${TIMESTAMP_FILE}"
+
+            echo "* Retrieve the timestamp file from the tracking branch: ${FILE_URL} *"
+            wget -O env/date.list ${FILE_URL}
+            cat env/date.list
+
+            echo "* Start prow-test-docker.sh *"
+            ./prow-test-docker.sh staging
+            rc=$?
+            [ $rc != 0 ] && echo "ERROR: prow-test-docker exited with code:$rc"
+            exit $rc
+
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: docker-root
+            mountPath: /var/lib/docker
+          env:
+            - name: S3_SECRET_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: docker-s3-credentials
+                  key: password
+        volumes:
+        - name: docker-root
+          emptyDir: {}
+
+    - name: postsubmit-test-docker-release
+      cluster: k8s-ppc64le-cluster
+      decorate: true
+      run_if_changed: 'env/test-release.list'
+      branches:
+        - main
+      reporter_config:
+        slack:
+          channel: 'prow-job-notifications'
+          job_states_to_report:
+           - success
+           - failure
+           - error
+          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
+      spec:
+        nodeSelector:
+          dedicated: runtimesTeam
+        tolerations:
+        - key: dedicated
+          operator: "Equal"
+          value: runtimesTeam
+          effect: "NoSchedule"
+        containers:
+        - image: quay.io/powercloud/docker-ce-build
+          command:
+          - /bin/bash
+          args:
+          - -c
+          - |
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+            set -o xtrace
+
+            #Timestamp file from the tracking branch (required to access the proper s3 directory)
+            TIMESTAMP_FILE=postsubmit-build-docker
+
+            FILE_URL="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/prow-job-tracking/job/${TIMESTAMP_FILE}"
+
+            echo "* Retrieve the timestamp file from the tracking branch: ${FILE_URL} *"
+            wget -O env/date.list ${FILE_URL}
+            cat env/date.list
+
+            echo "* Start prow-test-docker.sh *"
+            ./prow-test-docker.sh release
+            rc=$?
+            [ $rc != 0 ] && echo "ERROR: prow-test-docker exited with code:$rc"
+            exit $rc
+
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: docker-root
+            mountPath: /var/lib/docker
+          env:
+            - name: S3_SECRET_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: docker-s3-credentials
+                  key: password
+        volumes:
+        - name: docker-root
+          emptyDir: {}

--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
@@ -1,79 +1,11 @@
 postsubmits:
  ppc64le-cloud/docker-ce-build:
-    - name: postsubmit-build-docker
+    - name: postsubmit-test-docker-staging
       cluster: k8s-ppc64le-cluster
       decorate: true
-      decoration_config:
-        timeout: 3h
+      run_if_changed: 'env/test-staging.list'
       branches:
-          - main
-      run_if_changed: 'env/env.list'
-      reporter_config:
-        slack:
-          channel: 'prow-job-notifications'
-          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
-      spec:
-        nodeSelector:
-          dedicated: runtimesTeam
-        tolerations:
-        - key: dedicated
-          operator: "Equal"
-          value: runtimesTeam
-          effect: "NoSchedule"
-        containers:
-        - image: quay.io/powercloud/docker-ce-build
-          command:
-          - /bin/bash
-          args:
-          - -c
-          - |
-            set -o errexit
-            set -o nounset
-            set -o pipefail
-            set -o xtrace
-
-            # Set the SSH key for git from the secret 'git-ssh-docker-ce-build'
-            echo "* Set up the ssh key for git *"
-            mkdir -p ~/.ssh
-            cp /etc/ssh-key/ssh-privatekey  ~/.ssh/id_rsa
-            chmod 600 ~/.ssh/id_rsa
-            ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
-
-            echo "* Start prow-build-docker *"
-            ./prow-build-docker.sh
-            rc=$?
-            [ $rc != 0 ] && echo "ERROR: prow-build-docker exited with code:$rc"
-            exit $rc
-
-          securityContext:
-            privileged: true
-          volumeMounts:
-          - name: docker-root
-            mountPath: /var/lib/docker
-          - name: ssh-key
-            readOnly: true
-            mountPath: /etc/ssh-key
-          env:
-            - name: S3_SECRET_AUTH
-              valueFrom:
-                secretKeyRef:
-                  name: docker-s3-credentials
-                  key: password
-        volumes:
-        - name: docker-root
-          emptyDir: {}
-        - name: ssh-key
-          secret:
-           secretName: git-ssh-docker-ce-build
-
-    - name: postsubmit-build-test-containerd
-      cluster: k8s-ppc64le-cluster
-      decorate: true
-      decoration_config:
-        timeout: 3h
-      run_if_changed: 'job/postsubmit-build-docker'
-      branches:
-        - prow-job-tracking
+        - main
       reporter_config:
         slack:
           channel: 'prow-job-notifications'
@@ -97,40 +29,88 @@ postsubmits:
           args:
           - -c
           - |
-            ##
-            # This job is populated with the files from the 'prow-job-tracking' branch.
-            # We switch to the 'main' branch, as it contains the scripts used by this job.
-            ###
-
             set -o errexit
             set -o nounset
             set -o pipefail
             set -o xtrace
 
-            #Set this to your dev branch for testing
-            WORK_BRANCH=main
+            #Timestamp file from the tracking branch (required to access the proper s3 directory)
+            TIMESTAMP_FILE=postsubmit-build-docker
+
+            FILE_URL="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/prow-job-tracking/job/${TIMESTAMP_FILE}"
+
+            echo "* Retrieve the timestamp file from the tracking branch: ${FILE_URL} *"
+            wget -O env/date.list ${FILE_URL}
+            cat env/date.list
+
+            echo "* Start prow-test-docker.sh *"
+            ./prow-test-docker.sh staging
+            rc=$?
+            [ $rc != 0 ] && echo "ERROR: prow-test-docker exited with code:$rc"
+            exit $rc
+
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: docker-root
+            mountPath: /var/lib/docker
+          env:
+            - name: S3_SECRET_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: docker-s3-credentials
+                  key: password
+        volumes:
+        - name: docker-root
+          emptyDir: {}
+
+    - name: postsubmit-test-docker-release
+      cluster: k8s-ppc64le-cluster
+      decorate: true
+      run_if_changed: 'env/test-release.list'
+      branches:
+        - main
+      reporter_config:
+        slack:
+          channel: 'prow-job-notifications'
+          job_states_to_report:
+           - success
+           - failure
+           - error
+          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
+      spec:
+        nodeSelector:
+          dedicated: runtimesTeam
+        tolerations:
+        - key: dedicated
+          operator: "Equal"
+          value: runtimesTeam
+          effect: "NoSchedule"
+        containers:
+        - image: quay.io/powercloud/docker-ce-build
+          command:
+          - /bin/bash
+          args:
+          - -c
+          - |
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+            set -o xtrace
 
             #Timestamp file from the tracking branch (required to access the proper s3 directory)
             TIMESTAMP_FILE=postsubmit-build-docker
 
-            echo "* Setup the files from git *"
+            FILE_URL="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/prow-job-tracking/job/${TIMESTAMP_FILE}"
 
-            echo "* Backup timestamp file from the previous job *"
-            cp job/${TIMESTAMP_FILE} /tmp
-
-            echo "* Switch back to the git branch: ${REPO_OWNER}/${REPO_NAME}/${WORK_BRANCH} *"
-            git fetch https://github.com/${REPO_OWNER}/${REPO_NAME} ${WORK_BRANCH}
-            git branch --force ${WORK_BRANCH} FETCH_HEAD
-            git checkout ${WORK_BRANCH}
-
-            echo "* Restore back to the time stamp file from the tracking branch *"
-            cp /tmp/${TIMESTAMP_FILE} env/date.list
+            echo "* Retrieve the timestamp file from the tracking branch: ${FILE_URL} *"
+            wget -O env/date.list ${FILE_URL}
             cat env/date.list
 
-            echo "* Start prow-build-test-containerd *"
-            ./prow-build-test-containerd.sh
+            echo "* Start prow-test-docker.sh *"
+            ./prow-test-docker.sh release
             rc=$?
-            [ $rc != 0 ] && echo "ERROR: prow-build-test-containerd exited with code:$rc"
+            [ $rc != 0 ] && echo "ERROR: prow-test-docker exited with code:$rc"
             exit $rc
 
           securityContext:


### PR DESCRIPTION
Add 4 jobs for building Docker and containerd:
- postsubmit-build-docker, build docker packages and trigger postsubmit-build-containerd 
- postsubmit-build-containerd, build containerd and run the validation tests
- postsubmit-test-docker-staging, test the packages from the docker's staging repo
- postsubmit-test-docker-release, test the packages from the docker's release repo