### PR TITLE
Upgrade Prow Infra to v20230412-a86d65c3c2

### DIFF
--- a/config/prow/cluster/cherrypick_deployment.yaml
+++ b/config/prow/cluster/cherrypick_deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: cherrypick
-        image: gcr.io/k8s-prow/cherrypicker:v20230309-adf0d41516
+        image: gcr.io/k8s-prow/cherrypicker:v20230412-a86d65c3c2
         args:
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: gcr.io/k8s-prow/crier:v20230309-adf0d41516
+          image: gcr.io/k8s-prow/crier:v20230412-a86d65c3c2
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/crier_github_app_deployment.yaml
+++ b/config/prow/cluster/crier_github_app_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier2
-          image: gcr.io/k8s-prow/crier:v20230309-adf0d41516
+          image: gcr.io/k8s-prow/crier:v20230412-a86d65c3c2
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: gcr.io/k8s-prow/deck:v20230309-adf0d41516
+          image: gcr.io/k8s-prow/deck:v20230412-a86d65c3c2
           args:
             - --config-path=/etc/config/config.yaml
             - --plugin-config=/etc/plugins/plugins.yaml

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20230309-adf0d41516
+          image: gcr.io/k8s-prow/ghproxy:v20230412-a86d65c3c2
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: gcr.io/k8s-prow/hook:v20230309-adf0d41516
+          image: gcr.io/k8s-prow/hook:v20230412-a86d65c3c2
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/hook_github_app_deployment.yaml
+++ b/config/prow/cluster/hook_github_app_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook2
-          image: gcr.io/k8s-prow/hook:v20230309-adf0d41516
+          image: gcr.io/k8s-prow/hook:v20230412-a86d65c3c2
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: horologium
-          image: gcr.io/k8s-prow/horologium:v20230309-adf0d41516
+          image: gcr.io/k8s-prow/horologium:v20230412-a86d65c3c2
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/label_sync_cron_job.yaml
+++ b/config/prow/cluster/label_sync_cron_job.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20230309-adf0d41516
+              image: gcr.io/k8s-prow/label_sync:v20230412-a86d65c3c2
               args:
                 - --config=/etc/config/labels.yaml
                 - --confirm=true

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - --github-endpoint=https://api.github.com
             - --enable-controller=plank
             - --job-config-path=/etc/job-config
-          image: gcr.io/k8s-prow/prow-controller-manager:v20230309-adf0d41516
+          image: gcr.io/k8s-prow/prow-controller-manager:v20230412-a86d65c3c2
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG

--- a/config/prow/cluster/prow-controller-manager_rbac.yaml
+++ b/config/prow/cluster/prow-controller-manager_rbac.yaml
@@ -65,6 +65,7 @@ rules:
       - pods
     verbs:
       - delete
+      - get
       - list
       - watch
       - create

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
         - name: sinker
-          image: gcr.io/k8s-prow/sinker:v20230309-adf0d41516
+          image: gcr.io/k8s-prow/sinker:v20230412-a86d65c3c2
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20230309-adf0d41516
+          image: gcr.io/k8s-prow/status-reconciler:v20230412-a86d65c3c2
           args:
             - --dry-run=false
             - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: gcr.io/k8s-prow/tide:v20230309-adf0d41516
+          image: gcr.io/k8s-prow/tide:v20230412-a86d65c3c2
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -77,10 +77,10 @@ plank:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20230309-adf0d41516
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20230309-adf0d41516
-        initupload: gcr.io/k8s-prow/initupload:v20230309-adf0d41516
-        sidecar: gcr.io/k8s-prow/sidecar:v20230309-adf0d41516
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20230412-a86d65c3c2
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20230412-a86d65c3c2
+        initupload: gcr.io/k8s-prow/initupload:v20230412-a86d65c3c2
+        sidecar: gcr.io/k8s-prow/sidecar:v20230412-a86d65c3c2
       ssh_key_secrets:
         - bot-ssh-secret
 


### PR DESCRIPTION
- Changed the image tag for all components
- Had to include `get` verb to `prow-controller-manager` rbac to avoid below error in controller deployment:
```
{"component":"prow-controller-manager","error":"failed pod resource authorization check: unable to \"get\" pods","file":"k8s.io/test-infra/prow/cmd/prow-controller-manager/main.go:189","func":"main.main","level":"error","msg":"Failed to construct build cluster managers. Please check that the kubeconfig secrets are correct, and that RBAC roles on the build cluster allow Prow's service account to list pods on it.","severity":"error","time":"2023-04-13T08:51:00Z"}
```