### PR TITLE
Spec changes for prow infra upgrade to latest upstream version

### DIFF
--- a/config/prow/cluster/cherrypick_deployment.yaml
+++ b/config/prow/cluster/cherrypick_deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: cherrypick
-        image: gcr.io/k8s-prow/cherrypicker:v20221102-f0b00eafb2
+        image: gcr.io/k8s-prow/cherrypicker:v20221207-b79005b5d4
         args:
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: gcr.io/k8s-prow/crier:v20221102-f0b00eafb2
+          image: gcr.io/k8s-prow/crier:v20221207-b79005b5d4
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/crier_github_app_deployment.yaml
+++ b/config/prow/cluster/crier_github_app_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier2
-          image: gcr.io/k8s-prow/crier:v20221102-f0b00eafb2
+          image: gcr.io/k8s-prow/crier:v20221207-b79005b5d4
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: gcr.io/k8s-prow/deck:v20221102-f0b00eafb2
+          image: gcr.io/k8s-prow/deck:v20221207-b79005b5d4
           args:
             - --config-path=/etc/config/config.yaml
             - --plugin-config=/etc/plugins/plugins.yaml

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20221102-f0b00eafb2
+          image: gcr.io/k8s-prow/ghproxy:v20221207-b79005b5d4
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: gcr.io/k8s-prow/hook:v20221102-f0b00eafb2
+          image: gcr.io/k8s-prow/hook:v20221207-b79005b5d4
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/hook_github_app_deployment.yaml
+++ b/config/prow/cluster/hook_github_app_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook2
-          image: gcr.io/k8s-prow/hook:v20221102-f0b00eafb2
+          image: gcr.io/k8s-prow/hook:v20221207-b79005b5d4
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: horologium
-          image: gcr.io/k8s-prow/horologium:v20221102-f0b00eafb2
+          image: gcr.io/k8s-prow/horologium:v20221207-b79005b5d4
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/label_sync_cron_job.yaml
+++ b/config/prow/cluster/label_sync_cron_job.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20221102-f0b00eafb2
+              image: gcr.io/k8s-prow/label_sync:v20221207-b79005b5d4
               args:
                 - --config=/etc/config/labels.yaml
                 - --confirm=true

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - --github-endpoint=https://api.github.com
             - --enable-controller=plank
             - --job-config-path=/etc/job-config
-          image: gcr.io/k8s-prow/prow-controller-manager:v20221102-f0b00eafb2
+          image: gcr.io/k8s-prow/prow-controller-manager:v20221207-b79005b5d4
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG

--- a/config/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -538,7 +538,7 @@ spec:
                 description: JobQueueName is an optional field with name of a queue
                   defining max concurrency. When several jobs from the same queue
                   try to run at the same time, the number of them that is actually
-                  started is limited by JobQueueConcurrencies (part of Plank's config).
+                  started is limited by JobQueueCapacities (part of Plank's config).
                   If this field is left undefined inifinite concurrency is assumed.
                   This behaviour may be superseded by MaxConcurrency field, if it
                   is set to a constraining value.

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
         - name: sinker
-          image: gcr.io/k8s-prow/sinker:v20221102-f0b00eafb2
+          image: gcr.io/k8s-prow/sinker:v20221207-b79005b5d4
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20221102-f0b00eafb2
+          image: gcr.io/k8s-prow/status-reconciler:v20221207-b79005b5d4
           args:
             - --dry-run=false
             - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: gcr.io/k8s-prow/tide:v20221102-f0b00eafb2
+          image: gcr.io/k8s-prow/tide:v20221207-b79005b5d4
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -77,10 +77,10 @@ plank:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20221102-f0b00eafb2
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20221102-f0b00eafb2
-        initupload: gcr.io/k8s-prow/initupload:v20221102-f0b00eafb2
-        sidecar: gcr.io/k8s-prow/sidecar:v20221102-f0b00eafb2
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20221207-b79005b5d4
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20221207-b79005b5d4
+        initupload: gcr.io/k8s-prow/initupload:v20221207-b79005b5d4
+        sidecar: gcr.io/k8s-prow/sidecar:v20221207-b79005b5d4
       ssh_key_secrets:
         - bot-ssh-secret
 


### PR DESCRIPTION
- Have applied these on IKS cluster.
- The jobs are running fine https://prow.ppc64le-cloud.org/view/s3/ppc64le-prow-logs/logs/periodic-golang-master-build-ppc64le/1600897452892753920
- No errors in logs of controller, hook, tide, crier, sinker
- Apart from the change of image tags, https://github.com/kubernetes/test-infra/pull/27807 is the only change that applies to us between the last upgrade and now. 