### PR TITLE
Correct the update-job-config.sh

### DIFF
--- a/hack/update-job-config.sh
+++ b/hack/update-job-config.sh
@@ -22,4 +22,4 @@ do
   cm_file_content="${cm_file_content} --from-file=${job}=${tmp_dir}/${job}"
 done
 
-kubectl create cm job-config "${cm_file_content}" -n prow -o=yaml --dry-run=client | kubectl apply -f -
+kubectl create cm job-config ${cm_file_content} -n prow -o=yaml --dry-run=client | kubectl apply -f -


### PR DESCRIPTION
The `hack/update-job-config.sh` is throwing below error:
```
error: exactly one NAME is required, got 2
See 'kubectl create configmap -h' for help and examples
error: no objects passed to apply
```
Have to remove ""  while passing the `cm_file_content` value to `kubectl create` call.

```
[root@raji-workspace test-infra]# ./hack/update-job-config.sh
~/PR/test-infra ~/PR/test-infra
configmap/job-config2 created
[root@raji-workspace test-infra]# kubectl get configmaps -n prow
NAME               DATA   AGE
job-config2        34     10s
kube-root-ca.crt   1      71d
[root@raji-workspace test-infra]# git status
On branch update-job-config-sh
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   hack/update-job-config.sh

no changes added to commit (use "git add" and/or "git commit -a")
[root@raji-workspace test-infra]# vi hack/update-job-config.sh
[root@raji-workspace test-infra]#
[root@raji-workspace test-infra]# git diff
diff --git a/hack/update-job-config.sh b/hack/update-job-config.sh
index 5c59496..3a437f4 100755
--- a/hack/update-job-config.sh
+++ b/hack/update-job-config.sh
@@ -22,4 +22,4 @@ do
   cm_file_content="${cm_file_content} --from-file=${job}=${tmp_dir}/${job}"
 done

-kubectl create cm job-config "${cm_file_content}" -n prow -o=yaml --dry-run=client | kubectl apply -f -
+kubectl create cm job-config ${cm_file_content} -n prow -o=yaml --dry-run=client | kubectl apply -f -
[root@raji-workspace test-infra]# 
```
