### PR TITLE
Fix typo from PR #391

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
@@ -44,7 +44,7 @@ postsubmits:
                 export FORCE_HOST_GO=y
                 KUBE_BUILD_PLATFORMS=linux/ppc64le make cross
 
-                Check golang used for binary building
+                # Check golang used for binary building
                 go_version_bin=`go version _output/bin/kube-apiserver | cut -d ' ' -f3`
                 [[ "$go_version_env" == "$go_version_bin" ]] || { echo "The binary was not built with master go version"; exit 1; }
                 echo "The binaries are built with go version $go_version_bin"


### PR DESCRIPTION
This typo error is causing [`postsubmit-os-kubernetes-build-golang-master-ppc64le`](https://prow.ppc64le-cloud.org/job-history/s3/ppc64le-prow-logs/logs/postsubmit-os-kubernetes-build-golang-master-ppc64le) to fail.
@mkumatag Can you PTAL?
