### PR TITLE
Upgrade prow infra to v20221011-5d4db25b24

### DIFF
--- a/config/prow/cluster/cherrypick_deployment.yaml
+++ b/config/prow/cluster/cherrypick_deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: cherrypick
-        image: gcr.io/k8s-prow/cherrypicker:v20220926-17e1ece283
+        image: gcr.io/k8s-prow/cherrypicker:v20221011-5d4db25b24
         args:
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: gcr.io/k8s-prow/crier:v20220926-17e1ece283
+          image: gcr.io/k8s-prow/crier:v20221011-5d4db25b24
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/crier_github_app_deployment.yaml
+++ b/config/prow/cluster/crier_github_app_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier2
-          image: gcr.io/k8s-prow/crier:v20220926-17e1ece283
+          image: gcr.io/k8s-prow/crier:v20221011-5d4db25b24
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: gcr.io/k8s-prow/deck:v20220926-17e1ece283
+          image: gcr.io/k8s-prow/deck:v20221011-5d4db25b24
           args:
             - --config-path=/etc/config/config.yaml
             - --plugin-config=/etc/plugins/plugins.yaml

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20220926-17e1ece283
+          image: gcr.io/k8s-prow/ghproxy:v20221011-5d4db25b24
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: gcr.io/k8s-prow/hook:v20220926-17e1ece283
+          image: gcr.io/k8s-prow/hook:v20221011-5d4db25b24
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/hook_github_app_deployment.yaml
+++ b/config/prow/cluster/hook_github_app_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook2
-          image: gcr.io/k8s-prow/hook:v20220926-17e1ece283
+          image: gcr.io/k8s-prow/hook:v20221011-5d4db25b24
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: horologium
-          image: gcr.io/k8s-prow/horologium:v20220926-17e1ece283
+          image: gcr.io/k8s-prow/horologium:v20221011-5d4db25b24
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/label_sync_cron_job.yaml
+++ b/config/prow/cluster/label_sync_cron_job.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20220926-17e1ece283
+              image: gcr.io/k8s-prow/label_sync:v20221011-5d4db25b24
               args:
                 - --config=/etc/config/labels.yaml
                 - --confirm=true

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - --github-endpoint=https://api.github.com
             - --enable-controller=plank
             - --job-config-path=/etc/job-config
-          image: gcr.io/k8s-prow/prow-controller-manager:v20220926-17e1ece283
+          image: gcr.io/k8s-prow/prow-controller-manager:v20221011-5d4db25b24
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG

--- a/config/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -143,6 +143,17 @@ spec:
                       that contains a git http.cookiefile, which should be used during
                       the cloning process.
                     type: string
+                  default_memory_request:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: DefaultMemoryRequest is the default requested memory
+                      on a test container. If SetLimitEqualsMemoryRequest is also
+                      true then the Limit will also be set the same as this request.
+                      Could be overridden by memory request defined explicitly on
+                      prowjob.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   default_service_account_name:
                     description: DefaultServiceAccountName is the name of the Kubernetes
                       service account that should be used by the pod if one is not

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
         - name: sinker
-          image: gcr.io/k8s-prow/sinker:v20220926-17e1ece283
+          image: gcr.io/k8s-prow/sinker:v20221011-5d4db25b24
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20220926-17e1ece283
+          image: gcr.io/k8s-prow/status-reconciler:v20221011-5d4db25b24
           args:
             - --dry-run=false
             - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: gcr.io/k8s-prow/tide:v20220926-17e1ece283
+          image: gcr.io/k8s-prow/tide:v20221011-5d4db25b24
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -77,10 +77,10 @@ plank:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20220926-17e1ece283
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20220926-17e1ece283
-        initupload: gcr.io/k8s-prow/initupload:v20220926-17e1ece283
-        sidecar: gcr.io/k8s-prow/sidecar:v20220926-17e1ece283
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20221011-5d4db25b24
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20221011-5d4db25b24
+        initupload: gcr.io/k8s-prow/initupload:v20221011-5d4db25b24
+        sidecar: gcr.io/k8s-prow/sidecar:v20221011-5d4db25b24
       ssh_key_secrets:
         - bot-ssh-secret
 


### PR DESCRIPTION
Upgrade to the latest version to fix `crier` failure to remove `finalizer` from prow job pods in `test-pods` namespace.
They were struck in `Terminating` state.
To include fix https://github.com/kubernetes/test-infra/pull/27704