### PR TITLE
Remove linkcheck binary from postsubmit-kubernetes-build-golang-master job

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -37,7 +37,7 @@ postsubmits:
 
                 cp _output/bin/kubectl _output/release-stage/kubernetes/client/bin/
                 mv _output/bin/{apiextensions-apiserver,kube-aggregator,kube-apiserver,kube-controller-manager,kube-proxy,kube-scheduler,kubeadm,kubectl,kubelet} _output/release-stage/kubernetes/server/bin
-                mv _output/bin/{genyaml,go-runner,e2e_node.test,genman,kubemark,ginkgo,genswaggertypedocs,gendocs,genkubedocs,e2e.test,linkcheck} _output/release-stage/kubernetes/test/bin/
+                mv _output/bin/{genyaml,go-runner,e2e_node.test,genman,kubemark,ginkgo,genswaggertypedocs,gendocs,genkubedocs,e2e.test} _output/release-stage/kubernetes/test/bin/
 
                 tar -zcvf kubernetes-test-linux-`go env GOARCH`.tar.gz --directory=_output/release-stage/ kubernetes/test/bin
                 tar -zcvf kubernetes-client-linux-`go env GOARCH`.tar.gz --directory=_output/release-stage/ kubernetes/client/bin


### PR DESCRIPTION
There is a change upstream to drop linkcheck binary https://github.com/kubernetes/kubernetes/pull/112704
Hence the job `postsubmit-kubernetes-build-golang-master-ppc64le` has been failing with the below error:
```
+ mv _output/bin/genyaml _output/bin/go-runner _output/bin/e2e_node.test _output/bin/genman _output/bin/kubemark _output/bin/ginkgo _output/bin/genswaggertypedocs _output/bin/gendocs _output/bin/genkubedocs _output/bin/e2e.test _output/bin/linkcheck _output/release-stage/kubernetes/test/bin/
mv: cannot stat '_output/bin/linkcheck': No such file or directory
```
Failed job link: https://prow.ppc64le-cloud.org/view/s3/ppc64le-prow-logs/logs/postsubmit-kubernetes-build-golang-master-ppc64le/1574417521853861888