### PR TITLE
Update terraform validation path and add additional exec step to install `k8s-ansible` submodule.

### DIFF
--- a/config/jobs/ppc64le-cloud/kubetest2-plugins/kubetest2-plugins-presubmit.yaml
+++ b/config/jobs/ppc64le-cloud/kubetest2-plugins/kubetest2-plugins-presubmit.yaml
@@ -2,7 +2,7 @@ presubmits:
   ppc64le-cloud/kubetest2-plugins:
     - name: pull-kubetest2-plugins-terraform-validate
       decorate: true
-      run_if_changed: 'data/data'
+      run_if_changed: 'data'
       spec:
         containers:
           - image: hashicorp/terraform:1.1.7
@@ -15,8 +15,8 @@ presubmits:
                 wget -O linux_amd64.zip https://github.com/IBM-Cloud/terraform-provider-ibm/releases/download/v1.39.1/terraform-provider-ibm_1.39.1_linux_amd64.zip
                 mkdir -p $HOME/.terraform.d/plugins/registry.terraform.io/hashicorp/ibm/1.39.1/linux_amd64
                 unzip linux_amd64.zip -d $HOME/.terraform.d/plugins/registry.terraform.io/hashicorp/ibm/1.39.1/linux_amd64
-                terraform -chdir=data/data/powervs init
-                terraform -chdir=data/data/powervs validate
+                terraform -chdir=data/powervs init
+                terraform -chdir=data/powervs validate
       annotations:
         testgrid-dashboards: presubmits-kubetest2-plugins
         testgrid-tab-name: terraform-validate


### PR DESCRIPTION
Changes:
1 . Update terraform validation path for kubetests2-plugin pre-submit validation.
2. Execute go submodule update --init before installing kubetest2-tf plugin.

These changes are done to support the update made in the kubetest2-plugins repository, as the path for the .tf files have been changed from data/data/powervs to data/powervs.

PR in kubetest-plugins2 repository : https://github.com/ppc64le-cloud/kubetest2-plugins/pull/79