### PR TITLE
Update terraform validation path for pre-submit jobs for kubetest2-plugins repository.

### DIFF
--- a/config/jobs/periodic/containerd/test-containerd-powervs-periodic.yaml
+++ b/config/jobs/periodic/containerd/test-containerd-powervs-periodic.yaml
@@ -34,7 +34,7 @@ periodics:
 
               # Run test server
               mkdir ${ARTIFACTS}/runc_l1/
-              bash -x ./instantiate_vm_and_test.sh --output ${ARTIFACTS}/runc_l1/ --name rdr-runtimes-dev-periodic-containerd-runc-l1 --runc runc --runtime "io.containerd.runtime.v1.linux" --key atos-key --network  'public-192_168_139_176-29-VLAN_2050' 2>&1 | tee runc_l1.txt
+              bash -x ./instantiate_vm_and_test.sh --output ${ARTIFACTS}/runc_l1/ --name rdr-runtimes-containerd-runc-l1 --runc runc --runtime "io.containerd.runtime.v1.linux" --key atos-key --network  'public-192_168_139_176-29-VLAN_2050' 2>&1 | tee runc_l1.txt
 
               # Check results
               if [ -n "$(grep -En 'FAIL.*:' *.txt)" ]; then
@@ -77,7 +77,7 @@ periodics:
 
               # Run test server
               mkdir ${ARTIFACTS}/runc_v1/
-              bash -x ./instantiate_vm_and_test.sh --output ${ARTIFACTS}/runc_v1/ --name rdr-runtimes-dev-periodic-containerd-runc-v1 --runc runc --runtime "io.containerd.runc.v1" --key atos-key --network 'public-192_168_139_176-29-VLAN_2050' 2>&1 | tee runc_v1.txt
+              bash -x ./instantiate_vm_and_test.sh --output ${ARTIFACTS}/runc_v1/ --name rdr-runtimes-containerd-runc-v1 --runc runc --runtime "io.containerd.runc.v1" --key atos-key --network 'public-192_168_139_176-29-VLAN_2050' 2>&1 | tee runc_v1.txt
 
               # Check results
               if [ -n "$(grep -En 'FAIL.*:' *.txt)" ]; then
@@ -120,7 +120,7 @@ periodics:
 
               # Run test server
               mkdir ${ARTIFACTS}/runc_v2/
-              bash -x ./instantiate_vm_and_test.sh --output ${ARTIFACTS}/runc_v2/ --name rdr-runtimes-dev-periodic-containerd-runc-v2 --runc runc --runtime "io.containerd.runc.v2" --key atos-key --network 'public-192_168_139_176-29-VLAN_2050' 2>&1 | tee runc_v2.txt
+              bash -x ./instantiate_vm_and_test.sh --output ${ARTIFACTS}/runc_v2/ --name rdr-runtimes-containerd-runc-v2 --runc runc --runtime "io.containerd.runc.v2" --key atos-key --network 'public-192_168_139_176-29-VLAN_2050' 2>&1 | tee runc_v2.txt
 
               # Check results
               if [ -n "$(grep -En 'FAIL.*:' *.txt)" ]; then
@@ -163,7 +163,7 @@ periodics:
 
               # Run test server
               mkdir ${ARTIFACTS}/crun_v2/
-              bash -x ./instantiate_vm_and_test.sh --output ${ARTIFACTS}/crun_v2/ --name rdr-runtimes-dev-periodic-containerd-crun-v2 --runc crun --runtime "io.containerd.runc.v2" --key atos-key --network 'public-192_168_139_176-29-VLAN_2050' 2>&1 | tee crun_v2.txt
+              bash -x ./instantiate_vm_and_test.sh --output ${ARTIFACTS}/crun_v2/ --name rdr-runtimes-containerd-crun-v2 --runc crun --runtime "io.containerd.runc.v2" --key atos-key --network 'public-192_168_139_176-29-VLAN_2050' 2>&1 | tee crun_v2.txt
 
               # Check results
               if [ -n "$(grep -En 'FAIL.*:' *.txt)" ]; then

--- a/config/jobs/ppc64le-cloud/kubetest2-plugins/kubetest2-plugins-presubmit.yaml
+++ b/config/jobs/ppc64le-cloud/kubetest2-plugins/kubetest2-plugins-presubmit.yaml
@@ -2,7 +2,7 @@ presubmits:
   ppc64le-cloud/kubetest2-plugins:
     - name: pull-kubetest2-plugins-terraform-validate
       decorate: true
-      run_if_changed: 'data/data'
+      run_if_changed: 'data'
       spec:
         containers:
           - image: hashicorp/terraform:1.1.7
@@ -15,8 +15,8 @@ presubmits:
                 wget -O linux_amd64.zip https://github.com/IBM-Cloud/terraform-provider-ibm/releases/download/v1.39.1/terraform-provider-ibm_1.39.1_linux_amd64.zip
                 mkdir -p $HOME/.terraform.d/plugins/registry.terraform.io/hashicorp/ibm/1.39.1/linux_amd64
                 unzip linux_amd64.zip -d $HOME/.terraform.d/plugins/registry.terraform.io/hashicorp/ibm/1.39.1/linux_amd64
-                terraform -chdir=data/data/powervs init
-                terraform -chdir=data/data/powervs validate
+                terraform -chdir=data/powervs init
+                terraform -chdir=data/powervs validate
       annotations:
         testgrid-dashboards: presubmits-kubetest2-plugins
         testgrid-tab-name: terraform-validate


### PR DESCRIPTION
Changes: 
1 . Update terraform validation path for `kubetests2-plugin` pre-submit validation.

These changes are done to support the update made in the `kubetest2-plugins` repository, as the path for the `.tf` files have been changed from `data/data/powervs` to `data/powervs`.

PR in kubetest-plugins2 repository : https://github.com/ppc64le-cloud/kubetest2-plugins/pull/79