### PR TITLE
Rename perfdash.ppc64le-cloud.org => perf-dash.ppc64le-cloud.org

### DIFF
--- a/config/prow/perfdash/perfdash-ingress.yaml
+++ b/config/prow/perfdash/perfdash-ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/ingress.class: public-iks-k8s-nginx
 spec:
   rules:
-    - host: perfdash.ppc64le-cloud.org
+    - host: perf-dash.ppc64le-cloud.org
       http:
         paths:
           - path: /
@@ -19,5 +19,5 @@ spec:
                   name: status
   tls:
     - hosts:
-        - perfdash.ppc64le-cloud.org
+        - perf-dash.ppc64le-cloud.org
       secretName: ppc64le-cloud


### PR DESCRIPTION
Fixes ppc64le-cloud/test-infra#318