### PR TITLE
Update ingress specs

### DIFF
--- a/config/prow/cluster/cisearch_ingress.yaml
+++ b/config/prow/cluster/cisearch_ingress.yaml
@@ -4,9 +4,6 @@ metadata:
   namespace: prow
   name: ci-search
   annotations:
-    # Change this to your issuer when using cert-manager. Does
-    # nothing when not using cert-manager.
-    cert-manager.io/cluster-issuer: letsencrypt-staging
     kubernetes.io/ingress.class: public-iks-k8s-nginx
 spec:
   rules:

--- a/config/prow/cluster/deck_ingress.yaml
+++ b/config/prow/cluster/deck_ingress.yaml
@@ -5,9 +5,6 @@ metadata:
   namespace: prow
   name: deck
   annotations:
-    # Change this to your issuer when using cert-manager. Does
-    # nothing when not using cert-manager.
-    cert-manager.io/cluster-issuer: letsencrypt-staging
     kubernetes.io/ingress.class: public-iks-k8s-nginx
 spec:
   defaultBackend:

--- a/config/prow/cluster/hook_ingress.yaml
+++ b/config/prow/cluster/hook_ingress.yaml
@@ -5,9 +5,6 @@ metadata:
   namespace: prow
   name: hook
   annotations:
-    # Change this to your issuer when using cert-manager. Does
-    # nothing when not using cert-manager.
-    cert-manager.io/cluster-issuer: letsencrypt-staging
     kubernetes.io/ingress.class: public-iks-k8s-nginx
     nginx.ingress.kubernetes.io/rewrite-target: /hook
 spec:

--- a/config/prow/grafana-dashboard/grafana_ingress.yaml
+++ b/config/prow/grafana-dashboard/grafana_ingress.yaml
@@ -4,9 +4,6 @@ metadata:
   namespace: grafana-dashboard
   name: grafana
   annotations:
-    # Change this to your issuer when using cert-manager. Does
-    # nothing when not using cert-manager.
-    cert-manager.io/cluster-issuer: letsencrypt-staging
     kubernetes.io/ingress.class: public-iks-k8s-nginx
 spec:
   rules:

--- a/config/prow/perfdash/perfdash-ingress.yaml
+++ b/config/prow/perfdash/perfdash-ingress.yaml
@@ -1,26 +1,22 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: perfdash
   name: perfdash
   annotations:
-    # Change this to your issuer when using cert-manager. Does
-    # nothing when not using cert-manager.
-    cert-manager.io/cluster-issuer: letsencrypt-staging
     kubernetes.io/ingress.class: public-iks-k8s-nginx
 spec:
-  backend:
-    # specify the default backend for `ingress-gce` (https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#prow_backend)
-    serviceName: perfdash-status
-    servicePort: status
   rules:
     - host: perfdash.ppc64le-cloud.org
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: perfdash-status
-              servicePort: status
+              service:
+                name: perfdash-status
+                port:
+                  name: status
   tls:
     - hosts:
         - perfdash.ppc64le-cloud.org


### PR DESCRIPTION
- Updated perfdash ingress to `networking.k8s.io/v1` from `extensions/v1beta1`
- Remove `cert-manager.io/cluster-issuer: letsencrypt-staging` annotation as we started using secret manager instead of certificate manager.