### PR TITLE
 Upgrade all-in-one image for periodic-gcs-logs-cleanup job 

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-gcs-logs-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-gcs-logs-periodics.yaml
@@ -8,7 +8,7 @@ periodics:
           secret:
             secretName: gcs-credentials
       containers:
-        - image: quay.io/powercloud/all-in-one:0.1
+        - image: quay.io/powercloud/all-in-one:0.4
           command:
             - /bin/bash
           volumeMounts:
@@ -22,7 +22,7 @@ periodics:
               set -o nounset
               set -o pipefail
               set -o xtrace
-              go get  github.com/ppc64le-cloud/gcs-cleaner
+              go install github.com/ppc64le-cloud/gcs-cleaner@latest
               cat >config.yml <<EOL
               - dir: logs/periodic-kubernetes-unit-test-ppc64le
                 daysLimit: 15


### PR DESCRIPTION
`periodic-gcs-logs-cleanup` job still fails https://prow.ppc64le-cloud.org/view/s3/prow-logs/logs/periodic-gcs-logs-cleanup/1511401533537783808 even after the change https://github.com/ppc64le-cloud/gcs-cleaner/pull/5

`GO111MODULE=on` fixes it. https://prow.ppc64le-cloud.org/view/s3/prow-logs/logs/periodic-gcs-logs-cleanup/1511410294776139776
