### PR TITLE
Update base image for ci-search image

### DIFF
--- a/images/ci-search/Dockerfile
+++ b/images/ci-search/Dockerfile
@@ -7,7 +7,7 @@ RUN git clone https://github.com/openshift/ci-search \
     && grep -rl "prow\.ci\.openshift" . | xargs sed -i 's/prow\.ci\.openshift/prow\.ppc64le-cloud/g' \
     && make build
 
-FROM centos:7
+FROM quay.io/centos/centos:stream8
 COPY --from=0 /go/src/github.com/openshift/ci-search/search /usr/bin/
 RUN curl -L https://github.com/BurntSushi/ripgrep/releases/download/12.0.1/ripgrep-12.0.1-x86_64-unknown-linux-musl.tar.gz | \
     tar xvzf - --wildcards --no-same-owner --strip-components=1  -C /usr/bin '*/rg'


### PR DESCRIPTION
Have built and pushed the updated image to https://quay.io/repository/powercloud/ci-search.
`ci-search` service is working fine with the latest image.
Fixes #294 
![image](https://user-images.githubusercontent.com/63038004/195581332-bb1fec1a-7e3c-458e-835d-adaf4a3ec8b7.png)
