### PR TITLE
Log testpj pod details to a local file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,14 @@ https://github.com/kubernetes/test-infra/blob/master/prow/build_test_update.md#u
 # set the kubeconfig to proper cluster
 $ export KUBECONFIG=/home/.kube/config
 
-# run the ./hack/test-pj.sh script, following the script runs the k8s-ppc64le-cluster-health-check on the cluster configured by KUBECONFIG(default: ${HOME}/.kube/config)
-$ CONFIG_PATH=$(pwd)/config/prow/config.yaml JOB_CONFIG_PATH=$(pwd)/config/jobs/ppc64le-cloud/test-infra/test-infra-periodics.yaml ./hack/test-pj.sh k8s-ppc64le-cluster-health-check
+# run the ./hack/test-pj.sh script, following the script runs the k8s-ppc64le-cluster-health-check
+# on the cluster configured by KUBECONFIG(default: ${HOME}/.kube/config) and creates 
+# a file pod_table.txt in the present working directory with details about the 
+# job. The -j flag is used to specify the job to be run and is mandatory. The -p (purpose) flag
+# is used to specify the purpose for which the job is being run and is optional. 
+# The job name and the purpose among other details will be populated in pod_table.txt 
+# if the purpose flag is set.
+$ CONFIG_PATH=$(pwd)/config/prow/config.yaml JOB_CONFIG_PATH=$(pwd)/config/jobs/ppc64le-cloud/test-infra/test-infra-periodics.yaml ./hack/test-pj.sh -j k8s-ppc64le-cluster-health-check -p "Cluster health after new jobs"
 ```
 
 ## Tools exposed via this repository


### PR DESCRIPTION
Changes made:
1. testpj script run with -h, --h or --help flags or with inadequate parameters will display script usage information.
2. A third parameter can now be provided containing a string describing the purpose for which the job is being run. If specified, this purpose, along with the pod UUID, name of the job and timestamp will be logged to a file pod_table.txt (either new or existing) in PWD.