### PR TITLE
Use latest Terraform version for powervs jobs

### DIFF
--- a/config/jobs/ocp-automation/ocp4-upi-powervs/ocp4-upi-powervs-presubmit.yaml
+++ b/config/jobs/ocp-automation/ocp4-upi-powervs/ocp4-upi-powervs-presubmit.yaml
@@ -5,7 +5,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: hashicorp/terraform:0.13.5
+          - image: hashicorp/terraform
             command:
               - sh
             args:
@@ -22,7 +22,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: hashicorp/terraform:0.13.5
+          - image: hashicorp/terraform
             command:
               - sh
             args:


### PR DESCRIPTION
As we are using the latest Terraform binary now with https://github.com/ocp-power-automation/ocp4-upi-powervs/ the pre-submit job needs to updated to use the latest Terraform image for validate and fmt checks.

Signed-off-by: Yussuf Shaikh <yussuf@us.ibm.com>