### PR TITLE
Upgrade Prow Infra to v20230505-3fedf7ef10

### DIFF
--- a/config/prow/cluster/cherrypick_deployment.yaml
+++ b/config/prow/cluster/cherrypick_deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: cherrypick
-        image: gcr.io/k8s-prow/cherrypicker:v20230412-a86d65c3c2
+        image: gcr.io/k8s-prow/cherrypicker:v20230505-3fedf7ef10
         args:
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: gcr.io/k8s-prow/crier:v20230412-a86d65c3c2
+          image: gcr.io/k8s-prow/crier:v20230505-3fedf7ef10
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/crier_github_app_deployment.yaml
+++ b/config/prow/cluster/crier_github_app_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier2
-          image: gcr.io/k8s-prow/crier:v20230412-a86d65c3c2
+          image: gcr.io/k8s-prow/crier:v20230505-3fedf7ef10
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: gcr.io/k8s-prow/deck:v20230412-a86d65c3c2
+          image: gcr.io/k8s-prow/deck:v20230505-3fedf7ef10
           args:
             - --config-path=/etc/config/config.yaml
             - --plugin-config=/etc/plugins/plugins.yaml

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20230412-a86d65c3c2
+          image: gcr.io/k8s-prow/ghproxy:v20230505-3fedf7ef10
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: gcr.io/k8s-prow/hook:v20230412-a86d65c3c2
+          image: gcr.io/k8s-prow/hook:v20230505-3fedf7ef10
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/hook_github_app_deployment.yaml
+++ b/config/prow/cluster/hook_github_app_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook2
-          image: gcr.io/k8s-prow/hook:v20230412-a86d65c3c2
+          image: gcr.io/k8s-prow/hook:v20230505-3fedf7ef10
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: horologium
-          image: gcr.io/k8s-prow/horologium:v20230412-a86d65c3c2
+          image: gcr.io/k8s-prow/horologium:v20230505-3fedf7ef10
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/label_sync_cron_job.yaml
+++ b/config/prow/cluster/label_sync_cron_job.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20230412-a86d65c3c2
+              image: gcr.io/k8s-prow/label_sync:v20230505-3fedf7ef10
               args:
                 - --config=/etc/config/labels.yaml
                 - --confirm=true

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - --github-endpoint=https://api.github.com
             - --enable-controller=plank
             - --job-config-path=/etc/job-config
-          image: gcr.io/k8s-prow/prow-controller-manager:v20230412-a86d65c3c2
+          image: gcr.io/k8s-prow/prow-controller-manager:v20230505-3fedf7ef10
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG

--- a/config/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -475,6 +475,13 @@ spec:
                             description: CommitLink links to the commit identified
                               by the SHA.
                             type: string
+                          head_ref:
+                            description: 'HeadRef is the git ref (branch name) of
+                              the proposed change.  This can be more human-readable
+                              than just a PR #, and some tools want this metadata
+                              to help associate the work with a pull request (e.g.
+                              some code scanning services, or chromatic.com).'
+                            type: string
                           link:
                             description: Link links to the pull request itself.
                             type: string
@@ -21382,6 +21389,13 @@ spec:
                         commit_link:
                           description: CommitLink links to the commit identified by
                             the SHA.
+                          type: string
+                        head_ref:
+                          description: 'HeadRef is the git ref (branch name) of the
+                            proposed change.  This can be more human-readable than
+                            just a PR #, and some tools want this metadata to help
+                            associate the work with a pull request (e.g. some code
+                            scanning services, or chromatic.com).'
                           type: string
                         link:
                           description: Link links to the pull request itself.

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
         - name: sinker
-          image: gcr.io/k8s-prow/sinker:v20230412-a86d65c3c2
+          image: gcr.io/k8s-prow/sinker:v20230505-3fedf7ef10
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20230412-a86d65c3c2
+          image: gcr.io/k8s-prow/status-reconciler:v20230505-3fedf7ef10
           args:
             - --dry-run=false
             - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: gcr.io/k8s-prow/tide:v20230412-a86d65c3c2
+          image: gcr.io/k8s-prow/tide:v20230505-3fedf7ef10
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -77,10 +77,10 @@ plank:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20230412-a86d65c3c2
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20230412-a86d65c3c2
-        initupload: gcr.io/k8s-prow/initupload:v20230412-a86d65c3c2
-        sidecar: gcr.io/k8s-prow/sidecar:v20230412-a86d65c3c2
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20230505-3fedf7ef10
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20230505-3fedf7ef10
+        initupload: gcr.io/k8s-prow/initupload:v20230505-3fedf7ef10
+        sidecar: gcr.io/k8s-prow/sidecar:v20230505-3fedf7ef10
       ssh_key_secrets:
         - bot-ssh-secret
 


### PR DESCRIPTION
Including the change https://github.com/kubernetes/test-infra/commit/8acbda0b20d8952961a0cc6e7f28e4bb7dd36888
to Expose PR head ref name to prow jobs https://github.com/kubernetes/test-infra/pull/29309
The jobs are running fine after upgrade. Also no failure/error messages in prow component logs.
![image](https://user-images.githubusercontent.com/63038004/237018792-fea1f258-7ea4-453c-862d-28a1937520c0.png)
