### PR TITLE
Reduce memory provisioned for the PowerVS instances deployed for storage-perf-tests

### DIFF
--- a/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
@@ -153,6 +153,6 @@ periodics:
           --up --down --auto-approve --retry-on-tf-failure 3 \
           --break-kubetest-on-upfail true \
           --ignore-destroy-errors \
-          --powervs-memory 32 \
+          --powervs-memory 16 \
           --extra-vars "kubelet_extra_args=--kube-api-qps=100 --kube-api-burst=100 --max-pods 140" \
           --test=exec -- $GOPATH/src/github.com/kubernetes/perf-tests/clusterloader2/run-e2e.sh --testsuite=testing/experimental/storage/pod-startup/suite.yaml --provider=local --nodes=1 --report-dir=/logs/artifacts


### PR DESCRIPTION
Enhancement:

Changes to reduce the memory provisioned from 32GB to 16GB memory for 2x PowerVS instances, which are deployed for executing `periodic-kubernetes-storage-perf-test-ppc64le` tests. 

The changes were tested end-to-end and the tests had executed successfully. 