### PR TITLE
Fix the error with postsubmit-os-origin-build-golang-master-ppc64le job

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
@@ -66,6 +66,7 @@ postsubmits:
                 rm -rf /usr/local/go
                 tar -C /usr/local -xzf /tmp/golang.tar.gz
                 export PATH=/usr/local/go/bin:$PATH
+                export OPENSHIFT_SKIP_EXTERNAL_TESTS=true
                 make GO_REQUIRED_MIN_VERSION:= WHAT=cmd/openshift-tests
                 cp ./openshift-tests /usr/local/bin
                 openshift-tests help


### PR DESCRIPTION
The job ` postsubmit-os-origin-build-golang-master-ppc64le` started throwing below error since https://github.com/openshift/origin/pull/27570

```
+ openshift-tests run kubernetes/conformance --dry-run
  May 31 22:43:04.270: INFO: Enabling in-tree volume drivers
Attempting to pull tests from external binary...
  goroutine 1 [running]:
  runtime/debug.Stack()
  	runtime/debug/stack.go:24 +0x6c
  github.com/openshift/origin/test/extended/util.FatalErr({0x1703cfe0, 0xc0030baf90})
  	github.com/openshift/origin/test/extended/util/client.go:922 +0x3c
  github.com/openshift/origin/test/extended/util.(*CLI).AdminConfig(0x0?)
  	github.com/openshift/origin/test/extended/util/client.go:750 +0x58
  github.com/openshift/origin/test/extended/util.(*CLI).AdminConfigClient(0xc0030f5680)
  	github.com/openshift/origin/test/extended/util/client.go:663 +0x30
  github.com/openshift/origin/pkg/test/ginkgo.extractBinaryFromReleaseImage({0x17a59910, 0x9}, {0x17a88905, 0x12})
  	github.com/openshift/origin/pkg/test/ginkgo/external.go:77 +0xa8
  github.com/openshift/origin/pkg/test/ginkgo.externalTestsForSuite({0x18689750, 0x1bf09bc0})
  	github.com/openshift/origin/pkg/test/ginkgo/external.go:33 +0x58
  github.com/openshift/origin/pkg/test/ginkgo.(*Options).Run(0xc000cf4c40, 0x1b4de700, {0x17a75661, 0xf})
  	github.com/openshift/origin/pkg/test/ginkgo/cmd_runsuite.go:168 +0x210
  main.newRunCommand.func1.1()
  	github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:330 +0x298
  main.mirrorToFile(0x0?, 0x0?)
  	github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:467 +0xf0
  main.newRunCommand.func1(0xc000ce1800?, {0xc00063eb80?, 0x4?, 0x17a4af0b?})
  	github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:311 +0x88
  github.com/spf13/cobra.(*Command).execute(0xc000ae1800, {0xc00063eb60, 0x2, 0x2})
  	github.com/spf13/cobra@v1.6.0/command.go:916 +0x740
  github.com/spf13/cobra.(*Command).ExecuteC(0xc000ae1500)
  	github.com/spf13/cobra@v1.6.0/command.go:1040 +0x370
  github.com/spf13/cobra.(*Command).Execute(...)
  	github.com/spf13/cobra@v1.6.0/command.go:968
  main.main.func1(0xc000aa2600?)
  	github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:96 +0x8c
  main.main()
  	github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:97 +0x498

panic: [1m[38;5;9mYour Test Panicked[0m
```
**For now, exporting `OPENSHIFT_SKIP_EXTERNAL_TESTS=true` is avoiding this error.**

But the code at https://github.com/openshift/origin/blob/master/pkg/test/ginkgo/cmd_runsuite.go#L166-L168 has to be modified and made better to look for env variable and the corresponding adminconfig file for the openshift cluster required.
