### PR TITLE
Change prow tesbed from syd04 to syd05

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
@@ -23,4 +23,4 @@ periodics:
               chmod +x /usr/local/bin/pvsadm
 
               # delete all the vms created before 4hrs
-              pvsadm purge vms --instance-id f8640447-b356-47be-b87f-f36b72491390 --before 4h --ignore-errors --no-prompt
+              pvsadm purge vms --instance-id c3f5354a-517e-4927-8523-890c4bf3d6c5 --before 4h --ignore-errors --no-prompt

--- a/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
@@ -62,8 +62,8 @@ periodics:
 
         kubetest2 tf --powervs-dns k8s-tests \
           --powervs-image-name centos-stream-8 \
-          --powervs-region syd --powervs-zone syd04 \
-          --powervs-service-id f8640447-b356-47be-b87f-f36b72491390 \
+          --powervs-region syd --powervs-zone syd05 \
+          --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
           --powervs-ssh-key powercloud-bot-key \
           --ssh-private-key /etc/secret-volume/ssh-privatekey \
           --build-version $K8S_BUILD_VERSION \
@@ -141,8 +141,8 @@ periodics:
 
         kubetest2 tf --powervs-dns k8s-tests \
           --powervs-image-name centos-stream-8 \
-          --powervs-region syd --powervs-zone syd04 \
-          --powervs-service-id f8640447-b356-47be-b87f-f36b72491390 \
+          --powervs-region syd --powervs-zone syd05 \
+          --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
           --powervs-ssh-key powercloud-bot-key \
           --ssh-private-key /etc/secret-volume/ssh-privatekey \
           --build-version $K8S_BUILD_VERSION \

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -96,8 +96,8 @@ periodics:
 
               kubetest2 tf --powervs-dns k8s-tests \
                 --powervs-image-name centos-stream-8 \
-                --powervs-region syd --powervs-zone syd04 \
-                --powervs-service-id f8640447-b356-47be-b87f-f36b72491390 \
+                --powervs-region syd --powervs-zone syd05 \
+                --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
                 --powervs-ssh-key powercloud-bot-key \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \
                 --build-version $K8S_BUILD_VERSION \
@@ -110,8 +110,8 @@ periodics:
               export KUBECONFIG="$(pwd)/config1-$TIMESTAMP/kubeconfig"
               export ARTIFACTS=$ARTIFACTS/serial_tests_artifacts
               #Run Serial Conformance tests
-              kubetest2 tf --powervs-region syd --powervs-zone syd04 \
-                --powervs-service-id f8640447-b356-47be-b87f-f36b72491390 \
+              kubetest2 tf --powervs-region syd --powervs-zone syd05 \
+                --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
                 --ignore-cluster-dir true \
                 --cluster-name config1-$TIMESTAMP \
                 --down --auto-approve --ignore-destroy-errors \

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -145,8 +145,8 @@ postsubmits:
 
                 kubetest2 tf --powervs-dns k8s-tests \
                     --powervs-image-name centos-stream-8 \
-                    --powervs-region syd --powervs-zone syd04 \
-                    --powervs-service-id f8640447-b356-47be-b87f-f36b72491390 \
+                    --powervs-region syd --powervs-zone syd05 \
+                    --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
                     --powervs-ssh-key powercloud-bot-key \
                     --ssh-private-key /etc/secret-volume/ssh-privatekey \
                     --build-version $K8S_BUILD_VERSION \
@@ -162,8 +162,8 @@ postsubmits:
                     --ginkgo.flakeAttempts=2 \
                     --report-dir=$ARTIFACTS \
                     --kubeconfig="$(pwd)/config2-$TIMESTAMP/kubeconfig"
-                kubetest2 tf --powervs-region syd --powervs-zone syd04 \
-                    --powervs-service-id f8640447-b356-47be-b87f-f36b72491390 \
+                kubetest2 tf --powervs-region syd --powervs-zone syd05 \
+                    --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
                     --ignore-cluster-dir true \
                     --cluster-name config2-$TIMESTAMP \
                     --down --auto-approve --ignore-destroy-errors \


### PR DESCRIPTION
The prow jobs have been using `rdr-prow-testbed-sydo4` for jobs that need VM in PowerVS.
The lon04 received a resource crunch message from PowerVSteam. Thus moving to syd05 location.

`rdr-prow-testbed-syd05` is the new service instance.
https://prow.ppc64le-cloud.org/view/gs/ppc64le-kubernetes/logs/test-periodic-kubernetes-containerd-conformance-test-ppc64le/1552917631416143872 is the passed run in new service instance.