### PR TITLE
Move prow jobs testbed and SM to new PCLOUD Upstream account

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
@@ -23,4 +23,4 @@ periodics:
               chmod +x /usr/local/bin/pvsadm
 
               # delete all the vms created before 4hrs
-              pvsadm purge vms --instance-id 92a1f176-ce2b-4940-86fa-ad3e634ee851 --before 4h --ignore-errors --no-prompt
+              pvsadm purge vms --instance-id f8640447-b356-47be-b87f-f36b72491390 --before 4h --ignore-errors --no-prompt

--- a/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
@@ -61,9 +61,9 @@ periodics:
         chmod +x /usr/local/bin/kubectl
 
         kubetest2 tf --powervs-dns k8s-tests \
-          --powervs-image-name centos-8-stream-20gb \
-          --powervs-region syd --powervs-zone syd05 \
-          --powervs-service-id 92a1f176-ce2b-4940-86fa-ad3e634ee851 \
+          --powervs-image-name centos-stream-8 \
+          --powervs-region syd --powervs-zone syd04 \
+          --powervs-service-id f8640447-b356-47be-b87f-f36b72491390 \
           --powervs-ssh-key powercloud-bot-key \
           --ssh-private-key /etc/secret-volume/ssh-privatekey \
           --build-version $K8S_BUILD_VERSION \
@@ -140,9 +140,9 @@ periodics:
         chmod +x /usr/local/bin/kubectl
 
         kubetest2 tf --powervs-dns k8s-tests \
-          --powervs-image-name centos-8-stream-20gb \
-          --powervs-region syd --powervs-zone syd05 \
-          --powervs-service-id 92a1f176-ce2b-4940-86fa-ad3e634ee851 \
+          --powervs-image-name centos-stream-8 \
+          --powervs-region syd --powervs-zone syd04 \
+          --powervs-service-id f8640447-b356-47be-b87f-f36b72491390 \
           --powervs-ssh-key powercloud-bot-key \
           --ssh-private-key /etc/secret-volume/ssh-privatekey \
           --build-version $K8S_BUILD_VERSION \

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -95,9 +95,9 @@ periodics:
               chmod +x /usr/local/bin/kubectl
 
               kubetest2 tf --powervs-dns k8s-tests \
-                --powervs-image-name centos-8-stream-20gb \
-                --powervs-region syd --powervs-zone syd05 \
-                --powervs-service-id 92a1f176-ce2b-4940-86fa-ad3e634ee851 \
+                --powervs-image-name centos-stream-8 \
+                --powervs-region syd --powervs-zone syd04 \
+                --powervs-service-id f8640447-b356-47be-b87f-f36b72491390 \
                 --powervs-ssh-key powercloud-bot-key \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \
                 --build-version $K8S_BUILD_VERSION \
@@ -110,8 +110,8 @@ periodics:
               export KUBECONFIG="$(pwd)/config1-$TIMESTAMP/kubeconfig"
               export ARTIFACTS=$ARTIFACTS/serial_tests_artifacts
               #Run Serial Conformance tests
-              kubetest2 tf --powervs-region syd --powervs-zone syd05 \
-                --powervs-service-id 92a1f176-ce2b-4940-86fa-ad3e634ee851 \
+              kubetest2 tf --powervs-region syd --powervs-zone syd04 \
+                --powervs-service-id f8640447-b356-47be-b87f-f36b72491390 \
                 --ignore-cluster-dir true \
                 --cluster-name config1-$TIMESTAMP \
                 --down --auto-approve --ignore-destroy-errors \

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -144,9 +144,9 @@ postsubmits:
                 wget -qO- $URL/kubernetes-client-linux-ppc64le.tar.gz | tar xz -C /usr/local/bin --strip-components=3
 
                 kubetest2 tf --powervs-dns k8s-tests \
-                    --powervs-image-name centos-8-stream-20gb \
-                    --powervs-region syd --powervs-zone syd05 \
-                    --powervs-service-id 92a1f176-ce2b-4940-86fa-ad3e634ee851 \
+                    --powervs-image-name centos-stream-8 \
+                    --powervs-region syd --powervs-zone syd04 \
+                    --powervs-service-id f8640447-b356-47be-b87f-f36b72491390 \
                     --powervs-ssh-key powercloud-bot-key \
                     --ssh-private-key /etc/secret-volume/ssh-privatekey \
                     --build-version $K8S_BUILD_VERSION \
@@ -162,8 +162,8 @@ postsubmits:
                     --ginkgo.flakeAttempts=2 \
                     --report-dir=$ARTIFACTS \
                     --kubeconfig="$(pwd)/config2-$TIMESTAMP/kubeconfig"
-                kubetest2 tf --powervs-region syd --powervs-zone syd05 \
-                    --powervs-service-id 92a1f176-ce2b-4940-86fa-ad3e634ee851 \
+                kubetest2 tf --powervs-region syd --powervs-zone syd04 \
+                    --powervs-service-id f8640447-b356-47be-b87f-f36b72491390 \
                     --ignore-cluster-dir true \
                     --cluster-name config2-$TIMESTAMP \
                     --down --auto-approve --ignore-destroy-errors \

--- a/config/prow/external-secrets/public_cert.yaml
+++ b/config/prow/external-secrets/public_cert.yaml
@@ -15,9 +15,9 @@ spec:
   data:
   - secretKey: tls.crt
     remoteRef:
-      key: public_cert/b224974d-90d6-e7e1-517c-8cd3822d797b
+      key: public_cert/82d10b13-e2dd-7f8c-7515-4346747035aa
       property: certificate
   - secretKey: tls.key
     remoteRef:
-      key: public_cert/b224974d-90d6-e7e1-517c-8cd3822d797b
+      key: public_cert/82d10b13-e2dd-7f8c-7515-4346747035aa
       property: private_key

--- a/config/prow/external-secrets/secretstore_update.yaml
+++ b/config/prow/external-secrets/secretstore_update.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   provider:
     ibm:
-      serviceUrl: "https://654fc93a-61d6-4637-b77b-bd712d8cf5c1.us-south.secrets-manager.appdomain.cloud"
+      serviceUrl: "https://8839df52-56c9-4eff-a5be-9c75210f8916.us-south.secrets-manager.appdomain.cloud"
       auth:
         secretRef:
           secretApiKeySecretRef:


### PR DESCRIPTION
- Changed the service instance of PowerVS to the new one in new account.
- Change the secrets manager service instance ID and the public cert secret ID.

For this change to work, apply of a new APIKey in IKS cluster is required. 
Ref: https://github.ibm.com/powercloud-secrets/secrets/pull/19

https://prow.ppc64le-cloud.org/view/gs/ppc64le-kubernetes/logs/test-periodic-kubernetes-containerd-conformance-test-ppc64le/1541660962732380160 is the successful run on new testbed triggered from k8s cluster on my workspace.
