### PR TITLE
Remove the CAPIBM e2e job not using Boskos

### DIFF
--- a/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
+++ b/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
@@ -1,38 +1,4 @@
 periodics:
-  - name: periodic-cluster-api-provider-ibmcoud-e2e-test
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: ppc64le-kubernetes
-        path_strategy: explicit
-      gcs_credentials_secret: gcs-credentials
-    interval: 3h
-    extra_refs:
-      - base_ref: main
-        org: kubernetes-sigs
-        repo: cluster-api-provider-ibmcloud
-        workdir: true
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220121-354980456e-master
-          env:
-            - name: "E2E_FLAVOR"
-              value: "powervs"
-            - name: "IBMPOWERVS_SSHKEY_NAME"
-              value: "powercloud-bot-key"
-            - name: "BOSKOS_HOST"
-              value: "boskos.test-pods.svc.cluster.local"
-          command:
-            - "runner.sh"
-            - "./scripts/ci-e2e.sh"
-          envFrom:
-            - secretRef:
-                name: ibm-cloud-credentials
-          securityContext:
-            privileged: true
   - name: periodic-capi-provider-ibmcoud-e2e-boskos-new
     labels:
       preset-dind-enabled: "true"
@@ -60,8 +26,5 @@ periodics:
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
-          envFrom:
-            - secretRef:
-                name: ibm-cloud-credentials
           securityContext:
             privileged: true


### PR DESCRIPTION
This PR 

- Removes the CAPIBM e2e job following the earlier flow of not using boskos
- Removes the API Key secret reference for the e2e job using Boskos as it will be fetched from the user data of the resource