### PR TITLE
Add --fail flag to curl command in periodic-golang-master-build-ppc64le job

### DIFF
--- a/config/jobs/periodic/golang/build-golang-periodics.yaml
+++ b/config/jobs/periodic/golang/build-golang-periodics.yaml
@@ -26,7 +26,7 @@ periodics:
                 ./make.bash
                 cd ../..;rm -rf go/.git
                 tar -czvf go.tar.gz go
-                curl -v -X POST http://build-bot.prow:8090/build -H 'Content-Type: multipart/form-data' -F file=@go.tar.gz -F source=github.com/golang/go.git -F commit=$GITCOMMIT -F project=golang/master
+                curl -v -X POST http://build-bot.prow:8090/build --fail -H 'Content-Type: multipart/form-data' -F file=@go.tar.gz -F source=github.com/golang/go.git -F commit=$GITCOMMIT -F project=golang/master
               else
                 echo "$GITCOMMIT build already exist, hence skipping it"
               fi


### PR DESCRIPTION
Task : https://github.ibm.com/powercloud/container-dev/issues/1524

As mentioned in the above task, even when `build-bot` throws an error for the POST call, the job is passing 
https://prow.ppc64le-cloud.org/view/s3/prow-logs/logs/periodic-golang-master-build-ppc64le/1516269899868016640

Pass of `--fail` flag to curl command enables failure on server errors.
https://prow.ppc64le-cloud.org/view/s3/prow-logs/logs/periodic-golang-master-build-ppc64le/1516274352675360768 is the run when job failed with --fail flag when there is HTTP 500 response.