### PR TITLE
Remove push-gateway and  serve-metrics flags in ghproxy deployment

### DIFF
--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -25,8 +25,6 @@ spec:
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99
-            - --push-gateway=pushgateway
-            - --serve-metrics=true
           ports:
             - containerPort: 8888
           volumeMounts:


### PR DESCRIPTION
Fixes #316
Ref: https://kubernetes.slack.com/archives/CDECRSC5U/p1665603074971129