### PR TITLE
Upgrade Golang to fix master golang build failure

### DIFF
--- a/config/jobs/periodic/golang/build-golang-periodics.yaml
+++ b/config/jobs/periodic/golang/build-golang-periodics.yaml
@@ -5,7 +5,7 @@ periodics:
     interval: 1h
     spec:
       containers:
-        - image: golang:1.15
+        - image: golang:1.17
           command:
             - /bin/bash
             - -c


### PR DESCRIPTION
`periodic-golang-master-build-ppc64le` job has been failing since last night with below error:
```
+ ./make.bash
Building Go cmd/dist using /usr/local/go. (go1.15.15 linux/ppc64le)
found packages main (build.go) and building_Go_requires_Go_1_17_or_later (notgo117.go) in /root/go/src/cmd/dist
```

Thus upgrading the job's pod image to golang1.17 fixed this. Below is the test run:
https://prow.ppc64le-cloud.org/view/s3/prow-logs/logs/test-periodic-golang-master-build-ppc64le/1555406773970538496