### PR TITLE
Remove the workaround for kubetest2 issue #176

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -107,9 +107,6 @@ periodics:
                 --break-kubetest-on-upfail true \
                 --powervs-memory 32 \
                 --test=ginkgo -- --parallel 10 --flake-attempts 2 --test-package-bucket k8s-release-dev --test-package-dir ci --test-package-version $K8S_BUILD_VERSION --focus-regex='\[Conformance\]' --skip-regex='\[Serial\]'
-              #Workaround for kubetest2 failure to run twice
-              #https://github.com/kubernetes-sigs/kubetest2/issues/176
-              rm metadata.json
               export KUBECONFIG="$(pwd)/config1-$TIMESTAMP/kubeconfig"
               export ARTIFACTS=$ARTIFACTS/serial_tests_artifacts
               #Run Serial Conformance tests

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -162,9 +162,6 @@ postsubmits:
                     --ginkgo.flakeAttempts=2 \
                     --report-dir=$ARTIFACTS \
                     --kubeconfig="$(pwd)/config2-$TIMESTAMP/kubeconfig"
-                #Workaround for kubetest2 failure to run twice
-                #https://github.com/kubernetes-sigs/kubetest2/issues/176
-                rm metadata.json
                 kubetest2 tf --powervs-region lon --powervs-zone lon04 \
                     --powervs-service-id f57510e4-7109-45ab-9dbb-a9fd38529707 \
                     --ignore-cluster-dir true \


### PR DESCRIPTION
This is for the task https://github.ibm.com/powercloud/container-dev/issues/1583

The kubetest2-plugins have been all this while using the older version of kubetest2 `sigs.k8s.io/kubetest2 v0.0.0-20200910235614-8dd2cc76cff9` hence an issue https://github.com/kubernetes-sigs/kubetest2/issues/176 existed.

This issue is fixed after https://github.com/kubernetes-sigs/kubetest2/pull/162 in upstream kubetest2.
The update of golang and dependencies for kubetest2-tf plugin via https://github.com/ppc64le-cloud/kubetest2-plugins/pull/55/files fixed this in our jobs too!
Hence the workaround needs to be removed.