### PR TITLE
Edit postsubmit-kubernetes-build-golang-master-ppc64le job to remove gen* binaries

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -37,7 +37,7 @@ postsubmits:
 
                 cp _output/bin/kubectl _output/release-stage/kubernetes/client/bin/
                 mv _output/bin/{apiextensions-apiserver,kube-aggregator,kube-apiserver,kube-controller-manager,kube-proxy,kube-scheduler,kubeadm,kubectl,kubelet} _output/release-stage/kubernetes/server/bin
-                mv _output/bin/{genyaml,go-runner,e2e_node.test,genman,kubemark,ginkgo,genswaggertypedocs,gendocs,genkubedocs,e2e.test} _output/release-stage/kubernetes/test/bin/
+                mv _output/bin/{go-runner,e2e_node.test,kubemark,ginkgo,e2e.test} _output/release-stage/kubernetes/test/bin/
 
                 tar -zcvf kubernetes-test-linux-`go env GOARCH`.tar.gz --directory=_output/release-stage/ kubernetes/test/bin
                 tar -zcvf kubernetes-client-linux-`go env GOARCH`.tar.gz --directory=_output/release-stage/ kubernetes/client/bin


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/116860 has dropped development-time binaries from test targets.
Hence the job `postsubmit-kubernetes-build-golang-master-ppc64le` has been failing.
https://prow.ppc64le-cloud.org/job-history/s3/ppc64le-prow-logs/logs/postsubmit-kubernetes-build-golang-master-ppc64le