### PR TITLE
Update kubekins image to 1.25

### DIFF
--- a/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
+++ b/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
         workdir: true
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220916-c3af09ab20-1.24
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221116-7c85504268-1.25
           env:
             - name: "E2E_FLAVOR"
               value: "md-remediation"


### PR DESCRIPTION
Depends on https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/pull/962