### PR TITLE
Change the trigger schedule of periodic jobs

### DIFF
--- a/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
+++ b/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
@@ -9,7 +9,7 @@ periodics:
         bucket: ppc64le-kubernetes
         path_strategy: explicit
       gcs_credentials_secret: gcs-credentials
-    interval: 12h
+    cron: "0 9,21 * * *"
     extra_refs:
       - base_ref: main
         org: kubernetes-sigs
@@ -38,7 +38,7 @@ periodics:
         bucket: ppc64le-kubernetes
         path_strategy: explicit
       gcs_credentials_secret: gcs-credentials
-    interval: 24h
+    cron: "0 0 * * *"
     extra_refs:
       - base_ref: main
         org: kubernetes-sigs

--- a/config/jobs/periodic/golang/build-golang-periodics.yaml
+++ b/config/jobs/periodic/golang/build-golang-periodics.yaml
@@ -2,7 +2,7 @@ periodics:
   - name: periodic-golang-master-build-ppc64le
     cluster: k8s-ppc64le-cluster
     decorate: true
-    interval: 1h
+    cron: "50 1/1 * * *"
     spec:
       containers:
         - image: golang:1.17

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
         bucket: ppc64le-kubernetes
         path_strategy: explicit
       gcs_credentials_secret: gcs-credentials
-    interval: 3h
+    cron: "0 1/3 * * *"
     extra_refs:
       - base_ref: master
         org: kubernetes
@@ -49,7 +49,7 @@ periodics:
         bucket: ppc64le-kubernetes
         path_strategy: explicit
       gcs_credentials_secret: gcs-credentials
-    interval: 3h
+    cron: "0 2/3 * * *"
     extra_refs:
       - base_ref: master
         org: ppc64le-cloud


### PR DESCRIPTION
Changing the `interval` spec of periodic job to `cron` to distribute of the trigger of periodic jobs across different timestamps of a day.