### PR TITLE
Move the capi ibmcloud e2e job logs to GCS and enable Artifacts link

### DIFF
--- a/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
+++ b/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
@@ -4,6 +4,11 @@ periodics:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    decoration_config:
+      gcs_configuration:
+        bucket: ppc64le-kubernetes
+        path_strategy: explicit
+      gcs_credentials_secret: gcs-credentials
     interval: 3h
     extra_refs:
       - base_ref: main

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -20,6 +20,7 @@ in_repo_config:
 
 deck:
   spyglass:
+    gcs_browser_prefix: https://gcsweb.k8s.io/gcs/
     lenses:
       - lens:
           name: metadata


### PR DESCRIPTION
Have deployed configmap with this change in IKS cluster and able to view Artifacts through the link for already existing jobs in GCS.

But the jobs that have logs in IBM S3 thought have a `Artifacts` link displayed in UI, it would direct to an invalid path as below:

![image](https://user-images.githubusercontent.com/63038004/161055984-73d2bec1-1962-4fd1-8526-d01c35721fb2.png)

