### PR TITLE
Add runtime flag to kubectl buildkit

### DIFF
--- a/config/jobs/ocp-automation/openshift-install-power/openshift-install-power-images.yaml
+++ b/config/jobs/ocp-automation/openshift-install-power/openshift-install-power-images.yaml
@@ -53,7 +53,9 @@ postsubmits:
                 export KUBECONFIG=$(pwd)/kubeconfig
                 for version in 4.9 4.10 4.11 4.12
                 do
+                    kubectl buildkit create --runtime=containerd --namespace image-builder
                     kubectl build --push --registry-secret quay-powercloud-regcred --namespace image-builder --build-arg RELEASE_VER=$version -t quay.io/powercloud/openshift-install-powervs:ocp$version-amd -t quay.io/powercloud/openshift-install-powervs:$PULL_BASE_REF-ocp$version-amd -f images/Dockerfile ./
+                    kubectl buildkit create --runtime=containerd --namespace image-builder --kubeconfig /etc/kubeconfig/config
                     kubectl build --push --registry-secret quay-powercloud-regcred --kubeconfig /etc/kubeconfig/config --namespace image-builder --build-arg RELEASE_VER=$version -t quay.io/powercloud/openshift-install-powervs:ocp$version-ppc64le -t quay.io/powercloud/openshift-install-powervs:$PULL_BASE_REF-ocp$version-ppc64le -f images/Dockerfile ./
                 done
                 curl -L https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-`go env GOARCH` -o /usr/local/bin/manifest-tool


### PR DESCRIPTION
The job `openshift-install-power-build-and-push-on-release` has been failing with below error:
```
 #1 0.515 Warning 	buildkit-56d88f5d45-p2whx 	FailedMount 	MountVolume.SetUp failed for volume "docker-sock" : hostPath type check failed: /var/run/docker.sock is not a socket file
#1 0.515 WARN: initial attempt to deploy configured for the docker runtime failed, retrying with containerd
#1 waiting for 1 pods to be ready 115.6s done
#1 ERROR: expected 1 replicas to be ready, got 0 
```
https://prow.ppc64le-cloud.org/view/s3/ppc64le-prow-logs/logs/openshift-install-power-build-and-push-on-release/1620736137423228928

Have included the workaround mentioned in https://github.com/vmware-tanzu/buildkit-cli-for-kubectl/issues/109 . The image building is successful after this change.

The other image-building jobs that use kubectl build too might fail with this error.
Hope we can add the workaround when needed. The above issue in `buildkit-cli-for-kubectl` might get resolved too!