### PR TITLE
Use proper kubekins image

### DIFF
--- a/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
+++ b/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
         workdir: true
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220121-354980456e-master
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220916-c3af09ab20-1.24
           env:
             - name: "E2E_FLAVOR"
               value: "md-remediation"


### PR DESCRIPTION
Rightnow tests are failing with following error:

```shell
Docker in Docker enabled, initializing...
================================================================================
Starting Docker: docker.
Waiting for docker to be ready, sleeping for 1 seconds.
================================================================================
Done setting up docker in docker.
+ WRAPPED_COMMAND_PID=148
+ ./scripts/ci-e2e.sh
+ wait 148
Detected go version: go version go1.17.6 linux/amd64.
Kubernetes requires go1.18.0 or greater.
Please install go1.18.0 or later.
+ EXIT_VALUE=2
+ set +o xtrace
Cleaning up after docker in docker.
================================================================================
Cleaning up after docker
Stopping Docker: dockerProgram process in pidfile '/var/run/docker-ssd.pid', 1 process(es), refused to die.
================================================================================
Done cleaning up after docker in docker.
```

Job ref: https://prow.ppc64le-cloud.org/view/gs/ppc64le-kubernetes/logs/periodic-capi-provider-ibmcoud-e2e-boskos-new/1571068989197520896

This is happening after the recent change https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/pull/874, hence we need to update the image to appropriate image to run the tests properly.