### PR TITLE
Fix the error with postsubmit-master-golang-kubernetes-conformance-test-ppc64le job

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -162,6 +162,7 @@ postsubmits:
                     --ginkgo.flakeAttempts=2 \
                     --report-dir=$ARTIFACTS \
                     --kubeconfig="$(pwd)/config2-$TIMESTAMP/kubeconfig"
+                export ARTIFACTS=$ARTIFACTS/serial_tests_artifacts
                 kubetest2 tf --powervs-region syd --powervs-zone syd05 \
                     --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
                     --ignore-cluster-dir true \
@@ -170,5 +171,5 @@ postsubmits:
                     --test=exec -- /usr/local/bin/ginkgo /usr/local/bin/e2e.test \
                     -- --ginkgo.focus='\[Serial\].*\[Conformance\]' \
                     --ginkgo.flakeAttempts=2 \
-                    --report-dir=$ARTIFACTS/serial_tests_artifacts \
+                    --report-dir=$ARTIFACTS \
                     --kubeconfig="$(pwd)/config2-$TIMESTAMP/kubeconfig"


### PR DESCRIPTION
https://github.ibm.com/powercloud/container-dev/issues/1602
The job `postsubmit-master-golang-kubernetes-conformance-test-ppc64le` throws below error while executing the second kubetest2 tf command:
```
F0920 01:55:34.831870    4258 exec.go:100] failed to run exec tester: key tester-version already exists in the metadata
```

Have tested this change using `test-pj.sh` Below is the successful run:
https://prow.ppc64le-cloud.org/view/s3/ppc64le-prow-logs/logs/test-postsubmit-master-golang-kubernetes-conformance-test-ppc64le/1575708540578828288