### PR TITLE
Change of s3 bucket names after migration to new account

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -132,7 +132,7 @@ postsubmits:
 
                 # Details of IBM S3 storage
                 S3_SERVER=s3.us-south.cloud-object-storage.appdomain.cloud
-                BUCKET=ci-builds
+                BUCKET=ppc64le-ci-builds
                 DIRECTORY=kubernetes/master/golang/master
                 build_commit=$(jq -r .commit $GOPATH/src/github.com/ppc64le-cloud/builds/kubernetes/master/golang/master/build.yaml)
 

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - --github-endpoint=https://api.github.com
             - --job-config-path=/etc/job-config
             - --s3-credentials-file=/etc/s3-credentials/service-account.json
-            - --status-path=s3://status-reconciler/status-reconciler-status
+            - --status-path=s3://ppc64le-status-reconciler/status-reconciler-status
           volumeMounts:
             - name: github-token
               mountPath: /etc/github

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -32,8 +32,8 @@ spec:
             - --github-graphql-endpoint=http://ghproxy/graphql
             - --job-config-path=/etc/job-config
             - --s3-credentials-file=/etc/s3-credentials/service-account.json
-            - --status-path=s3://tide/tide-status
-            - --history-uri=s3://tide/tide-history.json
+            - --status-path=s3://ppc64le-tide/tide-status
+            - --history-uri=s3://ppc64le-tide/tide-history.json
           ports:
             - name: http
               containerPort: 8888

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -73,7 +73,7 @@ plank:
       grace_period: 15s
       censor_secrets: true
       gcs_configuration:
-        bucket: s3://prow-logs
+        bucket: s3://ppc64le-prow-logs
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
       utility_images:


### PR DESCRIPTION
Had to change the bucket names as deletion of old COS Service instance did not delete the buckets in it!
The old bucket names seem to be reserved for 7 days.
https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-compatibility-api-bucket-operations#compatibility-api-delete-bucket

https://ibm-systems.slack.com/archives/G01CH7AC8H1/p1661327236849609
