### PR TITLE
Upgrade prow specs to v20230106-0de7d15106

### DIFF
--- a/config/prow/cluster/cherrypick_deployment.yaml
+++ b/config/prow/cluster/cherrypick_deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: cherrypick
-        image: gcr.io/k8s-prow/cherrypicker:v20221207-b79005b5d4
+        image: gcr.io/k8s-prow/cherrypicker:v20230106-0de7d15106
         args:
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: gcr.io/k8s-prow/crier:v20221207-b79005b5d4
+          image: gcr.io/k8s-prow/crier:v20230106-0de7d15106
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/crier_github_app_deployment.yaml
+++ b/config/prow/cluster/crier_github_app_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier2
-          image: gcr.io/k8s-prow/crier:v20221207-b79005b5d4
+          image: gcr.io/k8s-prow/crier:v20230106-0de7d15106
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: gcr.io/k8s-prow/deck:v20221207-b79005b5d4
+          image: gcr.io/k8s-prow/deck:v20230106-0de7d15106
           args:
             - --config-path=/etc/config/config.yaml
             - --plugin-config=/etc/plugins/plugins.yaml

--- a/config/prow/cluster/deck_rbac.yaml
+++ b/config/prow/cluster/deck_rbac.yaml
@@ -23,6 +23,8 @@ rules:
       # **Warning:** Only use this for non-public deck instances, this allows
       # anyone with access to your Deck instance to create new Prowjobs
       # - create
+      # Required to abort jobs
+      # - patch
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20221207-b79005b5d4
+          image: gcr.io/k8s-prow/ghproxy:v20230106-0de7d15106
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: gcr.io/k8s-prow/hook:v20221207-b79005b5d4
+          image: gcr.io/k8s-prow/hook:v20230106-0de7d15106
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/hook_github_app_deployment.yaml
+++ b/config/prow/cluster/hook_github_app_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook2
-          image: gcr.io/k8s-prow/hook:v20221207-b79005b5d4
+          image: gcr.io/k8s-prow/hook:v20230106-0de7d15106
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: horologium
-          image: gcr.io/k8s-prow/horologium:v20221207-b79005b5d4
+          image: gcr.io/k8s-prow/horologium:v20230106-0de7d15106
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/label_sync_cron_job.yaml
+++ b/config/prow/cluster/label_sync_cron_job.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20221207-b79005b5d4
+              image: gcr.io/k8s-prow/label_sync:v20230106-0de7d15106
               args:
                 - --config=/etc/config/labels.yaml
                 - --confirm=true

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - --github-endpoint=https://api.github.com
             - --enable-controller=plank
             - --job-config-path=/etc/job-config
-          image: gcr.io/k8s-prow/prow-controller-manager:v20221207-b79005b5d4
+          image: gcr.io/k8s-prow/prow-controller-manager:v20230106-0de7d15106
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
         - name: sinker
-          image: gcr.io/k8s-prow/sinker:v20221207-b79005b5d4
+          image: gcr.io/k8s-prow/sinker:v20230106-0de7d15106
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20221207-b79005b5d4
+          image: gcr.io/k8s-prow/status-reconciler:v20230106-0de7d15106
           args:
             - --dry-run=false
             - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: gcr.io/k8s-prow/tide:v20221207-b79005b5d4
+          image: gcr.io/k8s-prow/tide:v20230106-0de7d15106
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -77,10 +77,10 @@ plank:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20221207-b79005b5d4
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20221207-b79005b5d4
-        initupload: gcr.io/k8s-prow/initupload:v20221207-b79005b5d4
-        sidecar: gcr.io/k8s-prow/sidecar:v20221207-b79005b5d4
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20230106-0de7d15106
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20230106-0de7d15106
+        initupload: gcr.io/k8s-prow/initupload:v20230106-0de7d15106
+        sidecar: gcr.io/k8s-prow/sidecar:v20230106-0de7d15106
       ssh_key_secrets:
         - bot-ssh-secret
 


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/28359 is the only change applicable to our infra from the last upgrade.

Even the above change had to be commented out as we have not enabled rerun/abort in our deck.