### PR TITLE
Increase cpu limit to 5000m for k8s and etcd UT

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -18,9 +18,9 @@ periodics:
         - image: quay.io/powercloud/all-in-one:0.5
           resources:
             requests:
-              cpu: "4000m"
+              cpu: "5000m"
             limits:
-              cpu: "4000m"
+              cpu: "5000m"
           command:
             - /bin/bash
           args:

--- a/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
@@ -16,9 +16,9 @@ postsubmits:
           - image: quay.io/powercloud/all-in-one:0.5
             resources:
             requests:
-              cpu: "4000m"
+              cpu: "5000m"
             limits:
-              cpu: "4000m"
+              cpu: "5000m"
             command:
               - /bin/bash
             args:

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -77,9 +77,9 @@ postsubmits:
           - image: quay.io/powercloud/all-in-one:0.5
             resources:
               requests:
-                cpu: "4000m"
+                cpu: "5000m"
               limits:
-                cpu: "4000m"
+                cpu: "5000m"
             command:
               - /bin/bash
             args:


### PR DESCRIPTION
The k8s and etcd UT building jobs have been flaking with timeout and connection issues that seem to be improved if cpu allocation is increased.

The upstream is giving 4cpus in amd and arm cases. 5cpus here might be necessary on ppc to get rid of these flaky failures:

https://prow.ppc64le-cloud.org/job-history/gs/ppc64le-kubernetes/logs/periodic-kubernetes-unit-test-ppc64le
https://prow.ppc64le-cloud.org/job-history/s3/ppc64le-prow-logs/logs/postsubmit-master-golang-kubernetes-unit-test-ppc64le
https://prow.ppc64le-cloud.org/job-history/s3/ppc64le-prow-logs/logs/postsubmit-master-golang-etcd-build-test-ppc64le

