### PR TITLE
Upgrade Golang to 1.20.6 to fix master golang build failure

### DIFF
--- a/config/jobs/periodic/golang/build-golang-periodics.yaml
+++ b/config/jobs/periodic/golang/build-golang-periodics.yaml
@@ -5,7 +5,7 @@ periodics:
     cron: "50 1/1 * * *"
     spec:
       containers:
-        - image: golang:1.17
+        - image: golang:1.20.6
           resources:
             requests:
               cpu: "2000m"


### PR DESCRIPTION
`periodic-golang-master-build-ppc64le`  job has been failing with below error since yesterday:
```
found packages main (build.go) and building_Go_requires_Go_1_20_6_or_later (notgo120.go) in /root/go/src/cmd/dist
```
https://prow.ppc64le-cloud.org/job-history/s3/ppc64le-prow-logs/logs/periodic-golang-master-build-ppc64le

Upgrade to 1.20.6 has fixed the failure: https://prow.ppc64le-cloud.org/job-history/s3/ppc64le-prow-logs/logs/test-periodic-golang-master-build-ppc64le