### PR TITLE
Change centos image name to skip the GET image error

### DIFF
--- a/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
@@ -61,7 +61,7 @@ periodics:
         chmod +x /usr/local/bin/kubectl
 
         kubetest2 tf --powervs-dns k8s-tests \
-          --powervs-image-name centos-8-stream-20gb \
+          --powervs-image-name centos8-stream-20GB \
           --powervs-region lon --powervs-zone lon04 \
           --powervs-service-id f57510e4-7109-45ab-9dbb-a9fd38529707 \
           --powervs-ssh-key powercloud-bot-key \
@@ -140,7 +140,7 @@ periodics:
         chmod +x /usr/local/bin/kubectl
 
         kubetest2 tf --powervs-dns k8s-tests \
-          --powervs-image-name centos-8-stream-20gb \
+          --powervs-image-name centos8-stream-20GB \
           --powervs-region lon --powervs-zone lon04 \
           --powervs-service-id f57510e4-7109-45ab-9dbb-a9fd38529707 \
           --powervs-ssh-key powercloud-bot-key \

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -95,7 +95,7 @@ periodics:
               chmod +x /usr/local/bin/kubectl
 
               kubetest2 tf --powervs-dns k8s-tests \
-                --powervs-image-name centos-8-stream-20gb \
+                --powervs-image-name centos8-stream-20GB \
                 --powervs-region lon --powervs-zone lon04 \
                 --powervs-service-id f57510e4-7109-45ab-9dbb-a9fd38529707 \
                 --powervs-ssh-key powercloud-bot-key \

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -144,7 +144,7 @@ postsubmits:
                 wget -qO- $URL/kubernetes-client-linux-ppc64le.tar.gz | tar xz -C /usr/local/bin --strip-components=3
 
                 kubetest2 tf --powervs-dns k8s-tests \
-                    --powervs-image-name centos-8-stream-20gb \
+                    --powervs-image-name centos8-stream-20GB \
                     --powervs-region lon --powervs-zone lon04 \
                     --powervs-service-id f57510e4-7109-45ab-9dbb-a9fd38529707 \
                     --powervs-ssh-key powercloud-bot-key \


### PR DESCRIPTION
To avoid below error with prow jobs:
```
failed to perform Get Image Operation for image centos-8-stream-20gb with error [GET /pcloud/v1/cloud-instances/{cloud_instance_id}/images/{image_id}][500] pcloudCloudinstancesImagesGetInternalServerError  &{Code:0 Description:an error has occurred; please try again: unable to get image 37091d0f-a4f6-42d8-8cb5-8d71b34307c6: Unable to get Image 37091d0f-a4f6-42d8-8cb5-8d71b34307c6: Resource not found: [GET https://192.168.24.137:9292/v2/images/37091d0f-a4f6-42d8-8cb5-8d71b34307c6], error message: {"message": "No image found with ID 37091d0f-a4f6-42d8-8cb5-8d71b34307c6<br /><br />\n\n\n", "code": "404 Not Found", "title": "Not Found"} Error:internal server error Message:}[0m
```