### PR TITLE
Add slack notification to containerd test

### DIFF
--- a/config/jobs/periodic/containerd/test-containerd-periodics.yaml
+++ b/config/jobs/periodic/containerd/test-containerd-periodics.yaml
@@ -3,6 +3,10 @@ periodics:
     cluster: k8s-ppc64le-cluster
     decorate: true
     interval: 24h
+    reporter_config:
+        slack:
+          channel: 'prow-job-notifications'
+          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
     extra_refs:
       - base_ref: main
         org: containerd


### PR DESCRIPTION
This PR adds slack notification if the containerd test CI fails.

Tested here: https://prow.ppc64le-cloud.org/view/s3/prow-logs/logs/periodic-containerd-test-ppc64le/1512363267522039808 .