### PR TITLE
Add ocp 4.11 to the images list

### DIFF
--- a/config/jobs/ocp-automation/openshift-install-power/openshift-install-power-images.yaml
+++ b/config/jobs/ocp-automation/openshift-install-power/openshift-install-power-images.yaml
@@ -58,7 +58,7 @@ postsubmits:
                     token: ${token}
                 EOL
                 export KUBECONFIG=$(pwd)/kubeconfig
-                for version in 4.9 4.10
+                for version in 4.9 4.10 4.11
                 do
                     kubectl build --push --registry-secret quay-powercloud-regcred --namespace image-builder --build-arg RELEASE_VER=$version -t quay.io/powercloud/openshift-install-powervs:ocp$version-amd -t quay.io/powercloud/openshift-install-powervs:$PULL_BASE_REF-ocp$version-amd -f images/Dockerfile ./
                     kubectl build --push --registry-secret quay-powercloud-regcred --kubeconfig /etc/kubeconfig/config --namespace image-builder --build-arg RELEASE_VER=$version -t quay.io/powercloud/openshift-install-powervs:ocp$version-ppc64le -t quay.io/powercloud/openshift-install-powervs:$PULL_BASE_REF-ocp$version-ppc64le -f images/Dockerfile ./
@@ -68,7 +68,7 @@ postsubmits:
                 cat > config.json << EOL
                 $DOCKER_CONFIG
                 EOL
-                for version in 4.9 4.10
+                for version in 4.9 4.10 4.11
                 do
                 cat > registry.yaml <<EOL
                 image: quay.io/powercloud/openshift-install-powervs:ocp$version


### PR DESCRIPTION
Adding the release OCP 4.11 to the docker images list.

Signed-off-by: Yussuf Shaikh <yussuf@us.ibm.com>