### PR TITLE
Use go install instead of go get

### DIFF
--- a/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
@@ -49,8 +49,8 @@ periodics:
 
         go install ./...
 
-        go get sigs.k8s.io/kubetest2@latest
-        go get sigs.k8s.io/kubetest2/...@latest
+        go install sigs.k8s.io/kubetest2@latest
+        go install sigs.k8s.io/kubetest2/...@latest
 
         TIMESTAMP=$(date +%s)
         K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
@@ -128,8 +128,8 @@ periodics:
 
         go install ./...
 
-        go get sigs.k8s.io/kubetest2@latest
-        go get sigs.k8s.io/kubetest2/...@latest
+        go install sigs.k8s.io/kubetest2@latest
+        go install sigs.k8s.io/kubetest2/...@latest
 
         TIMESTAMP=$(date +%s)
         K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -83,8 +83,8 @@ periodics:
 
               go install ./...
 
-              go get sigs.k8s.io/kubetest2@latest
-              go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
+              go install sigs.k8s.io/kubetest2@latest
+              go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
 
               TIMESTAMP=$(date +%s)
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -125,8 +125,8 @@ postsubmits:
 
                 go install ./...
 
-                go get sigs.k8s.io/kubetest2@latest
-                go get sigs.k8s.io/kubetest2/kubetest2-tester-exec@latest
+                go install sigs.k8s.io/kubetest2@latest
+                go install sigs.k8s.io/kubetest2/kubetest2-tester-exec@latest
 
                 TIMESTAMP=$(date +%s)
 


### PR DESCRIPTION
With the recent change in the `go get` behaviour, we need to use `go install` for our scenarios.
More information: https://golang.org/doc/go-get-install-deprecation