### PR TITLE
Add keep_going flags and remove TEST_OPTS for etcd job

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
@@ -31,6 +31,8 @@ postsubmits:
                 tar -C /usr/local -xzf /tmp/golang.tar.gz
                 export PATH=/usr/local/go/bin:$PATH
                 export PATH=$GOPATH/bin:$PATH
+                export KEEP_GOING_MODULE=true
+                export KEEP_GOING_SUITE=true
                 go version
                 ./scripts/build.sh
-                GOARCH=`go env GOARCH` TEST_OPTS="PASSES='unit integration_e2e'" make test
+                GOARCH=`go env GOARCH` make test


### PR DESCRIPTION
Adding the env variables based on the below PRs. We have been having the job `postsubmit-master-golang-etcd-build-test-ppc64le`failing for a long time with inconsistent failures.
These keep_going flags would enable us to have a complete suite run and get a better understanding of failures.
https://github.com/etcd-io/etcd/pull/15813
https://github.com/etcd-io/etcd/pull/15839

Also removing the `TEST_OPTS` variable passed in the job yaml.
The Makefile at https://github.com/etcd-io/etcd/blob/main/Makefile does not use this variable and PASSES the suite names as per the definition in Makefile.