### PR TITLE
Upgrade Prow infra to v20230801-2352e79673

### DIFF
--- a/config/prow/cluster/cherrypick_deployment.yaml
+++ b/config/prow/cluster/cherrypick_deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: cherrypick
-        image: gcr.io/k8s-prow/cherrypicker:v20230630-9eecc0f38f
+        image: gcr.io/k8s-prow/cherrypicker:v20230801-2352e79673
         args:
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: gcr.io/k8s-prow/crier:v20230630-9eecc0f38f
+          image: gcr.io/k8s-prow/crier:v20230801-2352e79673
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/crier_github_app_deployment.yaml
+++ b/config/prow/cluster/crier_github_app_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier2
-          image: gcr.io/k8s-prow/crier:v20230630-9eecc0f38f
+          image: gcr.io/k8s-prow/crier:v20230801-2352e79673
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: gcr.io/k8s-prow/deck:v20230630-9eecc0f38f
+          image: gcr.io/k8s-prow/deck:v20230801-2352e79673
           args:
             - --config-path=/etc/config/config.yaml
             - --plugin-config=/etc/plugins/plugins.yaml

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20230630-9eecc0f38f
+          image: gcr.io/k8s-prow/ghproxy:v20230801-2352e79673
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: gcr.io/k8s-prow/hook:v20230630-9eecc0f38f
+          image: gcr.io/k8s-prow/hook:v20230801-2352e79673
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/hook_github_app_deployment.yaml
+++ b/config/prow/cluster/hook_github_app_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook2
-          image: gcr.io/k8s-prow/hook:v20230630-9eecc0f38f
+          image: gcr.io/k8s-prow/hook:v20230801-2352e79673
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: horologium
-          image: gcr.io/k8s-prow/horologium:v20230630-9eecc0f38f
+          image: gcr.io/k8s-prow/horologium:v20230801-2352e79673
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/label_sync_cron_job.yaml
+++ b/config/prow/cluster/label_sync_cron_job.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20230630-9eecc0f38f
+              image: gcr.io/k8s-prow/label_sync:v20230801-2352e79673
               args:
                 - --config=/etc/config/labels.yaml
                 - --confirm=true

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - --github-endpoint=https://api.github.com
             - --enable-controller=plank
             - --job-config-path=/etc/job-config
-          image: gcr.io/k8s-prow/prow-controller-manager:v20230630-9eecc0f38f
+          image: gcr.io/k8s-prow/prow-controller-manager:v20230801-2352e79673
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG

--- a/config/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -159,6 +159,14 @@ spec:
                       service account that should be used by the pod if one is not
                       specified in the podspec.
                     type: string
+                  fs_group:
+                    description: FsGroup defines special supplemental group ID used
+                      in all containers in a Pod. This allows to change the ownership
+                      of particular volumes by kubelet. This field will not override
+                      the existing ProwJob's PodSecurityContext. Equivalent to PodSecurityContext's
+                      FsGroup
+                    format: int64
+                    type: integer
                   gcs_configuration:
                     description: GCSConfiguration holds options for pushing logs and
                       artifacts to GCS from a job.
@@ -385,6 +393,20 @@ spec:
                             type: object
                         type: object
                     type: object
+                  run_as_group:
+                    description: RunAsGroup defines GID of process in all containers
+                      running in a Pod. This field will not override the existing
+                      ProwJob's PodSecurityContext. Equivalent to PodSecurityContext's
+                      RunAsGroup
+                    format: int64
+                    type: integer
+                  run_as_user:
+                    description: RunAsUser defines UID for process in all containers
+                      running in a Pod. This field will not override the existing
+                      ProwJob's PodSecurityContext. Equivalent to PodSecurityContext's
+                      RunAsUser
+                    format: int64
+                    type: integer
                   s3_credentials_secret:
                     description: S3CredentialsSecret is the name of the Kubernetes
                       secret that holds blob storage push credentials.
@@ -585,19 +607,16 @@ spec:
                   params:
                     description: Params is a list of parameter names and values.
                     items:
-                      description: Param declares an ArrayOrString to use for the
-                        parameter called name.
+                      description: Param declares an ParamValues to use for the parameter
+                        called name.
                       properties:
                         name:
                           type: string
                         value:
-                          description: 'ArrayOrString is a type that can hold a single
+                          description: ParamValue is a type that can hold a single
                             string or string array. Used in JSON unmarshalling so
                             that a single JSON field can accept either an individual
-                            string or an array of strings. TODO (@chuangw6): This
-                            struct will be renamed or be embedded in a new struct
-                            to take into consideration the object case after the community
-                            reaches an agreement on it.'
+                            string or an array of strings.
                           properties:
                             arrayVal:
                               items:
@@ -626,68 +645,37 @@ spec:
                       - value
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   pipelineRef:
-                    description: 'PipelineRef can be used to refer to a specific instance
-                      of a Pipeline. Copied from CrossVersionObjectReference: https://github.com/kubernetes/kubernetes/blob/169df7434155cbbc22f1532cba8e0a9588e29ad8/pkg/apis/autoscaling/types.go#L64'
+                    description: PipelineRef can be used to refer to a specific instance
+                      of a Pipeline.
                     properties:
                       apiVersion:
                         description: API version of the referent
                         type: string
                       bundle:
-                        description: Bundle url reference to a Tekton Bundle.
+                        description: 'Bundle url reference to a Tekton Bundle. Deprecated:
+                          Please use ResolverRef with the bundles resolver instead.'
                         type: string
                       name:
                         description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                         type: string
-                      resolver:
-                        description: Resolver is the name of the resolver that should
-                          perform resolution of the referenced Tekton resource, such
-                          as "git".
-                        type: string
-                      resource:
-                        description: Resource contains the parameters used to identify
+                      params:
+                        description: Params contains the parameters used to identify
                           the referenced Tekton resource. Example entries might include
                           "repo" or "path" but the set of params ultimately depends
                           on the chosen resolver.
                         items:
-                          description: ResolverParam is a single parameter passed
-                            to a resolver.
+                          description: Param declares an ParamValues to use for the
+                            parameter called name.
                           properties:
                             name:
-                              description: Name is the name of the parameter that
-                                will be passed to the resolver.
                               type: string
                             value:
-                              description: Value is the string value of the parameter
-                                that will be passed to the resolver.
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                    type: object
-                  pipelineSpec:
-                    description: PipelineSpec defines the desired state of Pipeline.
-                    properties:
-                      description:
-                        description: Description is a user-facing description of the
-                          pipeline that may be used to populate a UI.
-                        type: string
-                      params:
-                        description: Params declares a list of input parameters that
-                          must be supplied when this Pipeline is run.
-                        items:
-                          description: ParamSpec defines arbitrary parameters needed
-                            beyond typed inputs (such as resources). Parameter values
-                            are provided by users as inputs on a TaskRun or PipelineRun.
-                          properties:
-                            default:
-                              description: Default is the value a parameter takes
-                                if no input value is supplied. If default is set,
-                                a Task may be executed without a supplied value for
-                                the parameter.
+                              description: ParamValue is a type that can hold a single
+                                string or string array. Used in JSON unmarshalling
+                                so that a single JSON field can accept either an individual
+                                string or an array of strings.
                               properties:
                                 arrayVal:
                                   items:
@@ -711,198 +699,91 @@ spec:
                               - stringVal
                               - type
                               type: object
-                            description:
-                              description: Description is a user-facing description
-                                of the parameter that may be used to populate a UI.
-                              type: string
-                            name:
-                              description: Name declares the name by which a parameter
-                                is referenced.
-                              type: string
-                            properties:
-                              additionalProperties:
-                                description: PropertySpec defines the struct for object
-                                  keys
-                                properties:
-                                  type:
-                                    description: ParamType indicates the type of an
-                                      input parameter; Used to distinguish between
-                                      a single string and an array of strings.
-                                    type: string
-                                type: object
-                              description: Properties is the JSON Schema properties
-                                to support key-value pairs parameter.
-                              type: object
-                            type:
-                              description: Type is the user-specified type of the
-                                parameter. The possible types are currently "string",
-                                "array" and "object", and "string" is the default.
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      resources:
-                        description: Resources declares the names and types of the
-                          resources given to the Pipeline's tasks as inputs and outputs.
-                        items:
-                          description: PipelineDeclaredResource is used by a Pipeline
-                            to declare the types of the PipelineResources that it
-                            will required to run and names which can be used to refer
-                            to these PipelineResources in PipelineTaskResourceBindings.
-                          properties:
-                            name:
-                              description: Name is the name that will be used by the
-                                Pipeline to refer to this resource. It does not directly
-                                correspond to the name of any PipelineResources Task
-                                inputs or outputs, and it does not correspond to the
-                                actual names of the PipelineResources that will be
-                                bound in the PipelineRun.
-                              type: string
-                            optional:
-                              description: 'Optional declares the resource as optional.
-                                optional: true - the resource is considered optional
-                                optional: false - the resource is considered required
-                                (default/equivalent of not specifying it)'
-                              type: boolean
-                            type:
-                              description: Type is the type of the PipelineResource.
-                              type: string
-                          required:
-                          - name
-                          - type
-                          type: object
-                        type: array
-                      results:
-                        description: Results are values that this pipeline can output
-                          once run
-                        items:
-                          description: PipelineResult used to describe the results
-                            of a pipeline
-                          properties:
-                            description:
-                              description: Description is a human-readable description
-                                of the result
-                              type: string
-                            name:
-                              description: Name the given name
-                              type: string
-                            value:
-                              description: Value the expression used to retrieve the
-                                value
-                              type: string
                           required:
                           - name
                           - value
                           type: object
                         type: array
-                      tasks:
-                        description: Tasks declares the graph of Tasks that execute
-                          when this Pipeline is run.
+                        x-kubernetes-list-type: atomic
+                      resolver:
+                        description: Resolver is the name of the resolver that should
+                          perform resolution of the referenced Tekton resource, such
+                          as "git".
+                        type: string
+                    type: object
+                  pipelineSpec:
+                    description: PipelineSpec defines the desired state of Pipeline.
+                    properties:
+                      description:
+                        description: Description is a user-facing description of the
+                          pipeline that may be used to populate a UI.
+                        type: string
+                      finally:
+                        description: Finally declares the list of Tasks that execute
+                          just before leaving the Pipeline i.e. either after all Tasks
+                          are finished executing successfully or after a failure which
+                          would result in ending the Pipeline
                         items:
                           description: PipelineTask defines a task in a Pipeline,
                             passing inputs from both Params and from the output of
                             previous tasks.
                           properties:
-                            conditions:
-                              description: Conditions is a list of conditions that
-                                need to be true for the task to run
-                              items:
-                                description: PipelineTaskCondition allows a PipelineTask
-                                  to declare a Condition to be evaluated before the
-                                  Task is run.
-                                properties:
-                                  conditionRef:
-                                    description: ConditionRef is the name of the Condition
-                                      to use for the conditionCheck
-                                    type: string
-                                  params:
-                                    description: Params declare parameters passed
-                                      to this Condition
-                                    items:
-                                      description: Param declares an ArrayOrString
-                                        to use for the parameter called name.
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          description: 'ArrayOrString is a type that
-                                            can hold a single string or string array.
-                                            Used in JSON unmarshalling so that a single
-                                            JSON field can accept either an individual
-                                            string or an array of strings. TODO (@chuangw6):
-                                            This struct will be renamed or be embedded
-                                            in a new struct to take into consideration
-                                            the object case after the community reaches
-                                            an agreement on it.'
-                                          properties:
-                                            arrayVal:
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                            objectVal:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                            stringVal:
+                            matrix:
+                              description: Matrix declares parameters used to fan
+                                out this task.
+                              properties:
+                                params:
+                                  description: Params is a list of parameters used
+                                    to fan out the pipelineTask Params takes only
+                                    `Parameters` of type `"array"` Each array element
+                                    is supplied to the `PipelineTask` by substituting
+                                    `params` of type `"string"` in the underlying
+                                    `Task`. The names of the `params` in the `Matrix`
+                                    must match the names of the `params` in the underlying
+                                    `Task` that they will be substituting.
+                                  items:
+                                    description: Param declares an ParamValues to
+                                      use for the parameter called name.
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        description: ParamValue is a type that can
+                                          hold a single string or string array. Used
+                                          in JSON unmarshalling so that a single JSON
+                                          field can accept either an individual string
+                                          or an array of strings.
+                                        properties:
+                                          arrayVal:
+                                            items:
                                               type: string
-                                            type:
-                                              description: ParamType indicates the
-                                                type of an input parameter; Used to
-                                                distinguish between a single string
-                                                and an array of strings.
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          objectVal:
+                                            additionalProperties:
                                               type: string
-                                          required:
-                                          - arrayVal
-                                          - objectVal
-                                          - stringVal
-                                          - type
-                                          type: object
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                  resources:
-                                    description: Resources declare the resources provided
-                                      to this Condition as input
-                                    items:
-                                      description: PipelineTaskInputResource maps
-                                        the name of a declared PipelineResource input
-                                        dependency in a Task to the resource in the
-                                        Pipeline's DeclaredPipelineResources that
-                                        should be used. This input may come from a
-                                        previous task.
-                                      properties:
-                                        from:
-                                          description: From is the list of PipelineTask
-                                            names that the resource has to come from.
-                                            (Implies an ordering in the execution
-                                            graph.)
-                                          items:
+                                            type: object
+                                          stringVal:
                                             type: string
-                                          type: array
-                                          x-kubernetes-list-type: atomic
-                                        name:
-                                          description: Name is the name of the PipelineResource
-                                            as declared by the Task.
-                                          type: string
-                                        resource:
-                                          description: Resource is the name of the
-                                            DeclaredPipelineResource to use.
-                                          type: string
-                                      required:
-                                      - name
-                                      - resource
-                                      type: object
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                required:
-                                - conditionRef
-                                type: object
-                              type: array
+                                          type:
+                                            description: ParamType indicates the type
+                                              of an input parameter; Used to distinguish
+                                              between a single string and an array
+                                              of strings.
+                                            type: string
+                                        required:
+                                        - arrayVal
+                                        - objectVal
+                                        - stringVal
+                                        - type
+                                        type: object
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
                             name:
                               description: Name is the name of this task within the
                                 context of a Pipeline. Name is used as a coordinate
@@ -913,20 +794,17 @@ spec:
                               description: Parameters declares parameters passed to
                                 this task.
                               items:
-                                description: Param declares an ArrayOrString to use
+                                description: Param declares an ParamValues to use
                                   for the parameter called name.
                                 properties:
                                   name:
                                     type: string
                                   value:
-                                    description: 'ArrayOrString is a type that can
-                                      hold a single string or string array. Used in
-                                      JSON unmarshalling so that a single JSON field
-                                      can accept either an individual string or an
-                                      array of strings. TODO (@chuangw6): This struct
-                                      will be renamed or be embedded in a new struct
-                                      to take into consideration the object case after
-                                      the community reaches an agreement on it.'
+                                    description: ParamValue is a type that can hold
+                                      a single string or string array. Used in JSON
+                                      unmarshalling so that a single JSON field can
+                                      accept either an individual string or an array
+                                      of strings.
                                     properties:
                                       arrayVal:
                                         items:
@@ -956,6 +834,7 @@ spec:
                                 - value
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             resources:
                               description: Resources declares the resources given
                                 to this task as inputs and outputs.
@@ -1031,6 +910,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             taskRef:
                               description: TaskRef is a reference to a task definition.
                               properties:
@@ -1038,7 +918,9 @@ spec:
                                   description: API version of the referent
                                   type: string
                                 bundle:
-                                  description: Bundle url reference to a Tekton Bundle.
+                                  description: 'Bundle url reference to a Tekton Bundle.
+                                    Deprecated: Please use ResolverRef with the bundles
+                                    resolver instead.'
                                   type: string
                                 kind:
                                   description: TaskKind indicates the kind of the
@@ -1047,254 +929,83 @@ spec:
                                 name:
                                   description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                   type: string
-                                resolver:
-                                  description: Resolver is the name of the resolver
-                                    that should perform resolution of the referenced
-                                    Tekton resource, such as "git".
-                                  type: string
-                                resource:
-                                  description: Resource contains the parameters used
+                                params:
+                                  description: Params contains the parameters used
                                     to identify the referenced Tekton resource. Example
                                     entries might include "repo" or "path" but the
                                     set of params ultimately depends on the chosen
                                     resolver.
                                   items:
-                                    description: ResolverParam is a single parameter
-                                      passed to a resolver.
+                                    description: Param declares an ParamValues to
+                                      use for the parameter called name.
                                     properties:
                                       name:
-                                        description: Name is the name of the parameter
-                                          that will be passed to the resolver.
                                         type: string
                                       value:
-                                        description: Value is the string value of
-                                          the parameter that will be passed to the
-                                          resolver.
-                                        type: string
+                                        description: ParamValue is a type that can
+                                          hold a single string or string array. Used
+                                          in JSON unmarshalling so that a single JSON
+                                          field can accept either an individual string
+                                          or an array of strings.
+                                        properties:
+                                          arrayVal:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          objectVal:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          stringVal:
+                                            type: string
+                                          type:
+                                            description: ParamType indicates the type
+                                              of an input parameter; Used to distinguish
+                                              between a single string and an array
+                                              of strings.
+                                            type: string
+                                        required:
+                                        - arrayVal
+                                        - objectVal
+                                        - stringVal
+                                        - type
+                                        type: object
                                     required:
                                     - name
                                     - value
                                     type: object
                                   type: array
                                   x-kubernetes-list-type: atomic
+                                resolver:
+                                  description: Resolver is the name of the resolver
+                                    that should perform resolution of the referenced
+                                    Tekton resource, such as "git".
+                                  type: string
                               type: object
                             taskSpec:
-                              description: TaskSpec is specification of a task
+                              description: TaskSpec is a specification of a task
                               properties:
+                                apiVersion:
+                                  type: string
                                 description:
                                   description: Description is a user-facing description
                                     of the task that may be used to populate a UI.
                                   type: string
-                                inputs:
-                                  description: Inputs is an optional set of parameters
-                                    and resources which must be supplied by the user
-                                    when a Task is executed by a TaskRun.
+                                kind:
+                                  type: string
+                                metadata:
+                                  description: PipelineTaskMetadata contains the labels
+                                    or annotations for an EmbeddedTask
                                   properties:
-                                    params:
-                                      description: Params is a list of input parameters
-                                        required to run the task. Params must be supplied
-                                        as inputs in TaskRuns unless they declare
-                                        a default value.
-                                      items:
-                                        description: ParamSpec defines arbitrary parameters
-                                          needed beyond typed inputs (such as resources).
-                                          Parameter values are provided by users as
-                                          inputs on a TaskRun or PipelineRun.
-                                        properties:
-                                          default:
-                                            description: Default is the value a parameter
-                                              takes if no input value is supplied.
-                                              If default is set, a Task may be executed
-                                              without a supplied value for the parameter.
-                                            properties:
-                                              arrayVal:
-                                                items:
-                                                  type: string
-                                                type: array
-                                                x-kubernetes-list-type: atomic
-                                              objectVal:
-                                                additionalProperties:
-                                                  type: string
-                                                type: object
-                                              stringVal:
-                                                type: string
-                                              type:
-                                                description: ParamType indicates the
-                                                  type of an input parameter; Used
-                                                  to distinguish between a single
-                                                  string and an array of strings.
-                                                type: string
-                                            required:
-                                            - arrayVal
-                                            - objectVal
-                                            - stringVal
-                                            - type
-                                            type: object
-                                          description:
-                                            description: Description is a user-facing
-                                              description of the parameter that may
-                                              be used to populate a UI.
-                                            type: string
-                                          name:
-                                            description: Name declares the name by
-                                              which a parameter is referenced.
-                                            type: string
-                                          properties:
-                                            additionalProperties:
-                                              description: PropertySpec defines the
-                                                struct for object keys
-                                              properties:
-                                                type:
-                                                  description: ParamType indicates
-                                                    the type of an input parameter;
-                                                    Used to distinguish between a
-                                                    single string and an array of
-                                                    strings.
-                                                  type: string
-                                              type: object
-                                            description: Properties is the JSON Schema
-                                              properties to support key-value pairs
-                                              parameter.
-                                            type: object
-                                          type:
-                                            description: Type is the user-specified
-                                              type of the parameter. The possible
-                                              types are currently "string", "array"
-                                              and "object", and "string" is the default.
-                                            type: string
-                                        required:
-                                        - name
-                                        type: object
-                                      type: array
-                                    resources:
-                                      description: Resources is a list of the input
-                                        resources required to run the task. Resources
-                                        are represented in TaskRuns as bindings to
-                                        instances of PipelineResources.
-                                      items:
-                                        description: TaskResource defines an input
-                                          or output Resource declared as a requirement
-                                          by a Task. The Name field will be used to
-                                          refer to these Resources within the Task
-                                          definition, and when provided as an Input,
-                                          the Name will be the path to the volume
-                                          mounted containing this Resource as an input
-                                          (e.g. an input Resource named `workspace`
-                                          will be mounted at `/workspace`).
-                                        properties:
-                                          description:
-                                            description: Description is a user-facing
-                                              description of the declared resource
-                                              that may be used to populate a UI.
-                                            type: string
-                                          name:
-                                            description: Name declares the name by
-                                              which a resource is referenced in the
-                                              definition. Resources may be referenced
-                                              by name in the definition of a Task's
-                                              steps.
-                                            type: string
-                                          optional:
-                                            description: 'Optional declares the resource
-                                              as optional. By default optional is
-                                              set to false which makes a resource
-                                              required. optional: true - the resource
-                                              is considered optional optional: false
-                                              - the resource is considered required
-                                              (equivalent of not specifying it)'
-                                            type: boolean
-                                          targetPath:
-                                            description: TargetPath is the path in
-                                              workspace directory where the resource
-                                              will be copied.
-                                            type: string
-                                          type:
-                                            description: Type is the type of this
-                                              resource;
-                                            type: string
-                                        required:
-                                        - name
-                                        - type
-                                        type: object
-                                      type: array
-                                  type: object
-                                outputs:
-                                  description: Outputs is an optional set of resources
-                                    and results produced when this Task is run.
-                                  properties:
-                                    resources:
-                                      items:
-                                        description: TaskResource defines an input
-                                          or output Resource declared as a requirement
-                                          by a Task. The Name field will be used to
-                                          refer to these Resources within the Task
-                                          definition, and when provided as an Input,
-                                          the Name will be the path to the volume
-                                          mounted containing this Resource as an input
-                                          (e.g. an input Resource named `workspace`
-                                          will be mounted at `/workspace`).
-                                        properties:
-                                          description:
-                                            description: Description is a user-facing
-                                              description of the declared resource
-                                              that may be used to populate a UI.
-                                            type: string
-                                          name:
-                                            description: Name declares the name by
-                                              which a resource is referenced in the
-                                              definition. Resources may be referenced
-                                              by name in the definition of a Task's
-                                              steps.
-                                            type: string
-                                          optional:
-                                            description: 'Optional declares the resource
-                                              as optional. By default optional is
-                                              set to false which makes a resource
-                                              required. optional: true - the resource
-                                              is considered optional optional: false
-                                              - the resource is considered required
-                                              (equivalent of not specifying it)'
-                                            type: boolean
-                                          targetPath:
-                                            description: TargetPath is the path in
-                                              workspace directory where the resource
-                                              will be copied.
-                                            type: string
-                                          type:
-                                            description: Type is the type of this
-                                              resource;
-                                            type: string
-                                        required:
-                                        - name
-                                        - type
-                                        type: object
-                                      type: array
-                                    results:
-                                      items:
-                                        description: TestResult allows a task to specify
-                                          the location where test logs can be found
-                                          and what format they will be in.
-                                        properties:
-                                          format:
-                                            description: 'TODO: maybe this is an enum
-                                              with types like "go test", "junit",
-                                              etc.'
-                                            type: string
-                                          name:
-                                            description: Name declares the name by
-                                              which a result is referenced in the
-                                              Task's definition. Results may be referenced
-                                              by name in the definition of a Task's
-                                              steps.
-                                            type: string
-                                          path:
-                                            type: string
-                                        required:
-                                        - format
-                                        - name
-                                        - path
-                                        type: object
-                                      type: array
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
                                   type: object
                                 params:
                                   description: Params is a list of input parameters
@@ -1495,6 +1206,21 @@ spec:
                                       name:
                                         description: Name the given name
                                         type: string
+                                      properties:
+                                        additionalProperties:
+                                          description: PropertySpec defines the struct
+                                            for object keys
+                                          properties:
+                                            type:
+                                              description: ParamType indicates the
+                                                type of an input parameter; Used to
+                                                distinguish between a single string
+                                                and an array of strings.
+                                              type: string
+                                          type: object
+                                        description: Properties is the JSON Schema
+                                          properties to support key-value pairs results.
+                                        type: object
                                       type:
                                         description: Type is the user-specified type
                                           of the result. The possible type is currently
@@ -1517,8 +1243,8 @@ spec:
                                     properties:
                                       args:
                                         description: 'Arguments to the entrypoint.
-                                          The docker image''s CMD is used if this
-                                          is not provided. Variable references $(VAR_NAME)
+                                          The image''s CMD is used if this is not
+                                          provided. Variable references $(VAR_NAME)
                                           are expanded using the container''s environment.
                                           If a variable cannot be resolved, the reference
                                           in the input string will be unchanged. Double
@@ -1535,10 +1261,10 @@ spec:
                                         x-kubernetes-list-type: atomic
                                       command:
                                         description: 'Entrypoint array. Not executed
-                                          within a shell. The docker image''s ENTRYPOINT
+                                          within a shell. The image''s ENTRYPOINT
                                           is used if this is not provided. Variable
                                           references $(VAR_NAME) are expanded using
-                                          the container''s environment. If a variable
+                                          the Sidecar''s environment. If a variable
                                           cannot be resolved, the reference in the
                                           input string will be unchanged. Double $$
                                           are reduced to a single $, which allows
@@ -1554,7 +1280,7 @@ spec:
                                         x-kubernetes-list-type: atomic
                                       env:
                                         description: List of environment variables
-                                          to set in the container. Cannot be updated.
+                                          to set in the Sidecar. Cannot be updated.
                                         items:
                                           description: EnvVar represents an environment
                                             variable present in a Container.
@@ -1687,10 +1413,10 @@ spec:
                                         x-kubernetes-list-type: atomic
                                       envFrom:
                                         description: List of sources to populate environment
-                                          variables in the container. The keys defined
+                                          variables in the Sidecar. The keys defined
                                           within a source must be a C_IDENTIFIER.
                                           All invalid keys will be reported as an
-                                          event when the container is starting. When
+                                          event when the Sidecar is starting. When
                                           a key exists in multiple sources, the value
                                           associated with the last source will take
                                           precedence. Values defined by an Env with
@@ -1738,12 +1464,8 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       image:
-                                        description: 'Docker image name. More info:
-                                          https://kubernetes.io/docs/concepts/containers/images
-                                          This field is optional to allow higher level
-                                          config management to default or override
-                                          container images in workload controllers
-                                          like Deployments and StatefulSets.'
+                                        description: 'Image name to be used by the
+                                          Sidecar. More info: https://kubernetes.io/docs/concepts/containers/images'
                                         type: string
                                       imagePullPolicy:
                                         description: 'Image pull policy. One of Always,
@@ -1754,7 +1476,7 @@ spec:
                                         type: string
                                       lifecycle:
                                         description: Actions that the management system
-                                          should take in response to container lifecycle
+                                          should take in response to Sidecar lifecycle
                                           events. Cannot be updated.
                                         properties:
                                           postStart:
@@ -1992,10 +1714,9 @@ spec:
                                             type: object
                                         type: object
                                       livenessProbe:
-                                        description: 'Periodic probe of container
-                                          liveness. Container will be restarted if
-                                          the probe fails. Cannot be updated. More
-                                          info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Periodic probe of Sidecar liveness.
+                                          Container will be restarted if the probe
+                                          fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2171,14 +1892,14 @@ spec:
                                             type: integer
                                         type: object
                                       name:
-                                        description: Name of the container specified
-                                          as a DNS_LABEL. Each container in a pod
-                                          must have a unique name (DNS_LABEL). Cannot
-                                          be updated.
+                                        description: Name of the Sidecar specified
+                                          as a DNS_LABEL. Each Sidecar in a Task must
+                                          have a unique name (DNS_LABEL). Cannot be
+                                          updated.
                                         type: string
                                       ports:
                                         description: List of ports to expose from
-                                          the container. Exposing a port here gives
+                                          the Sidecar. Exposing a port here gives
                                           the system additional information about
                                           the network connections a container uses,
                                           but is primarily informational. Not specifying
@@ -2233,10 +1954,10 @@ spec:
                                         - protocol
                                         x-kubernetes-list-type: map
                                       readinessProbe:
-                                        description: 'Periodic probe of container
-                                          service readiness. Container will be removed
-                                          from service endpoints if the probe fails.
-                                          Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Periodic probe of Sidecar service
+                                          readiness. Container will be removed from
+                                          service endpoints if the probe fails. Cannot
+                                          be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2413,8 +2134,8 @@ spec:
                                         type: object
                                       resources:
                                         description: 'Compute Resources required by
-                                          this container. Cannot be updated. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          this Sidecar. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -2450,8 +2171,8 @@ spec:
                                         type: string
                                       securityContext:
                                         description: 'SecurityContext defines the
-                                          security options the container should be
-                                          run with. If set, the fields of SecurityContext
+                                          security options the Sidecar should be run
+                                          with. If set, the fields of SecurityContext
                                           override the equivalent fields of PodSecurityContext.
                                           More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                         properties:
@@ -2663,10 +2384,10 @@ spec:
                                         type: object
                                       startupProbe:
                                         description: 'StartupProbe indicates that
-                                          the Pod has successfully initialized. If
-                                          specified, no other probes are executed
-                                          until this completes successfully. If this
-                                          probe fails, the Pod will be restarted,
+                                          the Pod the Sidecar is running in has successfully
+                                          initialized. If specified, no other probes
+                                          are executed until this completes successfully.
+                                          If this probe fails, the Pod will be restarted,
                                           just as if the livenessProbe failed. This
                                           can be used to provide different probe parameters
                                           at the beginning of a Pod''s lifecycle,
@@ -2849,11 +2570,11 @@ spec:
                                             type: integer
                                         type: object
                                       stdin:
-                                        description: Whether this container should
-                                          allocate a buffer for stdin in the container
-                                          runtime. If this is not set, reads from
-                                          stdin in the container will always result
-                                          in EOF. Default is false.
+                                        description: Whether this Sidecar should allocate
+                                          a buffer for stdin in the container runtime.
+                                          If this is not set, reads from stdin in
+                                          the Sidecar will always result in EOF. Default
+                                          is false.
                                         type: boolean
                                       stdinOnce:
                                         description: Whether the container runtime
@@ -2862,20 +2583,20 @@ spec:
                                           stdin is true the stdin stream will remain
                                           open across multiple attach sessions. If
                                           stdinOnce is set to true, stdin is opened
-                                          on container start, is empty until the first
+                                          on Sidecar start, is empty until the first
                                           client attaches to stdin, and then remains
                                           open and accepts data until the client disconnects,
                                           at which time stdin is closed and remains
-                                          closed until the container is restarted.
-                                          If this flag is false, a container processes
+                                          closed until the Sidecar is restarted. If
+                                          this flag is false, a container processes
                                           that reads from stdin will never receive
                                           an EOF. Default is false
                                         type: boolean
                                       terminationMessagePath:
                                         description: 'Optional: Path at which the
-                                          file to which the container''s termination
+                                          file to which the Sidecar''s termination
                                           message will be written is mounted into
-                                          the container''s filesystem. Message written
+                                          the Sidecar''s filesystem. Message written
                                           is intended to be brief final status, such
                                           as an assertion failure message. Will be
                                           truncated by the node if greater than 4096
@@ -2887,23 +2608,23 @@ spec:
                                         description: Indicate how the termination
                                           message should be populated. File will use
                                           the contents of terminationMessagePath to
-                                          populate the container status message on
-                                          both success and failure. FallbackToLogsOnError
-                                          will use the last chunk of container log
-                                          output if the termination message file is
-                                          empty and the container exited with an error.
-                                          The log output is limited to 2048 bytes
-                                          or 80 lines, whichever is smaller. Defaults
-                                          to File. Cannot be updated.
+                                          populate the Sidecar status message on both
+                                          success and failure. FallbackToLogsOnError
+                                          will use the last chunk of Sidecar log output
+                                          if the termination message file is empty
+                                          and the Sidecar exited with an error. The
+                                          log output is limited to 2048 bytes or 80
+                                          lines, whichever is smaller. Defaults to
+                                          File. Cannot be updated.
                                         type: string
                                       tty:
-                                        description: Whether this container should
-                                          allocate a TTY for itself, also requires
-                                          'stdin' to be true. Default is false.
+                                        description: Whether this Sidecar should allocate
+                                          a TTY for itself, also requires 'stdin'
+                                          to be true. Default is false.
                                         type: boolean
                                       volumeDevices:
                                         description: volumeDevices is the list of
-                                          block devices to be used by the container.
+                                          block devices to be used by the Sidecar.
                                         items:
                                           description: volumeDevice describes a mapping
                                             of a raw block device within a container.
@@ -2925,8 +2646,8 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       volumeMounts:
-                                        description: Pod volumes to mount into the
-                                          container's filesystem. Cannot be updated.
+                                        description: Volumes to mount into the Sidecar's
+                                          filesystem. Cannot be updated.
                                         items:
                                           description: VolumeMount describes a mounting
                                             of a Volume within a container.
@@ -2975,7 +2696,7 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       workingDir:
-                                        description: Container's working directory.
+                                        description: Sidecar's working directory.
                                           If not specified, the container runtime's
                                           default will be used, which might be configured
                                           in the container image. Cannot be updated.
@@ -3019,6 +2740,10 @@ spec:
                                     type: object
                                   type: array
                                   x-kubernetes-list-type: atomic
+                                spec:
+                                  description: Spec is a specification of a custom
+                                    task
+                                  type: object
                                 stepTemplate:
                                   description: StepTemplate can be used as the basis
                                     for all step containers within the Task, so that
@@ -3026,18 +2751,17 @@ spec:
                                   properties:
                                     args:
                                       description: 'Arguments to the entrypoint. The
-                                        docker image''s CMD is used if this is not
-                                        provided. Variable references $(VAR_NAME)
-                                        are expanded using the container''s environment.
-                                        If a variable cannot be resolved, the reference
-                                        in the input string will be unchanged. Double
-                                        $$ are reduced to a single $, which allows
-                                        for escaping the $(VAR_NAME) syntax: i.e.
-                                        "$$(VAR_NAME)" will produce the string literal
-                                        "$(VAR_NAME)". Escaped references will never
-                                        be expanded, regardless of whether the variable
-                                        exists or not. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                        image''s CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the Step''s environment. If a variable
+                                        cannot be resolved, the reference in the input
+                                        string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the
+                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded,
+                                        regardless of whether the variable exists
+                                        or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                       items:
                                         type: string
                                       type: array
@@ -3047,10 +2771,10 @@ spec:
                                         within a shell. The docker image''s ENTRYPOINT
                                         is used if this is not provided. Variable
                                         references $(VAR_NAME) are expanded using
-                                        the container''s environment. If a variable
-                                        cannot be resolved, the reference in the input
-                                        string will be unchanged. Double $$ are reduced
-                                        to a single $, which allows for escaping the
+                                        the Step''s environment. If a variable cannot
+                                        be resolved, the reference in the input string
+                                        will be unchanged. Double $$ are reduced to
+                                        a single $, which allows for escaping the
                                         $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
                                         produce the string literal "$(VAR_NAME)".
                                         Escaped references will never be expanded,
@@ -3190,14 +2914,14 @@ spec:
                                       x-kubernetes-list-type: atomic
                                     envFrom:
                                       description: List of sources to populate environment
-                                        variables in the container. The keys defined
-                                        within a source must be a C_IDENTIFIER. All
-                                        invalid keys will be reported as an event
-                                        when the container is starting. When a key
-                                        exists in multiple sources, the value associated
-                                        with the last source will take precedence.
-                                        Values defined by an Env with a duplicate
-                                        key will take precedence. Cannot be updated.
+                                        variables in the Step. The keys defined within
+                                        a source must be a C_IDENTIFIER. All invalid
+                                        keys will be reported as an event when the
+                                        container is starting. When a key exists in
+                                        multiple sources, the value associated with
+                                        the last source will take precedence. Values
+                                        defined by an Env with a duplicate key will
+                                        take precedence. Cannot be updated.
                                       items:
                                         description: EnvFromSource represents the
                                           source of a set of ConfigMaps
@@ -3239,8 +2963,8 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     image:
-                                      description: 'Docker image name. More info:
-                                        https://kubernetes.io/docs/concepts/containers/images
+                                      description: 'Default image name to use for
+                                        each Step. More info: https://kubernetes.io/docs/concepts/containers/images
                                         This field is optional to allow higher level
                                         config management to default or override container
                                         images in workload controllers like Deployments
@@ -3664,16 +3388,16 @@ spec:
                                       type: object
                                     name:
                                       description: Deprecated. This field will be
-                                        removed in a future release. DeprecatedName
-                                        of the container specified as a DNS_LABEL.
-                                        Each container in a pod must have a unique
-                                        name (DNS_LABEL). Cannot be updated.
+                                        removed in a future release. Default name
+                                        for each Step specified as a DNS_LABEL. Each
+                                        Step in a Task must have a unique name. Cannot
+                                        be updated.
                                       type: string
                                     ports:
                                       description: Deprecated. This field will be
                                         removed in a future release. List of ports
-                                        to expose from the container. Exposing a port
-                                        here gives the system additional information
+                                        to expose from the Step's container. Exposing
+                                        a port here gives the system additional information
                                         about the network connections a container
                                         uses, but is primarily informational. Not
                                         specifying a port here DOES NOT prevent that
@@ -3904,8 +3628,7 @@ spec:
                                       type: object
                                     resources:
                                       description: 'Compute Resources required by
-                                        this container. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        this Step. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -3935,10 +3658,10 @@ spec:
                                       type: object
                                     securityContext:
                                       description: 'SecurityContext defines the security
-                                        options the container should be run with.
-                                        If set, the fields of SecurityContext override
-                                        the equivalent fields of PodSecurityContext.
-                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                        options the Step should be run with. If set,
+                                        the fields of SecurityContext override the
+                                        equivalent fields of PodSecurityContext. More
+                                        info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                       properties:
                                         allowPrivilegeEscalation:
                                           description: 'AllowPrivilegeEscalation controls
@@ -4328,10 +4051,10 @@ spec:
                                     stdin:
                                       description: Deprecated. This field will be
                                         removed in a future release. Whether this
-                                        container should allocate a buffer for stdin
-                                        in the container runtime. If this is not set,
-                                        reads from stdin in the container will always
-                                        result in EOF. Default is false.
+                                        Step should allocate a buffer for stdin in
+                                        the container runtime. If this is not set,
+                                        reads from stdin in the Step will always result
+                                        in EOF. Default is false.
                                       type: boolean
                                     stdinOnce:
                                       description: Deprecated. This field will be
@@ -4351,42 +4074,25 @@ spec:
                                         false
                                       type: boolean
                                     terminationMessagePath:
-                                      description: 'Deprecated. This field will be
-                                        removed in a future release. Optional: Path
-                                        at which the file to which the container''s
-                                        termination message will be written is mounted
-                                        into the container''s filesystem. Message
-                                        written is intended to be brief final status,
-                                        such as an assertion failure message. Will
-                                        be truncated by the node if greater than 4096
-                                        bytes. The total message length across all
-                                        containers will be limited to 12kb. Defaults
-                                        to /dev/termination-log. Cannot be updated.'
+                                      description: Deprecated. This field will be
+                                        removed in a future release and cannot be
+                                        meaningfully used.
                                       type: string
                                     terminationMessagePolicy:
                                       description: Deprecated. This field will be
-                                        removed in a future release. Indicate how
-                                        the termination message should be populated.
-                                        File will use the contents of terminationMessagePath
-                                        to populate the container status message on
-                                        both success and failure. FallbackToLogsOnError
-                                        will use the last chunk of container log output
-                                        if the termination message file is empty and
-                                        the container exited with an error. The log
-                                        output is limited to 2048 bytes or 80 lines,
-                                        whichever is smaller. Defaults to File. Cannot
-                                        be updated.
+                                        removed in a future release and cannot be
+                                        meaningfully used.
                                       type: string
                                     tty:
                                       description: Deprecated. This field will be
                                         removed in a future release. Whether this
-                                        container should allocate a DeprecatedTTY
-                                        for itself, also requires 'stdin' to be true.
-                                        Default is false.
+                                        Step should allocate a DeprecatedTTY for itself,
+                                        also requires 'stdin' to be true. Default
+                                        is false.
                                       type: boolean
                                     volumeDevices:
                                       description: volumeDevices is the list of block
-                                        devices to be used by the container.
+                                        devices to be used by the Step.
                                       items:
                                         description: volumeDevice describes a mapping
                                           of a raw block device within a container.
@@ -4407,7 +4113,7 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     volumeMounts:
-                                      description: Pod volumes to mount into the container's
+                                      description: Volumes to mount into the Step's
                                         filesystem. Cannot be updated.
                                       items:
                                         description: VolumeMount describes a mounting
@@ -4457,10 +4163,10 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     workingDir:
-                                      description: Container's working directory.
-                                        If not specified, the container runtime's
-                                        default will be used, which might be configured
-                                        in the container image. Cannot be updated.
+                                      description: Step's working directory. If not
+                                        specified, the container runtime's default
+                                        will be used, which might be configured in
+                                        the container image. Cannot be updated.
                                       type: string
                                   required:
                                   - name
@@ -4474,8 +4180,8 @@ spec:
                                     properties:
                                       args:
                                         description: 'Arguments to the entrypoint.
-                                          The docker image''s CMD is used if this
-                                          is not provided. Variable references $(VAR_NAME)
+                                          The image''s CMD is used if this is not
+                                          provided. Variable references $(VAR_NAME)
                                           are expanded using the container''s environment.
                                           If a variable cannot be resolved, the reference
                                           in the input string will be unchanged. Double
@@ -4492,7 +4198,7 @@ spec:
                                         x-kubernetes-list-type: atomic
                                       command:
                                         description: 'Entrypoint array. Not executed
-                                          within a shell. The docker image''s ENTRYPOINT
+                                          within a shell. The image''s ENTRYPOINT
                                           is used if this is not provided. Variable
                                           references $(VAR_NAME) are expanded using
                                           the container''s environment. If a variable
@@ -4695,12 +4401,8 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       image:
-                                        description: 'Docker image name. More info:
-                                          https://kubernetes.io/docs/concepts/containers/images
-                                          This field is optional to allow higher level
-                                          config management to default or override
-                                          container images in workload controllers
-                                          like Deployments and StatefulSets.'
+                                        description: 'Image reference name to run
+                                          for this Step. More info: https://kubernetes.io/docs/concepts/containers/images'
                                         type: string
                                       imagePullPolicy:
                                         description: 'Image pull policy. One of Always,
@@ -4953,9 +4655,9 @@ spec:
                                       livenessProbe:
                                         description: 'Deprecated. This field will
                                           be removed in a future release. Periodic
-                                          probe of container liveness. Container will
-                                          be restarted if the probe fails. Cannot
-                                          be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          probe of container liveness. Step will be
+                                          restarted if the probe fails. Cannot be
+                                          updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -5131,28 +4833,23 @@ spec:
                                             type: integer
                                         type: object
                                       name:
-                                        description: Name of the container specified
-                                          as a DNS_LABEL. Each container in a pod
-                                          must have a unique name (DNS_LABEL). Cannot
-                                          be updated.
+                                        description: Name of the Step specified as
+                                          a DNS_LABEL. Each Step in a Task must have
+                                          a unique name.
                                         type: string
                                       onError:
                                         description: OnError defines the exiting behavior
                                           of a container on error can be set to [
-                                          continue | stopAndFail ] stopAndFail indicates
-                                          exit the taskRun if the container exits
-                                          with non-zero exit code continue indicates
-                                          continue executing the rest of the steps
-                                          irrespective of the container exit code
+                                          continue | stopAndFail ]
                                         type: string
                                       ports:
                                         description: Deprecated. This field will be
                                           removed in a future release. List of ports
-                                          to expose from the container. Exposing a
-                                          port here gives the system additional information
-                                          about the network connections a container
-                                          uses, but is primarily informational. Not
-                                          specifying a port here DOES NOT prevent
+                                          to expose from the Step's container. Exposing
+                                          a port here gives the system additional
+                                          information about the network connections
+                                          a container uses, but is primarily informational.
+                                          Not specifying a port here DOES NOT prevent
                                           that port from being exposed. Any port which
                                           is listening on the default "0.0.0.0" address
                                           inside a container will be accessible from
@@ -5205,7 +4902,7 @@ spec:
                                       readinessProbe:
                                         description: 'Deprecated. This field will
                                           be removed in a future release. Periodic
-                                          probe of container service readiness. Container
+                                          probe of container service readiness. Step
                                           will be removed from service endpoints if
                                           the probe fails. Cannot be updated. More
                                           info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
@@ -5385,8 +5082,8 @@ spec:
                                         type: object
                                       resources:
                                         description: 'Compute Resources required by
-                                          this container. Cannot be updated. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          this Step. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -5422,8 +5119,8 @@ spec:
                                         type: string
                                       securityContext:
                                         description: 'SecurityContext defines the
-                                          security options the container should be
-                                          run with. If set, the fields of SecurityContext
+                                          security options the Step should be run
+                                          with. If set, the fields of SecurityContext
                                           override the equivalent fields of PodSecurityContext.
                                           More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                         properties:
@@ -5636,17 +5333,17 @@ spec:
                                       startupProbe:
                                         description: 'Deprecated. This field will
                                           be removed in a future release. DeprecatedStartupProbe
-                                          indicates that the Pod has successfully
-                                          initialized. If specified, no other probes
-                                          are executed until this completes successfully.
-                                          If this probe fails, the Pod will be restarted,
-                                          just as if the livenessProbe failed. This
-                                          can be used to provide different probe parameters
-                                          at the beginning of a Pod''s lifecycle,
-                                          when it might take a long time to load data
-                                          or warm a cache, than during steady-state
-                                          operation. This cannot be updated. More
-                                          info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          indicates that the Pod this Step runs in
+                                          has successfully initialized. If specified,
+                                          no other probes are executed until this
+                                          completes successfully. If this probe fails,
+                                          the Pod will be restarted, just as if the
+                                          livenessProbe failed. This can be used to
+                                          provide different probe parameters at the
+                                          beginning of a Pod''s lifecycle, when it
+                                          might take a long time to load data or warm
+                                          a cache, than during steady-state operation.
+                                          This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -5821,6 +5518,15 @@ spec:
                                             format: int32
                                             type: integer
                                         type: object
+                                      stderrConfig:
+                                        description: Stores configuration for the
+                                          stderr stream of the step.
+                                        properties:
+                                          path:
+                                            description: Path to duplicate stdout
+                                              stream to on container's local filesystem.
+                                            type: string
+                                        type: object
                                       stdin:
                                         description: Deprecated. This field will be
                                           removed in a future release. Whether this
@@ -5846,33 +5552,24 @@ spec:
                                           processes that reads from stdin will never
                                           receive an EOF. Default is false
                                         type: boolean
+                                      stdoutConfig:
+                                        description: Stores configuration for the
+                                          stdout stream of the step.
+                                        properties:
+                                          path:
+                                            description: Path to duplicate stdout
+                                              stream to on container's local filesystem.
+                                            type: string
+                                        type: object
                                       terminationMessagePath:
-                                        description: 'Deprecated. This field will
-                                          be removed in a future release. Optional:
-                                          Path at which the file to which the container''s
-                                          termination message will be written is mounted
-                                          into the container''s filesystem. Message
-                                          written is intended to be brief final status,
-                                          such as an assertion failure message. Will
-                                          be truncated by the node if greater than
-                                          4096 bytes. The total message length across
-                                          all containers will be limited to 12kb.
-                                          Defaults to /dev/termination-log. Cannot
-                                          be updated.'
+                                        description: Deprecated. This field will be
+                                          removed in a future release and can't be
+                                          meaningfully used.
                                         type: string
                                       terminationMessagePolicy:
                                         description: Deprecated. This field will be
-                                          removed in a future release. Indicate how
-                                          the termination message should be populated.
-                                          File will use the contents of terminationMessagePath
-                                          to populate the container status message
-                                          on both success and failure. FallbackToLogsOnError
-                                          will use the last chunk of container log
-                                          output if the termination message file is
-                                          empty and the container exited with an error.
-                                          The log output is limited to 2048 bytes
-                                          or 80 lines, whichever is smaller. Defaults
-                                          to File. Cannot be updated.
+                                          removed in a future release and can't be
+                                          meaningfully used.
                                         type: string
                                       timeout:
                                         description: 'Timeout is the time after which
@@ -5889,7 +5586,7 @@ spec:
                                         type: boolean
                                       volumeDevices:
                                         description: volumeDevices is the list of
-                                          block devices to be used by the container.
+                                          block devices to be used by the Step.
                                         items:
                                           description: volumeDevice describes a mapping
                                             of a raw block device within a container.
@@ -5911,8 +5608,8 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       volumeMounts:
-                                        description: Pod volumes to mount into the
-                                          container's filesystem. Cannot be updated.
+                                        description: Volumes to mount into the Step's
+                                          filesystem. Cannot be updated.
                                         items:
                                           description: VolumeMount describes a mounting
                                             of a Volume within a container.
@@ -5961,9 +5658,9 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                       workingDir:
-                                        description: Container's working directory.
-                                          If not specified, the container runtime's
-                                          default will be used, which might be configured
+                                        description: Step's working directory. If
+                                          not specified, the container runtime's default
+                                          will be used, which might be configured
                                           in the container image. Cannot be updated.
                                         type: string
                                       workspaces:
@@ -7909,6 +7606,38 @@ spec:
                                 be less than 24h. Refer Go''s ParseDuration documentation
                                 for expected format: https://golang.org/pkg/time/#ParseDuration'
                               type: string
+                            when:
+                              description: WhenExpressions is a list of when expressions
+                                that need to be true for the task to run
+                              items:
+                                description: WhenExpression allows a PipelineTask
+                                  to declare expressions to be evaluated before the
+                                  Task is run to determine whether the Task should
+                                  be executed or skipped
+                                properties:
+                                  input:
+                                    description: Input is the string for guard checking
+                                      which can be a static input or an output from
+                                      a parent Task
+                                    type: string
+                                  operator:
+                                    description: Operator that represents an Input's
+                                      relationship to the values
+                                    type: string
+                                  values:
+                                    description: Values is an array of strings, which
+                                      is compared against the input, for guard checking
+                                      It must be non-empty
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - input
+                                - operator
+                                - values
+                                type: object
+                              type: array
                             workspaces:
                               description: Workspaces maps workspaces from the pipeline
                                 spec to the workspaces declared in the Task.
@@ -7935,8 +7664,7110 @@ spec:
                                 - name
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
+                      params:
+                        description: Params declares a list of input parameters that
+                          must be supplied when this Pipeline is run.
+                        items:
+                          description: ParamSpec defines arbitrary parameters needed
+                            beyond typed inputs (such as resources). Parameter values
+                            are provided by users as inputs on a TaskRun or PipelineRun.
+                          properties:
+                            default:
+                              description: Default is the value a parameter takes
+                                if no input value is supplied. If default is set,
+                                a Task may be executed without a supplied value for
+                                the parameter.
+                              properties:
+                                arrayVal:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                objectVal:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                stringVal:
+                                  type: string
+                                type:
+                                  description: ParamType indicates the type of an
+                                    input parameter; Used to distinguish between a
+                                    single string and an array of strings.
+                                  type: string
+                              required:
+                              - arrayVal
+                              - objectVal
+                              - stringVal
+                              - type
+                              type: object
+                            description:
+                              description: Description is a user-facing description
+                                of the parameter that may be used to populate a UI.
+                              type: string
+                            name:
+                              description: Name declares the name by which a parameter
+                                is referenced.
+                              type: string
+                            properties:
+                              additionalProperties:
+                                description: PropertySpec defines the struct for object
+                                  keys
+                                properties:
+                                  type:
+                                    description: ParamType indicates the type of an
+                                      input parameter; Used to distinguish between
+                                      a single string and an array of strings.
+                                    type: string
+                                type: object
+                              description: Properties is the JSON Schema properties
+                                to support key-value pairs parameter.
+                              type: object
+                            type:
+                              description: Type is the user-specified type of the
+                                parameter. The possible types are currently "string",
+                                "array" and "object", and "string" is the default.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      resources:
+                        description: Resources declares the names and types of the
+                          resources given to the Pipeline's tasks as inputs and outputs.
+                        items:
+                          description: PipelineDeclaredResource is used by a Pipeline
+                            to declare the types of the PipelineResources that it
+                            will required to run and names which can be used to refer
+                            to these PipelineResources in PipelineTaskResourceBindings.
+                          properties:
+                            name:
+                              description: Name is the name that will be used by the
+                                Pipeline to refer to this resource. It does not directly
+                                correspond to the name of any PipelineResources Task
+                                inputs or outputs, and it does not correspond to the
+                                actual names of the PipelineResources that will be
+                                bound in the PipelineRun.
+                              type: string
+                            optional:
+                              description: 'Optional declares the resource as optional.
+                                optional: true - the resource is considered optional
+                                optional: false - the resource is considered required
+                                (default/equivalent of not specifying it)'
+                              type: boolean
+                            type:
+                              description: Type is the type of the PipelineResource.
+                              type: string
+                          required:
+                          - name
+                          - type
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      results:
+                        description: Results are values that this pipeline can output
+                          once run
+                        items:
+                          description: PipelineResult used to describe the results
+                            of a pipeline
+                          properties:
+                            description:
+                              description: Description is a human-readable description
+                                of the result
+                              type: string
+                            name:
+                              description: Name the given name
+                              type: string
+                            type:
+                              description: Type is the user-specified type of the
+                                result. The possible types are 'string', 'array',
+                                and 'object', with 'string' as the default. 'array'
+                                and 'object' types are alpha features.
+                              type: string
+                            value:
+                              description: Value the expression used to retrieve the
+                                value
+                              properties:
+                                arrayVal:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                objectVal:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                stringVal:
+                                  type: string
+                                type:
+                                  description: ParamType indicates the type of an
+                                    input parameter; Used to distinguish between a
+                                    single string and an array of strings.
+                                  type: string
+                              required:
+                              - arrayVal
+                              - objectVal
+                              - stringVal
+                              - type
+                              type: object
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      tasks:
+                        description: Tasks declares the graph of Tasks that execute
+                          when this Pipeline is run.
+                        items:
+                          description: PipelineTask defines a task in a Pipeline,
+                            passing inputs from both Params and from the output of
+                            previous tasks.
+                          properties:
+                            matrix:
+                              description: Matrix declares parameters used to fan
+                                out this task.
+                              properties:
+                                params:
+                                  description: Params is a list of parameters used
+                                    to fan out the pipelineTask Params takes only
+                                    `Parameters` of type `"array"` Each array element
+                                    is supplied to the `PipelineTask` by substituting
+                                    `params` of type `"string"` in the underlying
+                                    `Task`. The names of the `params` in the `Matrix`
+                                    must match the names of the `params` in the underlying
+                                    `Task` that they will be substituting.
+                                  items:
+                                    description: Param declares an ParamValues to
+                                      use for the parameter called name.
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        description: ParamValue is a type that can
+                                          hold a single string or string array. Used
+                                          in JSON unmarshalling so that a single JSON
+                                          field can accept either an individual string
+                                          or an array of strings.
+                                        properties:
+                                          arrayVal:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          objectVal:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          stringVal:
+                                            type: string
+                                          type:
+                                            description: ParamType indicates the type
+                                              of an input parameter; Used to distinguish
+                                              between a single string and an array
+                                              of strings.
+                                            type: string
+                                        required:
+                                        - arrayVal
+                                        - objectVal
+                                        - stringVal
+                                        - type
+                                        type: object
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            name:
+                              description: Name is the name of this task within the
+                                context of a Pipeline. Name is used as a coordinate
+                                with the `from` and `runAfter` fields to establish
+                                the execution order of tasks relative to one another.
+                              type: string
+                            params:
+                              description: Parameters declares parameters passed to
+                                this task.
+                              items:
+                                description: Param declares an ParamValues to use
+                                  for the parameter called name.
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    description: ParamValue is a type that can hold
+                                      a single string or string array. Used in JSON
+                                      unmarshalling so that a single JSON field can
+                                      accept either an individual string or an array
+                                      of strings.
+                                    properties:
+                                      arrayVal:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      objectVal:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      stringVal:
+                                        type: string
+                                      type:
+                                        description: ParamType indicates the type
+                                          of an input parameter; Used to distinguish
+                                          between a single string and an array of
+                                          strings.
+                                        type: string
+                                    required:
+                                    - arrayVal
+                                    - objectVal
+                                    - stringVal
+                                    - type
+                                    type: object
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            resources:
+                              description: Resources declares the resources given
+                                to this task as inputs and outputs.
+                              properties:
+                                inputs:
+                                  description: Inputs holds the mapping from the PipelineResources
+                                    declared in DeclaredPipelineResources to the input
+                                    PipelineResources required by the Task.
+                                  items:
+                                    description: PipelineTaskInputResource maps the
+                                      name of a declared PipelineResource input dependency
+                                      in a Task to the resource in the Pipeline's
+                                      DeclaredPipelineResources that should be used.
+                                      This input may come from a previous task.
+                                    properties:
+                                      from:
+                                        description: From is the list of PipelineTask
+                                          names that the resource has to come from.
+                                          (Implies an ordering in the execution graph.)
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      name:
+                                        description: Name is the name of the PipelineResource
+                                          as declared by the Task.
+                                        type: string
+                                      resource:
+                                        description: Resource is the name of the DeclaredPipelineResource
+                                          to use.
+                                        type: string
+                                    required:
+                                    - name
+                                    - resource
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                outputs:
+                                  description: Outputs holds the mapping from the
+                                    PipelineResources declared in DeclaredPipelineResources
+                                    to the input PipelineResources required by the
+                                    Task.
+                                  items:
+                                    description: PipelineTaskOutputResource maps the
+                                      name of a declared PipelineResource output dependency
+                                      in a Task to the resource in the Pipeline's
+                                      DeclaredPipelineResources that should be used.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the PipelineResource
+                                          as declared by the Task.
+                                        type: string
+                                      resource:
+                                        description: Resource is the name of the DeclaredPipelineResource
+                                          to use.
+                                        type: string
+                                    required:
+                                    - name
+                                    - resource
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            retries:
+                              description: 'Retries represents how many times this
+                                task should be retried in case of task failure: ConditionSucceeded
+                                set to False'
+                              type: integer
+                            runAfter:
+                              description: RunAfter is the list of PipelineTask names
+                                that should be executed before this Task executes.
+                                (Used to force a specific ordering in graph execution.)
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            taskRef:
+                              description: TaskRef is a reference to a task definition.
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent
+                                  type: string
+                                bundle:
+                                  description: 'Bundle url reference to a Tekton Bundle.
+                                    Deprecated: Please use ResolverRef with the bundles
+                                    resolver instead.'
+                                  type: string
+                                kind:
+                                  description: TaskKind indicates the kind of the
+                                    task, namespaced or cluster scoped.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                  type: string
+                                params:
+                                  description: Params contains the parameters used
+                                    to identify the referenced Tekton resource. Example
+                                    entries might include "repo" or "path" but the
+                                    set of params ultimately depends on the chosen
+                                    resolver.
+                                  items:
+                                    description: Param declares an ParamValues to
+                                      use for the parameter called name.
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        description: ParamValue is a type that can
+                                          hold a single string or string array. Used
+                                          in JSON unmarshalling so that a single JSON
+                                          field can accept either an individual string
+                                          or an array of strings.
+                                        properties:
+                                          arrayVal:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          objectVal:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          stringVal:
+                                            type: string
+                                          type:
+                                            description: ParamType indicates the type
+                                              of an input parameter; Used to distinguish
+                                              between a single string and an array
+                                              of strings.
+                                            type: string
+                                        required:
+                                        - arrayVal
+                                        - objectVal
+                                        - stringVal
+                                        - type
+                                        type: object
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                resolver:
+                                  description: Resolver is the name of the resolver
+                                    that should perform resolution of the referenced
+                                    Tekton resource, such as "git".
+                                  type: string
+                              type: object
+                            taskSpec:
+                              description: TaskSpec is a specification of a task
+                              properties:
+                                apiVersion:
+                                  type: string
+                                description:
+                                  description: Description is a user-facing description
+                                    of the task that may be used to populate a UI.
+                                  type: string
+                                kind:
+                                  type: string
+                                metadata:
+                                  description: PipelineTaskMetadata contains the labels
+                                    or annotations for an EmbeddedTask
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                params:
+                                  description: Params is a list of input parameters
+                                    required to run the task. Params must be supplied
+                                    as inputs in TaskRuns unless they declare a default
+                                    value.
+                                  items:
+                                    description: ParamSpec defines arbitrary parameters
+                                      needed beyond typed inputs (such as resources).
+                                      Parameter values are provided by users as inputs
+                                      on a TaskRun or PipelineRun.
+                                    properties:
+                                      default:
+                                        description: Default is the value a parameter
+                                          takes if no input value is supplied. If
+                                          default is set, a Task may be executed without
+                                          a supplied value for the parameter.
+                                        properties:
+                                          arrayVal:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          objectVal:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          stringVal:
+                                            type: string
+                                          type:
+                                            description: ParamType indicates the type
+                                              of an input parameter; Used to distinguish
+                                              between a single string and an array
+                                              of strings.
+                                            type: string
+                                        required:
+                                        - arrayVal
+                                        - objectVal
+                                        - stringVal
+                                        - type
+                                        type: object
+                                      description:
+                                        description: Description is a user-facing
+                                          description of the parameter that may be
+                                          used to populate a UI.
+                                        type: string
+                                      name:
+                                        description: Name declares the name by which
+                                          a parameter is referenced.
+                                        type: string
+                                      properties:
+                                        additionalProperties:
+                                          description: PropertySpec defines the struct
+                                            for object keys
+                                          properties:
+                                            type:
+                                              description: ParamType indicates the
+                                                type of an input parameter; Used to
+                                                distinguish between a single string
+                                                and an array of strings.
+                                              type: string
+                                          type: object
+                                        description: Properties is the JSON Schema
+                                          properties to support key-value pairs parameter.
+                                        type: object
+                                      type:
+                                        description: Type is the user-specified type
+                                          of the parameter. The possible types are
+                                          currently "string", "array" and "object",
+                                          and "string" is the default.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                resources:
+                                  description: Resources is a list input and output
+                                    resource to run the task Resources are represented
+                                    in TaskRuns as bindings to instances of PipelineResources.
+                                  properties:
+                                    inputs:
+                                      description: Inputs holds the mapping from the
+                                        PipelineResources declared in DeclaredPipelineResources
+                                        to the input PipelineResources required by
+                                        the Task.
+                                      items:
+                                        description: TaskResource defines an input
+                                          or output Resource declared as a requirement
+                                          by a Task. The Name field will be used to
+                                          refer to these Resources within the Task
+                                          definition, and when provided as an Input,
+                                          the Name will be the path to the volume
+                                          mounted containing this Resource as an input
+                                          (e.g. an input Resource named `workspace`
+                                          will be mounted at `/workspace`).
+                                        properties:
+                                          description:
+                                            description: Description is a user-facing
+                                              description of the declared resource
+                                              that may be used to populate a UI.
+                                            type: string
+                                          name:
+                                            description: Name declares the name by
+                                              which a resource is referenced in the
+                                              definition. Resources may be referenced
+                                              by name in the definition of a Task's
+                                              steps.
+                                            type: string
+                                          optional:
+                                            description: 'Optional declares the resource
+                                              as optional. By default optional is
+                                              set to false which makes a resource
+                                              required. optional: true - the resource
+                                              is considered optional optional: false
+                                              - the resource is considered required
+                                              (equivalent of not specifying it)'
+                                            type: boolean
+                                          targetPath:
+                                            description: TargetPath is the path in
+                                              workspace directory where the resource
+                                              will be copied.
+                                            type: string
+                                          type:
+                                            description: Type is the type of this
+                                              resource;
+                                            type: string
+                                        required:
+                                        - name
+                                        - type
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    outputs:
+                                      description: Outputs holds the mapping from
+                                        the PipelineResources declared in DeclaredPipelineResources
+                                        to the input PipelineResources required by
+                                        the Task.
+                                      items:
+                                        description: TaskResource defines an input
+                                          or output Resource declared as a requirement
+                                          by a Task. The Name field will be used to
+                                          refer to these Resources within the Task
+                                          definition, and when provided as an Input,
+                                          the Name will be the path to the volume
+                                          mounted containing this Resource as an input
+                                          (e.g. an input Resource named `workspace`
+                                          will be mounted at `/workspace`).
+                                        properties:
+                                          description:
+                                            description: Description is a user-facing
+                                              description of the declared resource
+                                              that may be used to populate a UI.
+                                            type: string
+                                          name:
+                                            description: Name declares the name by
+                                              which a resource is referenced in the
+                                              definition. Resources may be referenced
+                                              by name in the definition of a Task's
+                                              steps.
+                                            type: string
+                                          optional:
+                                            description: 'Optional declares the resource
+                                              as optional. By default optional is
+                                              set to false which makes a resource
+                                              required. optional: true - the resource
+                                              is considered optional optional: false
+                                              - the resource is considered required
+                                              (equivalent of not specifying it)'
+                                            type: boolean
+                                          targetPath:
+                                            description: TargetPath is the path in
+                                              workspace directory where the resource
+                                              will be copied.
+                                            type: string
+                                          type:
+                                            description: Type is the type of this
+                                              resource;
+                                            type: string
+                                        required:
+                                        - name
+                                        - type
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                results:
+                                  description: Results are values that this Task can
+                                    output
+                                  items:
+                                    description: TaskResult used to describe the results
+                                      of a task
+                                    properties:
+                                      description:
+                                        description: Description is a human-readable
+                                          description of the result
+                                        type: string
+                                      name:
+                                        description: Name the given name
+                                        type: string
+                                      properties:
+                                        additionalProperties:
+                                          description: PropertySpec defines the struct
+                                            for object keys
+                                          properties:
+                                            type:
+                                              description: ParamType indicates the
+                                                type of an input parameter; Used to
+                                                distinguish between a single string
+                                                and an array of strings.
+                                              type: string
+                                          type: object
+                                        description: Properties is the JSON Schema
+                                          properties to support key-value pairs results.
+                                        type: object
+                                      type:
+                                        description: Type is the user-specified type
+                                          of the result. The possible type is currently
+                                          "string" and will support "array" in following
+                                          work.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                sidecars:
+                                  description: Sidecars are run alongside the Task's
+                                    step containers. They begin before the steps start
+                                    and end after the steps complete.
+                                  items:
+                                    description: Sidecar has nearly the same data
+                                      structure as Step but does not have the ability
+                                      to timeout.
+                                    properties:
+                                      args:
+                                        description: 'Arguments to the entrypoint.
+                                          The image''s CMD is used if this is not
+                                          provided. Variable references $(VAR_NAME)
+                                          are expanded using the container''s environment.
+                                          If a variable cannot be resolved, the reference
+                                          in the input string will be unchanged. Double
+                                          $$ are reduced to a single $, which allows
+                                          for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal
+                                          "$(VAR_NAME)". Escaped references will never
+                                          be expanded, regardless of whether the variable
+                                          exists or not. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      command:
+                                        description: 'Entrypoint array. Not executed
+                                          within a shell. The image''s ENTRYPOINT
+                                          is used if this is not provided. Variable
+                                          references $(VAR_NAME) are expanded using
+                                          the Sidecar''s environment. If a variable
+                                          cannot be resolved, the reference in the
+                                          input string will be unchanged. Double $$
+                                          are reduced to a single $, which allows
+                                          for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal
+                                          "$(VAR_NAME)". Escaped references will never
+                                          be expanded, regardless of whether the variable
+                                          exists or not. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      env:
+                                        description: List of environment variables
+                                          to set in the Sidecar. Cannot be updated.
+                                        items:
+                                          description: EnvVar represents an environment
+                                            variable present in a Container.
+                                          properties:
+                                            name:
+                                              description: Name of the environment
+                                                variable. Must be a C_IDENTIFIER.
+                                              type: string
+                                            value:
+                                              description: 'Variable references $(VAR_NAME)
+                                                are expanded using the previously
+                                                defined environment variables in the
+                                                container and any service environment
+                                                variables. If a variable cannot be
+                                                resolved, the reference in the input
+                                                string will be unchanged. Double $$
+                                                are reduced to a single $, which allows
+                                                for escaping the $(VAR_NAME) syntax:
+                                                i.e. "$$(VAR_NAME)" will produce the
+                                                string literal "$(VAR_NAME)". Escaped
+                                                references will never be expanded,
+                                                regardless of whether the variable
+                                                exists or not. Defaults to "".'
+                                              type: string
+                                            valueFrom:
+                                              description: Source for the environment
+                                                variable's value. Cannot be used if
+                                                value is not empty.
+                                              properties:
+                                                configMapKeyRef:
+                                                  description: Selects a key of a
+                                                    ConfigMap.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the ConfigMap or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                fieldRef:
+                                                  description: 'Selects a field of
+                                                    the pod: supports metadata.name,
+                                                    metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                                    `metadata.annotations[''<KEY>'']`,
+                                                    spec.nodeName, spec.serviceAccountName,
+                                                    status.hostIP, status.podIP, status.podIPs.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                resourceFieldRef:
+                                                  description: 'Selects a resource
+                                                    of the container: only resources
+                                                    limits and requests (limits.cpu,
+                                                    limits.memory, limits.ephemeral-storage,
+                                                    requests.cpu, requests.memory
+                                                    and requests.ephemeral-storage)
+                                                    are currently supported.'
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                                secretKeyRef:
+                                                  description: Selects a key of a
+                                                    secret in the pod's namespace
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                              type: object
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      envFrom:
+                                        description: List of sources to populate environment
+                                          variables in the Sidecar. The keys defined
+                                          within a source must be a C_IDENTIFIER.
+                                          All invalid keys will be reported as an
+                                          event when the Sidecar is starting. When
+                                          a key exists in multiple sources, the value
+                                          associated with the last source will take
+                                          precedence. Values defined by an Env with
+                                          a duplicate key will take precedence. Cannot
+                                          be updated.
+                                        items:
+                                          description: EnvFromSource represents the
+                                            source of a set of ConfigMaps
+                                          properties:
+                                            configMapRef:
+                                              description: The ConfigMap to select
+                                                from
+                                              properties:
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap must be defined
+                                                  type: boolean
+                                              type: object
+                                            prefix:
+                                              description: An optional identifier
+                                                to prepend to each key in the ConfigMap.
+                                                Must be a C_IDENTIFIER.
+                                              type: string
+                                            secretRef:
+                                              description: The Secret to select from
+                                              properties:
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret must be defined
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      image:
+                                        description: 'Image name to be used by the
+                                          Sidecar. More info: https://kubernetes.io/docs/concepts/containers/images'
+                                        type: string
+                                      imagePullPolicy:
+                                        description: 'Image pull policy. One of Always,
+                                          Never, IfNotPresent. Defaults to Always
+                                          if :latest tag is specified, or IfNotPresent
+                                          otherwise. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                        type: string
+                                      lifecycle:
+                                        description: Actions that the management system
+                                          should take in response to Sidecar lifecycle
+                                          events. Cannot be updated.
+                                        properties:
+                                          postStart:
+                                            description: 'PostStart is called immediately
+                                              after a container is created. If the
+                                              handler fails, the container is terminated
+                                              and restarted according to its restart
+                                              policy. Other management of the container
+                                              blocks until the hook completes. More
+                                              info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                            properties:
+                                              exec:
+                                                description: Exec specifies the action
+                                                  to take.
+                                                properties:
+                                                  command:
+                                                    description: Command is the command
+                                                      line to execute inside the container,
+                                                      the working directory for the
+                                                      command  is root ('/') in the
+                                                      container's filesystem. The
+                                                      command is simply exec'd, it
+                                                      is not run inside a shell, so
+                                                      traditional shell instructions
+                                                      ('|', etc) won't work. To use
+                                                      a shell, you need to explicitly
+                                                      call out to that shell. Exit
+                                                      status of 0 is treated as live/healthy
+                                                      and non-zero is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the
+                                                  http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: Host name to connect
+                                                      to, defaults to the pod IP.
+                                                      You probably want to set "Host"
+                                                      in httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to
+                                                      set in the request. HTTP allows
+                                                      repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes
+                                                        a custom header to be used
+                                                        in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: The header
+                                                            field name
+                                                          type: string
+                                                        value:
+                                                          description: The header
+                                                            field value
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on
+                                                      the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Name or number of
+                                                      the port to access on the container.
+                                                      Number must be in the range
+                                                      1 to 65535. Name must be an
+                                                      IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: Scheme to use for
+                                                      connecting to the host. Defaults
+                                                      to HTTP.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              tcpSocket:
+                                                description: Deprecated. TCPSocket
+                                                  is NOT supported as a LifecycleHandler
+                                                  and kept for the backward compatibility.
+                                                  There are no validation of this
+                                                  field and lifecycle hooks will fail
+                                                  in runtime when tcp handler is specified.
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name
+                                                      to connect to, defaults to the
+                                                      pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Number or name of
+                                                      the port to access on the container.
+                                                      Number must be in the range
+                                                      1 to 65535. Name must be an
+                                                      IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                            type: object
+                                          preStop:
+                                            description: 'PreStop is called immediately
+                                              before a container is terminated due
+                                              to an API request or management event
+                                              such as liveness/startup probe failure,
+                                              preemption, resource contention, etc.
+                                              The handler is not called if the container
+                                              crashes or exits. The Pod''s termination
+                                              grace period countdown begins before
+                                              the PreStop hook is executed. Regardless
+                                              of the outcome of the handler, the container
+                                              will eventually terminate within the
+                                              Pod''s termination grace period (unless
+                                              delayed by finalizers). Other management
+                                              of the container blocks until the hook
+                                              completes or until the termination grace
+                                              period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                            properties:
+                                              exec:
+                                                description: Exec specifies the action
+                                                  to take.
+                                                properties:
+                                                  command:
+                                                    description: Command is the command
+                                                      line to execute inside the container,
+                                                      the working directory for the
+                                                      command  is root ('/') in the
+                                                      container's filesystem. The
+                                                      command is simply exec'd, it
+                                                      is not run inside a shell, so
+                                                      traditional shell instructions
+                                                      ('|', etc) won't work. To use
+                                                      a shell, you need to explicitly
+                                                      call out to that shell. Exit
+                                                      status of 0 is treated as live/healthy
+                                                      and non-zero is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the
+                                                  http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: Host name to connect
+                                                      to, defaults to the pod IP.
+                                                      You probably want to set "Host"
+                                                      in httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to
+                                                      set in the request. HTTP allows
+                                                      repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes
+                                                        a custom header to be used
+                                                        in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: The header
+                                                            field name
+                                                          type: string
+                                                        value:
+                                                          description: The header
+                                                            field value
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on
+                                                      the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Name or number of
+                                                      the port to access on the container.
+                                                      Number must be in the range
+                                                      1 to 65535. Name must be an
+                                                      IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: Scheme to use for
+                                                      connecting to the host. Defaults
+                                                      to HTTP.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              tcpSocket:
+                                                description: Deprecated. TCPSocket
+                                                  is NOT supported as a LifecycleHandler
+                                                  and kept for the backward compatibility.
+                                                  There are no validation of this
+                                                  field and lifecycle hooks will fail
+                                                  in runtime when tcp handler is specified.
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name
+                                                      to connect to, defaults to the
+                                                      pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Number or name of
+                                                      the port to access on the container.
+                                                      Number must be in the range
+                                                      1 to 65535. Name must be an
+                                                      IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                            type: object
+                                        type: object
+                                      livenessProbe:
+                                        description: 'Periodic probe of Sidecar liveness.
+                                          Container will be restarted if the probe
+                                          fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures
+                                              for the probe to be considered failed
+                                              after having succeeded. Defaults to
+                                              3. Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          grpc:
+                                            description: GRPC specifies an action
+                                              involving a GRPC port. This is a beta
+                                              field and requires enabling GRPCContainerProbe
+                                              feature gate.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC
+                                                  service. Number must be in the range
+                                                  1 to 65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                description: "Service is the name
+                                                  of the service to place in the gRPC
+                                                  HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                  \n If this is not specified, the
+                                                  default behavior is defined by gRPC."
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: 'Number of seconds after
+                                              the container has started before liveness
+                                              probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: How often (in seconds) to
+                                              perform the probe. Default to 10 seconds.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes
+                                              for the probe to be considered successful
+                                              after having failed. Defaults to 1.
+                                              Must be 1 for liveness and startup.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds
+                                              the pod needs to terminate gracefully
+                                              upon probe failure. The grace period
+                                              is the duration in seconds after the
+                                              processes running in the pod are sent
+                                              a termination signal and the time when
+                                              the processes are forcibly halted with
+                                              a kill signal. Set this value longer
+                                              than the expected cleanup time for your
+                                              process. If this value is nil, the pod's
+                                              terminationGracePeriodSeconds will be
+                                              used. Otherwise, this value overrides
+                                              the value provided by the pod spec.
+                                              Value must be non-negative integer.
+                                              The value zero indicates stop immediately
+                                              via the kill signal (no opportunity
+                                              to shut down). This is a beta field
+                                              and requires enabling ProbeTerminationGracePeriod
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
+                                            format: int64
+                                            type: integer
+                                          timeoutSeconds:
+                                            description: 'Number of seconds after
+                                              which the probe times out. Defaults
+                                              to 1 second. Minimum value is 1. More
+                                              info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      name:
+                                        description: Name of the Sidecar specified
+                                          as a DNS_LABEL. Each Sidecar in a Task must
+                                          have a unique name (DNS_LABEL). Cannot be
+                                          updated.
+                                        type: string
+                                      ports:
+                                        description: List of ports to expose from
+                                          the Sidecar. Exposing a port here gives
+                                          the system additional information about
+                                          the network connections a container uses,
+                                          but is primarily informational. Not specifying
+                                          a port here DOES NOT prevent that port from
+                                          being exposed. Any port which is listening
+                                          on the default "0.0.0.0" address inside
+                                          a container will be accessible from the
+                                          network. Cannot be updated.
+                                        items:
+                                          description: ContainerPort represents a
+                                            network port in a single container.
+                                          properties:
+                                            containerPort:
+                                              description: Number of port to expose
+                                                on the pod's IP address. This must
+                                                be a valid port number, 0 < x < 65536.
+                                              format: int32
+                                              type: integer
+                                            hostIP:
+                                              description: What host IP to bind the
+                                                external port to.
+                                              type: string
+                                            hostPort:
+                                              description: Number of port to expose
+                                                on the host. If specified, this must
+                                                be a valid port number, 0 < x < 65536.
+                                                If HostNetwork is specified, this
+                                                must match ContainerPort. Most containers
+                                                do not need this.
+                                              format: int32
+                                              type: integer
+                                            name:
+                                              description: If specified, this must
+                                                be an IANA_SVC_NAME and unique within
+                                                the pod. Each named port in a pod
+                                                must have a unique name. Name for
+                                                the port that can be referred to by
+                                                services.
+                                              type: string
+                                            protocol:
+                                              default: TCP
+                                              description: Protocol for port. Must
+                                                be UDP, TCP, or SCTP. Defaults to
+                                                "TCP".
+                                              type: string
+                                          required:
+                                          - containerPort
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - containerPort
+                                        - protocol
+                                        x-kubernetes-list-type: map
+                                      readinessProbe:
+                                        description: 'Periodic probe of Sidecar service
+                                          readiness. Container will be removed from
+                                          service endpoints if the probe fails. Cannot
+                                          be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures
+                                              for the probe to be considered failed
+                                              after having succeeded. Defaults to
+                                              3. Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          grpc:
+                                            description: GRPC specifies an action
+                                              involving a GRPC port. This is a beta
+                                              field and requires enabling GRPCContainerProbe
+                                              feature gate.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC
+                                                  service. Number must be in the range
+                                                  1 to 65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                description: "Service is the name
+                                                  of the service to place in the gRPC
+                                                  HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                  \n If this is not specified, the
+                                                  default behavior is defined by gRPC."
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: 'Number of seconds after
+                                              the container has started before liveness
+                                              probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: How often (in seconds) to
+                                              perform the probe. Default to 10 seconds.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes
+                                              for the probe to be considered successful
+                                              after having failed. Defaults to 1.
+                                              Must be 1 for liveness and startup.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds
+                                              the pod needs to terminate gracefully
+                                              upon probe failure. The grace period
+                                              is the duration in seconds after the
+                                              processes running in the pod are sent
+                                              a termination signal and the time when
+                                              the processes are forcibly halted with
+                                              a kill signal. Set this value longer
+                                              than the expected cleanup time for your
+                                              process. If this value is nil, the pod's
+                                              terminationGracePeriodSeconds will be
+                                              used. Otherwise, this value overrides
+                                              the value provided by the pod spec.
+                                              Value must be non-negative integer.
+                                              The value zero indicates stop immediately
+                                              via the kill signal (no opportunity
+                                              to shut down). This is a beta field
+                                              and requires enabling ProbeTerminationGracePeriod
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
+                                            format: int64
+                                            type: integer
+                                          timeoutSeconds:
+                                            description: 'Number of seconds after
+                                              which the probe times out. Defaults
+                                              to 1 second. Minimum value is 1. More
+                                              info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      resources:
+                                        description: 'Compute Resources required by
+                                          this Sidecar. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Limits describes the maximum
+                                              amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Requests describes the minimum
+                                              amount of compute resources required.
+                                              If Requests is omitted for a container,
+                                              it defaults to Limits if that is explicitly
+                                              specified, otherwise to an implementation-defined
+                                              value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                        type: object
+                                      script:
+                                        description: "Script is the contents of an
+                                          executable file to execute. \n If Script
+                                          is not empty, the Step cannot have an Command
+                                          or Args."
+                                        type: string
+                                      securityContext:
+                                        description: 'SecurityContext defines the
+                                          security options the Sidecar should be run
+                                          with. If set, the fields of SecurityContext
+                                          override the equivalent fields of PodSecurityContext.
+                                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            description: 'AllowPrivilegeEscalation
+                                              controls whether a process can gain
+                                              more privileges than its parent process.
+                                              This bool directly controls if the no_new_privs
+                                              flag will be set on the container process.
+                                              AllowPrivilegeEscalation is true always
+                                              when the container is: 1) run as Privileged
+                                              2) has CAP_SYS_ADMIN Note that this
+                                              field cannot be set when spec.os.name
+                                              is windows.'
+                                            type: boolean
+                                          capabilities:
+                                            description: The capabilities to add/drop
+                                              when running containers. Defaults to
+                                              the default set of capabilities granted
+                                              by the container runtime. Note that
+                                              this field cannot be set when spec.os.name
+                                              is windows.
+                                            properties:
+                                              add:
+                                                description: Added capabilities
+                                                items:
+                                                  description: Capability represent
+                                                    POSIX capabilities type
+                                                  type: string
+                                                type: array
+                                              drop:
+                                                description: Removed capabilities
+                                                items:
+                                                  description: Capability represent
+                                                    POSIX capabilities type
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          privileged:
+                                            description: Run container in privileged
+                                              mode. Processes in privileged containers
+                                              are essentially equivalent to root on
+                                              the host. Defaults to false. Note that
+                                              this field cannot be set when spec.os.name
+                                              is windows.
+                                            type: boolean
+                                          procMount:
+                                            description: procMount denotes the type
+                                              of proc mount to use for the containers.
+                                              The default is DefaultProcMount which
+                                              uses the container runtime defaults
+                                              for readonly paths and masked paths.
+                                              This requires the ProcMountType feature
+                                              flag to be enabled. Note that this field
+                                              cannot be set when spec.os.name is windows.
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            description: Whether this container has
+                                              a read-only root filesystem. Default
+                                              is false. Note that this field cannot
+                                              be set when spec.os.name is windows.
+                                            type: boolean
+                                          runAsGroup:
+                                            description: The GID to run the entrypoint
+                                              of the container process. Uses runtime
+                                              default if unset. May also be set in
+                                              PodSecurityContext.  If set in both
+                                              SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence. Note that this field
+                                              cannot be set when spec.os.name is windows.
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            description: Indicates that the container
+                                              must run as a non-root user. If true,
+                                              the Kubelet will validate the image
+                                              at runtime to ensure that it does not
+                                              run as UID 0 (root) and fail to start
+                                              the container if it does. If unset or
+                                              false, no such validation will be performed.
+                                              May also be set in PodSecurityContext.  If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence.
+                                            type: boolean
+                                          runAsUser:
+                                            description: The UID to run the entrypoint
+                                              of the container process. Defaults to
+                                              user specified in image metadata if
+                                              unspecified. May also be set in PodSecurityContext.  If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence. Note that this field
+                                              cannot be set when spec.os.name is windows.
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            description: The SELinux context to be
+                                              applied to the container. If unspecified,
+                                              the container runtime will allocate
+                                              a random SELinux context for each container.  May
+                                              also be set in PodSecurityContext.  If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence. Note that this field
+                                              cannot be set when spec.os.name is windows.
+                                            properties:
+                                              level:
+                                                description: Level is SELinux level
+                                                  label that applies to the container.
+                                                type: string
+                                              role:
+                                                description: Role is a SELinux role
+                                                  label that applies to the container.
+                                                type: string
+                                              type:
+                                                description: Type is a SELinux type
+                                                  label that applies to the container.
+                                                type: string
+                                              user:
+                                                description: User is a SELinux user
+                                                  label that applies to the container.
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            description: The seccomp options to use
+                                              by this container. If seccomp options
+                                              are provided at both the pod & container
+                                              level, the container options override
+                                              the pod options. Note that this field
+                                              cannot be set when spec.os.name is windows.
+                                            properties:
+                                              localhostProfile:
+                                                description: localhostProfile indicates
+                                                  a profile defined in a file on the
+                                                  node should be used. The profile
+                                                  must be preconfigured on the node
+                                                  to work. Must be a descending path,
+                                                  relative to the kubelet's configured
+                                                  seccomp profile location. Must only
+                                                  be set if type is "Localhost".
+                                                type: string
+                                              type:
+                                                description: "type indicates which
+                                                  kind of seccomp profile will be
+                                                  applied. Valid options are: \n Localhost
+                                                  - a profile defined in a file on
+                                                  the node should be used. RuntimeDefault
+                                                  - the container runtime default
+                                                  profile should be used. Unconfined
+                                                  - no profile should be applied."
+                                                type: string
+                                            required:
+                                            - type
+                                            type: object
+                                          windowsOptions:
+                                            description: The Windows specific settings
+                                              applied to all containers. If unspecified,
+                                              the options from the PodSecurityContext
+                                              will be used. If set in both SecurityContext
+                                              and PodSecurityContext, the value specified
+                                              in SecurityContext takes precedence.
+                                              Note that this field cannot be set when
+                                              spec.os.name is linux.
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                description: GMSACredentialSpec is
+                                                  where the GMSA admission webhook
+                                                  (https://github.com/kubernetes-sigs/windows-gmsa)
+                                                  inlines the contents of the GMSA
+                                                  credential spec named by the GMSACredentialSpecName
+                                                  field.
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                description: GMSACredentialSpecName
+                                                  is the name of the GMSA credential
+                                                  spec to use.
+                                                type: string
+                                              hostProcess:
+                                                description: HostProcess determines
+                                                  if a container should be run as
+                                                  a 'Host Process' container. This
+                                                  field is alpha-level and will only
+                                                  be honored by components that enable
+                                                  the WindowsHostProcessContainers
+                                                  feature flag. Setting this field
+                                                  without the feature flag will result
+                                                  in errors when validating the Pod.
+                                                  All of a Pod's containers must have
+                                                  the same effective HostProcess value
+                                                  (it is not allowed to have a mix
+                                                  of HostProcess containers and non-HostProcess
+                                                  containers).  In addition, if HostProcess
+                                                  is true then HostNetwork must also
+                                                  be set to true.
+                                                type: boolean
+                                              runAsUserName:
+                                                description: The UserName in Windows
+                                                  to run the entrypoint of the container
+                                                  process. Defaults to the user specified
+                                                  in image metadata if unspecified.
+                                                  May also be set in PodSecurityContext.
+                                                  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified
+                                                  in SecurityContext takes precedence.
+                                                type: string
+                                            type: object
+                                        type: object
+                                      startupProbe:
+                                        description: 'StartupProbe indicates that
+                                          the Pod the Sidecar is running in has successfully
+                                          initialized. If specified, no other probes
+                                          are executed until this completes successfully.
+                                          If this probe fails, the Pod will be restarted,
+                                          just as if the livenessProbe failed. This
+                                          can be used to provide different probe parameters
+                                          at the beginning of a Pod''s lifecycle,
+                                          when it might take a long time to load data
+                                          or warm a cache, than during steady-state
+                                          operation. This cannot be updated. More
+                                          info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures
+                                              for the probe to be considered failed
+                                              after having succeeded. Defaults to
+                                              3. Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          grpc:
+                                            description: GRPC specifies an action
+                                              involving a GRPC port. This is a beta
+                                              field and requires enabling GRPCContainerProbe
+                                              feature gate.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC
+                                                  service. Number must be in the range
+                                                  1 to 65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                description: "Service is the name
+                                                  of the service to place in the gRPC
+                                                  HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                  \n If this is not specified, the
+                                                  default behavior is defined by gRPC."
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: 'Number of seconds after
+                                              the container has started before liveness
+                                              probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: How often (in seconds) to
+                                              perform the probe. Default to 10 seconds.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes
+                                              for the probe to be considered successful
+                                              after having failed. Defaults to 1.
+                                              Must be 1 for liveness and startup.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds
+                                              the pod needs to terminate gracefully
+                                              upon probe failure. The grace period
+                                              is the duration in seconds after the
+                                              processes running in the pod are sent
+                                              a termination signal and the time when
+                                              the processes are forcibly halted with
+                                              a kill signal. Set this value longer
+                                              than the expected cleanup time for your
+                                              process. If this value is nil, the pod's
+                                              terminationGracePeriodSeconds will be
+                                              used. Otherwise, this value overrides
+                                              the value provided by the pod spec.
+                                              Value must be non-negative integer.
+                                              The value zero indicates stop immediately
+                                              via the kill signal (no opportunity
+                                              to shut down). This is a beta field
+                                              and requires enabling ProbeTerminationGracePeriod
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
+                                            format: int64
+                                            type: integer
+                                          timeoutSeconds:
+                                            description: 'Number of seconds after
+                                              which the probe times out. Defaults
+                                              to 1 second. Minimum value is 1. More
+                                              info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      stdin:
+                                        description: Whether this Sidecar should allocate
+                                          a buffer for stdin in the container runtime.
+                                          If this is not set, reads from stdin in
+                                          the Sidecar will always result in EOF. Default
+                                          is false.
+                                        type: boolean
+                                      stdinOnce:
+                                        description: Whether the container runtime
+                                          should close the stdin channel after it
+                                          has been opened by a single attach. When
+                                          stdin is true the stdin stream will remain
+                                          open across multiple attach sessions. If
+                                          stdinOnce is set to true, stdin is opened
+                                          on Sidecar start, is empty until the first
+                                          client attaches to stdin, and then remains
+                                          open and accepts data until the client disconnects,
+                                          at which time stdin is closed and remains
+                                          closed until the Sidecar is restarted. If
+                                          this flag is false, a container processes
+                                          that reads from stdin will never receive
+                                          an EOF. Default is false
+                                        type: boolean
+                                      terminationMessagePath:
+                                        description: 'Optional: Path at which the
+                                          file to which the Sidecar''s termination
+                                          message will be written is mounted into
+                                          the Sidecar''s filesystem. Message written
+                                          is intended to be brief final status, such
+                                          as an assertion failure message. Will be
+                                          truncated by the node if greater than 4096
+                                          bytes. The total message length across all
+                                          containers will be limited to 12kb. Defaults
+                                          to /dev/termination-log. Cannot be updated.'
+                                        type: string
+                                      terminationMessagePolicy:
+                                        description: Indicate how the termination
+                                          message should be populated. File will use
+                                          the contents of terminationMessagePath to
+                                          populate the Sidecar status message on both
+                                          success and failure. FallbackToLogsOnError
+                                          will use the last chunk of Sidecar log output
+                                          if the termination message file is empty
+                                          and the Sidecar exited with an error. The
+                                          log output is limited to 2048 bytes or 80
+                                          lines, whichever is smaller. Defaults to
+                                          File. Cannot be updated.
+                                        type: string
+                                      tty:
+                                        description: Whether this Sidecar should allocate
+                                          a TTY for itself, also requires 'stdin'
+                                          to be true. Default is false.
+                                        type: boolean
+                                      volumeDevices:
+                                        description: volumeDevices is the list of
+                                          block devices to be used by the Sidecar.
+                                        items:
+                                          description: volumeDevice describes a mapping
+                                            of a raw block device within a container.
+                                          properties:
+                                            devicePath:
+                                              description: devicePath is the path
+                                                inside of the container that the device
+                                                will be mapped to.
+                                              type: string
+                                            name:
+                                              description: name must match the name
+                                                of a persistentVolumeClaim in the
+                                                pod
+                                              type: string
+                                          required:
+                                          - devicePath
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      volumeMounts:
+                                        description: Volumes to mount into the Sidecar's
+                                          filesystem. Cannot be updated.
+                                        items:
+                                          description: VolumeMount describes a mounting
+                                            of a Volume within a container.
+                                          properties:
+                                            mountPath:
+                                              description: Path within the container
+                                                at which the volume should be mounted.  Must
+                                                not contain ':'.
+                                              type: string
+                                            mountPropagation:
+                                              description: mountPropagation determines
+                                                how mounts are propagated from the
+                                                host to container and the other way
+                                                around. When not set, MountPropagationNone
+                                                is used. This field is beta in 1.10.
+                                              type: string
+                                            name:
+                                              description: This must match the Name
+                                                of a Volume.
+                                              type: string
+                                            readOnly:
+                                              description: Mounted read-only if true,
+                                                read-write otherwise (false or unspecified).
+                                                Defaults to false.
+                                              type: boolean
+                                            subPath:
+                                              description: Path within the volume
+                                                from which the container's volume
+                                                should be mounted. Defaults to ""
+                                                (volume's root).
+                                              type: string
+                                            subPathExpr:
+                                              description: Expanded path within the
+                                                volume from which the container's
+                                                volume should be mounted. Behaves
+                                                similarly to SubPath but environment
+                                                variable references $(VAR_NAME) are
+                                                expanded using the container's environment.
+                                                Defaults to "" (volume's root). SubPathExpr
+                                                and SubPath are mutually exclusive.
+                                              type: string
+                                          required:
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      workingDir:
+                                        description: Sidecar's working directory.
+                                          If not specified, the container runtime's
+                                          default will be used, which might be configured
+                                          in the container image. Cannot be updated.
+                                        type: string
+                                      workspaces:
+                                        description: "This is an alpha field. You
+                                          must set the \"enable-api-fields\" feature
+                                          flag to \"alpha\" for this field to be supported.
+                                          \n Workspaces is a list of workspaces from
+                                          the Task that this Sidecar wants exclusive
+                                          access to. Adding a workspace to this list
+                                          means that any other Step or Sidecar that
+                                          does not also request this Workspace will
+                                          not have access to it."
+                                        items:
+                                          description: WorkspaceUsage is used by a
+                                            Step or Sidecar to declare that it wants
+                                            isolated access to a Workspace defined
+                                            in a Task.
+                                          properties:
+                                            mountPath:
+                                              description: MountPath is the path that
+                                                the workspace should be mounted to
+                                                inside the Step or Sidecar, overriding
+                                                any MountPath specified in the Task's
+                                                WorkspaceDeclaration.
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                workspace this Step or Sidecar wants
+                                                access to.
+                                              type: string
+                                          required:
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                spec:
+                                  description: Spec is a specification of a custom
+                                    task
+                                  type: object
+                                stepTemplate:
+                                  description: StepTemplate can be used as the basis
+                                    for all step containers within the Task, so that
+                                    the steps inherit settings on the base container.
+                                  properties:
+                                    args:
+                                      description: 'Arguments to the entrypoint. The
+                                        image''s CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the Step''s environment. If a variable
+                                        cannot be resolved, the reference in the input
+                                        string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the
+                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded,
+                                        regardless of whether the variable exists
+                                        or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      description: 'Entrypoint array. Not executed
+                                        within a shell. The docker image''s ENTRYPOINT
+                                        is used if this is not provided. Variable
+                                        references $(VAR_NAME) are expanded using
+                                        the Step''s environment. If a variable cannot
+                                        be resolved, the reference in the input string
+                                        will be unchanged. Double $$ are reduced to
+                                        a single $, which allows for escaping the
+                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded,
+                                        regardless of whether the variable exists
+                                        or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      description: List of environment variables to
+                                        set in the container. Cannot be updated.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: Name of the environment variable.
+                                              Must be a C_IDENTIFIER.
+                                            type: string
+                                          value:
+                                            description: 'Variable references $(VAR_NAME)
+                                              are expanded using the previously defined
+                                              environment variables in the container
+                                              and any service environment variables.
+                                              If a variable cannot be resolved, the
+                                              reference in the input string will be
+                                              unchanged. Double $$ are reduced to
+                                              a single $, which allows for escaping
+                                              the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                              will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded,
+                                              regardless of whether the variable exists
+                                              or not. Defaults to "".'
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                              fieldRef:
+                                                description: 'Selects a field of the
+                                                  pod: supports metadata.name, metadata.namespace,
+                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                                  spec.nodeName, spec.serviceAccountName,
+                                                  status.hostIP, status.podIP, status.podIPs.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  limits.ephemeral-storage, requests.cpu,
+                                                  requests.memory and requests.ephemeral-storage)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields.
+                                                      apiVersion, kind, uid?'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    envFrom:
+                                      description: List of sources to populate environment
+                                        variables in the Step. The keys defined within
+                                        a source must be a C_IDENTIFIER. All invalid
+                                        keys will be reported as an event when the
+                                        container is starting. When a key exists in
+                                        multiple sources, the value associated with
+                                        the last source will take precedence. Values
+                                        defined by an Env with a duplicate key will
+                                        take precedence. Cannot be updated.
+                                      items:
+                                        description: EnvFromSource represents the
+                                          source of a set of ConfigMaps
+                                        properties:
+                                          configMapRef:
+                                            description: The ConfigMap to select from
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                          prefix:
+                                            description: An optional identifier to
+                                              prepend to each key in the ConfigMap.
+                                              Must be a C_IDENTIFIER.
+                                            type: string
+                                          secretRef:
+                                            description: The Secret to select from
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      description: 'Default image name to use for
+                                        each Step. More info: https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level
+                                        config management to default or override container
+                                        images in workload controllers like Deployments
+                                        and StatefulSets.'
+                                      type: string
+                                    imagePullPolicy:
+                                      description: 'Image pull policy. One of Always,
+                                        Never, IfNotPresent. Defaults to Always if
+                                        :latest tag is specified, or IfNotPresent
+                                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                      type: string
+                                    lifecycle:
+                                      description: Deprecated. This field will be
+                                        removed in a future release. Actions that
+                                        the management system should take in response
+                                        to container lifecycle events. Cannot be updated.
+                                      properties:
+                                        postStart:
+                                          description: 'PostStart is called immediately
+                                            after a container is created. If the handler
+                                            fails, the container is terminated and
+                                            restarted according to its restart policy.
+                                            Other management of the container blocks
+                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          properties:
+                                            exec:
+                                              description: Exec specifies the action
+                                                to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The command
+                                                    is simply exec'd, it is not run
+                                                    inside a shell, so traditional
+                                                    shell instructions ('|', etc)
+                                                    won't work. To use a shell, you
+                                                    need to explicitly call out to
+                                                    that shell. Exit status of 0 is
+                                                    treated as live/healthy and non-zero
+                                                    is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies the http
+                                                request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP. You
+                                                    probably want to set "Host" in
+                                                    httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header field
+                                                          name
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: Scheme to use for connecting
+                                                    to the host. Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              description: Deprecated. TCPSocket is
+                                                NOT supported as a LifecycleHandler
+                                                and kept for the backward compatibility.
+                                                There are no validation of this field
+                                                and lifecycle hooks will fail in runtime
+                                                when tcp handler is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          description: 'PreStop is called immediately
+                                            before a container is terminated due to
+                                            an API request or management event such
+                                            as liveness/startup probe failure, preemption,
+                                            resource contention, etc. The handler
+                                            is not called if the container crashes
+                                            or exits. The Pod''s termination grace
+                                            period countdown begins before the PreStop
+                                            hook is executed. Regardless of the outcome
+                                            of the handler, the container will eventually
+                                            terminate within the Pod''s termination
+                                            grace period (unless delayed by finalizers).
+                                            Other management of the container blocks
+                                            until the hook completes or until the
+                                            termination grace period is reached. More
+                                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          properties:
+                                            exec:
+                                              description: Exec specifies the action
+                                                to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The command
+                                                    is simply exec'd, it is not run
+                                                    inside a shell, so traditional
+                                                    shell instructions ('|', etc)
+                                                    won't work. To use a shell, you
+                                                    need to explicitly call out to
+                                                    that shell. Exit status of 0 is
+                                                    treated as live/healthy and non-zero
+                                                    is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies the http
+                                                request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP. You
+                                                    probably want to set "Host" in
+                                                    httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header field
+                                                          name
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: Scheme to use for connecting
+                                                    to the host. Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              description: Deprecated. TCPSocket is
+                                                NOT supported as a LifecycleHandler
+                                                and kept for the backward compatibility.
+                                                There are no validation of this field
+                                                and lifecycle hooks will fail in runtime
+                                                when tcp handler is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      description: 'Deprecated. This field will be
+                                        removed in a future release. Periodic probe
+                                        of container liveness. Container will be restarted
+                                        if the probe fails. Cannot be updated. More
+                                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      properties:
+                                        exec:
+                                          description: Exec specifies the action to
+                                            take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies an action involving
+                                            a GRPC port. This is a beta field and
+                                            requires enabling GRPCContainerProbe feature
+                                            gate.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              description: "Service is the name of
+                                                the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                \n If this is not specified, the default
+                                                behavior is defined by gRPC."
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      description: Deprecated. This field will be
+                                        removed in a future release. Default name
+                                        for each Step specified as a DNS_LABEL. Each
+                                        Step in a Task must have a unique name. Cannot
+                                        be updated.
+                                      type: string
+                                    ports:
+                                      description: Deprecated. This field will be
+                                        removed in a future release. List of ports
+                                        to expose from the Step's container. Exposing
+                                        a port here gives the system additional information
+                                        about the network connections a container
+                                        uses, but is primarily informational. Not
+                                        specifying a port here DOES NOT prevent that
+                                        port from being exposed. Any port which is
+                                        listening on the default "0.0.0.0" address
+                                        inside a container will be accessible from
+                                        the network. Cannot be updated.
+                                      items:
+                                        description: ContainerPort represents a network
+                                          port in a single container.
+                                        properties:
+                                          containerPort:
+                                            description: Number of port to expose
+                                              on the pod's IP address. This must be
+                                              a valid port number, 0 < x < 65536.
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            description: What host IP to bind the
+                                              external port to.
+                                            type: string
+                                          hostPort:
+                                            description: Number of port to expose
+                                              on the host. If specified, this must
+                                              be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must
+                                              match ContainerPort. Most containers
+                                              do not need this.
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            description: If specified, this must be
+                                              an IANA_SVC_NAME and unique within the
+                                              pod. Each named port in a pod must have
+                                              a unique name. Name for the port that
+                                              can be referred to by services.
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            description: Protocol for port. Must be
+                                              UDP, TCP, or SCTP. Defaults to "TCP".
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      description: 'Deprecated. This field will be
+                                        removed in a future release. Periodic probe
+                                        of container service readiness. Container
+                                        will be removed from service endpoints if
+                                        the probe fails. Cannot be updated. More info:
+                                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      properties:
+                                        exec:
+                                          description: Exec specifies the action to
+                                            take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies an action involving
+                                            a GRPC port. This is a beta field and
+                                            requires enabling GRPCContainerProbe feature
+                                            gate.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              description: "Service is the name of
+                                                the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                \n If this is not specified, the default
+                                                behavior is defined by gRPC."
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resources:
+                                      description: 'Compute Resources required by
+                                        this Step. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                    securityContext:
+                                      description: 'SecurityContext defines the security
+                                        options the Step should be run with. If set,
+                                        the fields of SecurityContext override the
+                                        equivalent fields of PodSecurityContext. More
+                                        info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: 'AllowPrivilegeEscalation controls
+                                            whether a process can gain more privileges
+                                            than its parent process. This bool directly
+                                            controls if the no_new_privs flag will
+                                            be set on the container process. AllowPrivilegeEscalation
+                                            is true always when the container is:
+                                            1) run as Privileged 2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when
+                                            spec.os.name is windows.'
+                                          type: boolean
+                                        capabilities:
+                                          description: The capabilities to add/drop
+                                            when running containers. Defaults to the
+                                            default set of capabilities granted by
+                                            the container runtime. Note that this
+                                            field cannot be set when spec.os.name
+                                            is windows.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                          type: object
+                                        privileged:
+                                          description: Run container in privileged
+                                            mode. Processes in privileged containers
+                                            are essentially equivalent to root on
+                                            the host. Defaults to false. Note that
+                                            this field cannot be set when spec.os.name
+                                            is windows.
+                                          type: boolean
+                                        procMount:
+                                          description: procMount denotes the type
+                                            of proc mount to use for the containers.
+                                            The default is DefaultProcMount which
+                                            uses the container runtime defaults for
+                                            readonly paths and masked paths. This
+                                            requires the ProcMountType feature flag
+                                            to be enabled. Note that this field cannot
+                                            be set when spec.os.name is windows.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: Whether this container has
+                                            a read-only root filesystem. Default is
+                                            false. Note that this field cannot be
+                                            set when spec.os.name is windows.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: The GID to run the entrypoint
+                                            of the container process. Uses runtime
+                                            default if unset. May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: Indicates that the container
+                                            must run as a non-root user. If true,
+                                            the Kubelet will validate the image at
+                                            runtime to ensure that it does not run
+                                            as UID 0 (root) and fail to start the
+                                            container if it does. If unset or false,
+                                            no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: The UID to run the entrypoint
+                                            of the container process. Defaults to
+                                            user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: The SELinux context to be applied
+                                            to the container. If unspecified, the
+                                            container runtime will allocate a random
+                                            SELinux context for each container.  May
+                                            also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: The seccomp options to use
+                                            by this container. If seccomp options
+                                            are provided at both the pod & container
+                                            level, the container options override
+                                            the pod options. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: localhostProfile indicates
+                                                a profile defined in a file on the
+                                                node should be used. The profile must
+                                                be preconfigured on the node to work.
+                                                Must be a descending path, relative
+                                                to the kubelet's configured seccomp
+                                                profile location. Must only be set
+                                                if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: "type indicates which kind
+                                                of seccomp profile will be applied.
+                                                Valid options are: \n Localhost -
+                                                a profile defined in a file on the
+                                                node should be used. RuntimeDefault
+                                                - the container runtime default profile
+                                                should be used. Unconfined - no profile
+                                                should be applied."
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: The Windows specific settings
+                                            applied to all containers. If unspecified,
+                                            the options from the PodSecurityContext
+                                            will be used. If set in both SecurityContext
+                                            and PodSecurityContext, the value specified
+                                            in SecurityContext takes precedence. Note
+                                            that this field cannot be set when spec.os.name
+                                            is linux.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: GMSACredentialSpec is where
+                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                                inlines the contents of the GMSA credential
+                                                spec named by the GMSACredentialSpecName
+                                                field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            hostProcess:
+                                              description: HostProcess determines
+                                                if a container should be run as a
+                                                'Host Process' container. This field
+                                                is alpha-level and will only be honored
+                                                by components that enable the WindowsHostProcessContainers
+                                                feature flag. Setting this field without
+                                                the feature flag will result in errors
+                                                when validating the Pod. All of a
+                                                Pod's containers must have the same
+                                                effective HostProcess value (it is
+                                                not allowed to have a mix of HostProcess
+                                                containers and non-HostProcess containers).  In
+                                                addition, if HostProcess is true then
+                                                HostNetwork must also be set to true.
+                                              type: boolean
+                                            runAsUserName:
+                                              description: The UserName in Windows
+                                                to run the entrypoint of the container
+                                                process. Defaults to the user specified
+                                                in image metadata if unspecified.
+                                                May also be set in PodSecurityContext.
+                                                If set in both SecurityContext and
+                                                PodSecurityContext, the value specified
+                                                in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      description: 'Deprecated. This field will be
+                                        removed in a future release. DeprecatedStartupProbe
+                                        indicates that the Pod has successfully initialized.
+                                        If specified, no other probes are executed
+                                        until this completes successfully. If this
+                                        probe fails, the Pod will be restarted, just
+                                        as if the livenessProbe failed. This can be
+                                        used to provide different probe parameters
+                                        at the beginning of a Pod''s lifecycle, when
+                                        it might take a long time to load data or
+                                        warm a cache, than during steady-state operation.
+                                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      properties:
+                                        exec:
+                                          description: Exec specifies the action to
+                                            take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies an action involving
+                                            a GRPC port. This is a beta field and
+                                            requires enabling GRPCContainerProbe feature
+                                            gate.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              description: "Service is the name of
+                                                the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                \n If this is not specified, the default
+                                                behavior is defined by gRPC."
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: Scheme to use for connecting
+                                                to the host. Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      description: Deprecated. This field will be
+                                        removed in a future release. Whether this
+                                        Step should allocate a buffer for stdin in
+                                        the container runtime. If this is not set,
+                                        reads from stdin in the Step will always result
+                                        in EOF. Default is false.
+                                      type: boolean
+                                    stdinOnce:
+                                      description: Deprecated. This field will be
+                                        removed in a future release. Whether the container
+                                        runtime should close the stdin channel after
+                                        it has been opened by a single attach. When
+                                        stdin is true the stdin stream will remain
+                                        open across multiple attach sessions. If stdinOnce
+                                        is set to true, stdin is opened on container
+                                        start, is empty until the first client attaches
+                                        to stdin, and then remains open and accepts
+                                        data until the client disconnects, at which
+                                        time stdin is closed and remains closed until
+                                        the container is restarted. If this flag is
+                                        false, a container processes that reads from
+                                        stdin will never receive an EOF. Default is
+                                        false
+                                      type: boolean
+                                    terminationMessagePath:
+                                      description: Deprecated. This field will be
+                                        removed in a future release and cannot be
+                                        meaningfully used.
+                                      type: string
+                                    terminationMessagePolicy:
+                                      description: Deprecated. This field will be
+                                        removed in a future release and cannot be
+                                        meaningfully used.
+                                      type: string
+                                    tty:
+                                      description: Deprecated. This field will be
+                                        removed in a future release. Whether this
+                                        Step should allocate a DeprecatedTTY for itself,
+                                        also requires 'stdin' to be true. Default
+                                        is false.
+                                      type: boolean
+                                    volumeDevices:
+                                      description: volumeDevices is the list of block
+                                        devices to be used by the Step.
+                                      items:
+                                        description: volumeDevice describes a mapping
+                                          of a raw block device within a container.
+                                        properties:
+                                          devicePath:
+                                            description: devicePath is the path inside
+                                              of the container that the device will
+                                              be mapped to.
+                                            type: string
+                                          name:
+                                            description: name must match the name
+                                              of a persistentVolumeClaim in the pod
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    volumeMounts:
+                                      description: Volumes to mount into the Step's
+                                        filesystem. Cannot be updated.
+                                      items:
+                                        description: VolumeMount describes a mounting
+                                          of a Volume within a container.
+                                        properties:
+                                          mountPath:
+                                            description: Path within the container
+                                              at which the volume should be mounted.  Must
+                                              not contain ':'.
+                                            type: string
+                                          mountPropagation:
+                                            description: mountPropagation determines
+                                              how mounts are propagated from the host
+                                              to container and the other way around.
+                                              When not set, MountPropagationNone is
+                                              used. This field is beta in 1.10.
+                                            type: string
+                                          name:
+                                            description: This must match the Name
+                                              of a Volume.
+                                            type: string
+                                          readOnly:
+                                            description: Mounted read-only if true,
+                                              read-write otherwise (false or unspecified).
+                                              Defaults to false.
+                                            type: boolean
+                                          subPath:
+                                            description: Path within the volume from
+                                              which the container's volume should
+                                              be mounted. Defaults to "" (volume's
+                                              root).
+                                            type: string
+                                          subPathExpr:
+                                            description: Expanded path within the
+                                              volume from which the container's volume
+                                              should be mounted. Behaves similarly
+                                              to SubPath but environment variable
+                                              references $(VAR_NAME) are expanded
+                                              using the container's environment. Defaults
+                                              to "" (volume's root). SubPathExpr and
+                                              SubPath are mutually exclusive.
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    workingDir:
+                                      description: Step's working directory. If not
+                                        specified, the container runtime's default
+                                        will be used, which might be configured in
+                                        the container image. Cannot be updated.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                steps:
+                                  description: Steps are the steps of the build; each
+                                    step is run sequentially with the source mounted
+                                    into /workspace.
+                                  items:
+                                    description: Step runs a subcomponent of a Task
+                                    properties:
+                                      args:
+                                        description: 'Arguments to the entrypoint.
+                                          The image''s CMD is used if this is not
+                                          provided. Variable references $(VAR_NAME)
+                                          are expanded using the container''s environment.
+                                          If a variable cannot be resolved, the reference
+                                          in the input string will be unchanged. Double
+                                          $$ are reduced to a single $, which allows
+                                          for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal
+                                          "$(VAR_NAME)". Escaped references will never
+                                          be expanded, regardless of whether the variable
+                                          exists or not. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      command:
+                                        description: 'Entrypoint array. Not executed
+                                          within a shell. The image''s ENTRYPOINT
+                                          is used if this is not provided. Variable
+                                          references $(VAR_NAME) are expanded using
+                                          the container''s environment. If a variable
+                                          cannot be resolved, the reference in the
+                                          input string will be unchanged. Double $$
+                                          are reduced to a single $, which allows
+                                          for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal
+                                          "$(VAR_NAME)". Escaped references will never
+                                          be expanded, regardless of whether the variable
+                                          exists or not. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      env:
+                                        description: List of environment variables
+                                          to set in the container. Cannot be updated.
+                                        items:
+                                          description: EnvVar represents an environment
+                                            variable present in a Container.
+                                          properties:
+                                            name:
+                                              description: Name of the environment
+                                                variable. Must be a C_IDENTIFIER.
+                                              type: string
+                                            value:
+                                              description: 'Variable references $(VAR_NAME)
+                                                are expanded using the previously
+                                                defined environment variables in the
+                                                container and any service environment
+                                                variables. If a variable cannot be
+                                                resolved, the reference in the input
+                                                string will be unchanged. Double $$
+                                                are reduced to a single $, which allows
+                                                for escaping the $(VAR_NAME) syntax:
+                                                i.e. "$$(VAR_NAME)" will produce the
+                                                string literal "$(VAR_NAME)". Escaped
+                                                references will never be expanded,
+                                                regardless of whether the variable
+                                                exists or not. Defaults to "".'
+                                              type: string
+                                            valueFrom:
+                                              description: Source for the environment
+                                                variable's value. Cannot be used if
+                                                value is not empty.
+                                              properties:
+                                                configMapKeyRef:
+                                                  description: Selects a key of a
+                                                    ConfigMap.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the ConfigMap or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                fieldRef:
+                                                  description: 'Selects a field of
+                                                    the pod: supports metadata.name,
+                                                    metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                                    `metadata.annotations[''<KEY>'']`,
+                                                    spec.nodeName, spec.serviceAccountName,
+                                                    status.hostIP, status.podIP, status.podIPs.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                resourceFieldRef:
+                                                  description: 'Selects a resource
+                                                    of the container: only resources
+                                                    limits and requests (limits.cpu,
+                                                    limits.memory, limits.ephemeral-storage,
+                                                    requests.cpu, requests.memory
+                                                    and requests.ephemeral-storage)
+                                                    are currently supported.'
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                                secretKeyRef:
+                                                  description: Selects a key of a
+                                                    secret in the pod's namespace
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                              type: object
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      envFrom:
+                                        description: List of sources to populate environment
+                                          variables in the container. The keys defined
+                                          within a source must be a C_IDENTIFIER.
+                                          All invalid keys will be reported as an
+                                          event when the container is starting. When
+                                          a key exists in multiple sources, the value
+                                          associated with the last source will take
+                                          precedence. Values defined by an Env with
+                                          a duplicate key will take precedence. Cannot
+                                          be updated.
+                                        items:
+                                          description: EnvFromSource represents the
+                                            source of a set of ConfigMaps
+                                          properties:
+                                            configMapRef:
+                                              description: The ConfigMap to select
+                                                from
+                                              properties:
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap must be defined
+                                                  type: boolean
+                                              type: object
+                                            prefix:
+                                              description: An optional identifier
+                                                to prepend to each key in the ConfigMap.
+                                                Must be a C_IDENTIFIER.
+                                              type: string
+                                            secretRef:
+                                              description: The Secret to select from
+                                              properties:
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret must be defined
+                                                  type: boolean
+                                              type: object
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      image:
+                                        description: 'Image reference name to run
+                                          for this Step. More info: https://kubernetes.io/docs/concepts/containers/images'
+                                        type: string
+                                      imagePullPolicy:
+                                        description: 'Image pull policy. One of Always,
+                                          Never, IfNotPresent. Defaults to Always
+                                          if :latest tag is specified, or IfNotPresent
+                                          otherwise. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                        type: string
+                                      lifecycle:
+                                        description: Deprecated. This field will be
+                                          removed in a future release. Actions that
+                                          the management system should take in response
+                                          to container lifecycle events. Cannot be
+                                          updated.
+                                        properties:
+                                          postStart:
+                                            description: 'PostStart is called immediately
+                                              after a container is created. If the
+                                              handler fails, the container is terminated
+                                              and restarted according to its restart
+                                              policy. Other management of the container
+                                              blocks until the hook completes. More
+                                              info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                            properties:
+                                              exec:
+                                                description: Exec specifies the action
+                                                  to take.
+                                                properties:
+                                                  command:
+                                                    description: Command is the command
+                                                      line to execute inside the container,
+                                                      the working directory for the
+                                                      command  is root ('/') in the
+                                                      container's filesystem. The
+                                                      command is simply exec'd, it
+                                                      is not run inside a shell, so
+                                                      traditional shell instructions
+                                                      ('|', etc) won't work. To use
+                                                      a shell, you need to explicitly
+                                                      call out to that shell. Exit
+                                                      status of 0 is treated as live/healthy
+                                                      and non-zero is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the
+                                                  http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: Host name to connect
+                                                      to, defaults to the pod IP.
+                                                      You probably want to set "Host"
+                                                      in httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to
+                                                      set in the request. HTTP allows
+                                                      repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes
+                                                        a custom header to be used
+                                                        in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: The header
+                                                            field name
+                                                          type: string
+                                                        value:
+                                                          description: The header
+                                                            field value
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on
+                                                      the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Name or number of
+                                                      the port to access on the container.
+                                                      Number must be in the range
+                                                      1 to 65535. Name must be an
+                                                      IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: Scheme to use for
+                                                      connecting to the host. Defaults
+                                                      to HTTP.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              tcpSocket:
+                                                description: Deprecated. TCPSocket
+                                                  is NOT supported as a LifecycleHandler
+                                                  and kept for the backward compatibility.
+                                                  There are no validation of this
+                                                  field and lifecycle hooks will fail
+                                                  in runtime when tcp handler is specified.
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name
+                                                      to connect to, defaults to the
+                                                      pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Number or name of
+                                                      the port to access on the container.
+                                                      Number must be in the range
+                                                      1 to 65535. Name must be an
+                                                      IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                            type: object
+                                          preStop:
+                                            description: 'PreStop is called immediately
+                                              before a container is terminated due
+                                              to an API request or management event
+                                              such as liveness/startup probe failure,
+                                              preemption, resource contention, etc.
+                                              The handler is not called if the container
+                                              crashes or exits. The Pod''s termination
+                                              grace period countdown begins before
+                                              the PreStop hook is executed. Regardless
+                                              of the outcome of the handler, the container
+                                              will eventually terminate within the
+                                              Pod''s termination grace period (unless
+                                              delayed by finalizers). Other management
+                                              of the container blocks until the hook
+                                              completes or until the termination grace
+                                              period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                            properties:
+                                              exec:
+                                                description: Exec specifies the action
+                                                  to take.
+                                                properties:
+                                                  command:
+                                                    description: Command is the command
+                                                      line to execute inside the container,
+                                                      the working directory for the
+                                                      command  is root ('/') in the
+                                                      container's filesystem. The
+                                                      command is simply exec'd, it
+                                                      is not run inside a shell, so
+                                                      traditional shell instructions
+                                                      ('|', etc) won't work. To use
+                                                      a shell, you need to explicitly
+                                                      call out to that shell. Exit
+                                                      status of 0 is treated as live/healthy
+                                                      and non-zero is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the
+                                                  http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: Host name to connect
+                                                      to, defaults to the pod IP.
+                                                      You probably want to set "Host"
+                                                      in httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to
+                                                      set in the request. HTTP allows
+                                                      repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes
+                                                        a custom header to be used
+                                                        in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: The header
+                                                            field name
+                                                          type: string
+                                                        value:
+                                                          description: The header
+                                                            field value
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on
+                                                      the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Name or number of
+                                                      the port to access on the container.
+                                                      Number must be in the range
+                                                      1 to 65535. Name must be an
+                                                      IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: Scheme to use for
+                                                      connecting to the host. Defaults
+                                                      to HTTP.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              tcpSocket:
+                                                description: Deprecated. TCPSocket
+                                                  is NOT supported as a LifecycleHandler
+                                                  and kept for the backward compatibility.
+                                                  There are no validation of this
+                                                  field and lifecycle hooks will fail
+                                                  in runtime when tcp handler is specified.
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name
+                                                      to connect to, defaults to the
+                                                      pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Number or name of
+                                                      the port to access on the container.
+                                                      Number must be in the range
+                                                      1 to 65535. Name must be an
+                                                      IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                            type: object
+                                        type: object
+                                      livenessProbe:
+                                        description: 'Deprecated. This field will
+                                          be removed in a future release. Periodic
+                                          probe of container liveness. Step will be
+                                          restarted if the probe fails. Cannot be
+                                          updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures
+                                              for the probe to be considered failed
+                                              after having succeeded. Defaults to
+                                              3. Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          grpc:
+                                            description: GRPC specifies an action
+                                              involving a GRPC port. This is a beta
+                                              field and requires enabling GRPCContainerProbe
+                                              feature gate.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC
+                                                  service. Number must be in the range
+                                                  1 to 65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                description: "Service is the name
+                                                  of the service to place in the gRPC
+                                                  HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                  \n If this is not specified, the
+                                                  default behavior is defined by gRPC."
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: 'Number of seconds after
+                                              the container has started before liveness
+                                              probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: How often (in seconds) to
+                                              perform the probe. Default to 10 seconds.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes
+                                              for the probe to be considered successful
+                                              after having failed. Defaults to 1.
+                                              Must be 1 for liveness and startup.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds
+                                              the pod needs to terminate gracefully
+                                              upon probe failure. The grace period
+                                              is the duration in seconds after the
+                                              processes running in the pod are sent
+                                              a termination signal and the time when
+                                              the processes are forcibly halted with
+                                              a kill signal. Set this value longer
+                                              than the expected cleanup time for your
+                                              process. If this value is nil, the pod's
+                                              terminationGracePeriodSeconds will be
+                                              used. Otherwise, this value overrides
+                                              the value provided by the pod spec.
+                                              Value must be non-negative integer.
+                                              The value zero indicates stop immediately
+                                              via the kill signal (no opportunity
+                                              to shut down). This is a beta field
+                                              and requires enabling ProbeTerminationGracePeriod
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
+                                            format: int64
+                                            type: integer
+                                          timeoutSeconds:
+                                            description: 'Number of seconds after
+                                              which the probe times out. Defaults
+                                              to 1 second. Minimum value is 1. More
+                                              info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      name:
+                                        description: Name of the Step specified as
+                                          a DNS_LABEL. Each Step in a Task must have
+                                          a unique name.
+                                        type: string
+                                      onError:
+                                        description: OnError defines the exiting behavior
+                                          of a container on error can be set to [
+                                          continue | stopAndFail ]
+                                        type: string
+                                      ports:
+                                        description: Deprecated. This field will be
+                                          removed in a future release. List of ports
+                                          to expose from the Step's container. Exposing
+                                          a port here gives the system additional
+                                          information about the network connections
+                                          a container uses, but is primarily informational.
+                                          Not specifying a port here DOES NOT prevent
+                                          that port from being exposed. Any port which
+                                          is listening on the default "0.0.0.0" address
+                                          inside a container will be accessible from
+                                          the network. Cannot be updated.
+                                        items:
+                                          description: ContainerPort represents a
+                                            network port in a single container.
+                                          properties:
+                                            containerPort:
+                                              description: Number of port to expose
+                                                on the pod's IP address. This must
+                                                be a valid port number, 0 < x < 65536.
+                                              format: int32
+                                              type: integer
+                                            hostIP:
+                                              description: What host IP to bind the
+                                                external port to.
+                                              type: string
+                                            hostPort:
+                                              description: Number of port to expose
+                                                on the host. If specified, this must
+                                                be a valid port number, 0 < x < 65536.
+                                                If HostNetwork is specified, this
+                                                must match ContainerPort. Most containers
+                                                do not need this.
+                                              format: int32
+                                              type: integer
+                                            name:
+                                              description: If specified, this must
+                                                be an IANA_SVC_NAME and unique within
+                                                the pod. Each named port in a pod
+                                                must have a unique name. Name for
+                                                the port that can be referred to by
+                                                services.
+                                              type: string
+                                            protocol:
+                                              default: TCP
+                                              description: Protocol for port. Must
+                                                be UDP, TCP, or SCTP. Defaults to
+                                                "TCP".
+                                              type: string
+                                          required:
+                                          - containerPort
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - containerPort
+                                        - protocol
+                                        x-kubernetes-list-type: map
+                                      readinessProbe:
+                                        description: 'Deprecated. This field will
+                                          be removed in a future release. Periodic
+                                          probe of container service readiness. Step
+                                          will be removed from service endpoints if
+                                          the probe fails. Cannot be updated. More
+                                          info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures
+                                              for the probe to be considered failed
+                                              after having succeeded. Defaults to
+                                              3. Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          grpc:
+                                            description: GRPC specifies an action
+                                              involving a GRPC port. This is a beta
+                                              field and requires enabling GRPCContainerProbe
+                                              feature gate.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC
+                                                  service. Number must be in the range
+                                                  1 to 65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                description: "Service is the name
+                                                  of the service to place in the gRPC
+                                                  HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                  \n If this is not specified, the
+                                                  default behavior is defined by gRPC."
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: 'Number of seconds after
+                                              the container has started before liveness
+                                              probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: How often (in seconds) to
+                                              perform the probe. Default to 10 seconds.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes
+                                              for the probe to be considered successful
+                                              after having failed. Defaults to 1.
+                                              Must be 1 for liveness and startup.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds
+                                              the pod needs to terminate gracefully
+                                              upon probe failure. The grace period
+                                              is the duration in seconds after the
+                                              processes running in the pod are sent
+                                              a termination signal and the time when
+                                              the processes are forcibly halted with
+                                              a kill signal. Set this value longer
+                                              than the expected cleanup time for your
+                                              process. If this value is nil, the pod's
+                                              terminationGracePeriodSeconds will be
+                                              used. Otherwise, this value overrides
+                                              the value provided by the pod spec.
+                                              Value must be non-negative integer.
+                                              The value zero indicates stop immediately
+                                              via the kill signal (no opportunity
+                                              to shut down). This is a beta field
+                                              and requires enabling ProbeTerminationGracePeriod
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
+                                            format: int64
+                                            type: integer
+                                          timeoutSeconds:
+                                            description: 'Number of seconds after
+                                              which the probe times out. Defaults
+                                              to 1 second. Minimum value is 1. More
+                                              info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      resources:
+                                        description: 'Compute Resources required by
+                                          this Step. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Limits describes the maximum
+                                              amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Requests describes the minimum
+                                              amount of compute resources required.
+                                              If Requests is omitted for a container,
+                                              it defaults to Limits if that is explicitly
+                                              specified, otherwise to an implementation-defined
+                                              value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                        type: object
+                                      script:
+                                        description: "Script is the contents of an
+                                          executable file to execute. \n If Script
+                                          is not empty, the Step cannot have an Command
+                                          and the Args will be passed to the Script."
+                                        type: string
+                                      securityContext:
+                                        description: 'SecurityContext defines the
+                                          security options the Step should be run
+                                          with. If set, the fields of SecurityContext
+                                          override the equivalent fields of PodSecurityContext.
+                                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            description: 'AllowPrivilegeEscalation
+                                              controls whether a process can gain
+                                              more privileges than its parent process.
+                                              This bool directly controls if the no_new_privs
+                                              flag will be set on the container process.
+                                              AllowPrivilegeEscalation is true always
+                                              when the container is: 1) run as Privileged
+                                              2) has CAP_SYS_ADMIN Note that this
+                                              field cannot be set when spec.os.name
+                                              is windows.'
+                                            type: boolean
+                                          capabilities:
+                                            description: The capabilities to add/drop
+                                              when running containers. Defaults to
+                                              the default set of capabilities granted
+                                              by the container runtime. Note that
+                                              this field cannot be set when spec.os.name
+                                              is windows.
+                                            properties:
+                                              add:
+                                                description: Added capabilities
+                                                items:
+                                                  description: Capability represent
+                                                    POSIX capabilities type
+                                                  type: string
+                                                type: array
+                                              drop:
+                                                description: Removed capabilities
+                                                items:
+                                                  description: Capability represent
+                                                    POSIX capabilities type
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          privileged:
+                                            description: Run container in privileged
+                                              mode. Processes in privileged containers
+                                              are essentially equivalent to root on
+                                              the host. Defaults to false. Note that
+                                              this field cannot be set when spec.os.name
+                                              is windows.
+                                            type: boolean
+                                          procMount:
+                                            description: procMount denotes the type
+                                              of proc mount to use for the containers.
+                                              The default is DefaultProcMount which
+                                              uses the container runtime defaults
+                                              for readonly paths and masked paths.
+                                              This requires the ProcMountType feature
+                                              flag to be enabled. Note that this field
+                                              cannot be set when spec.os.name is windows.
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            description: Whether this container has
+                                              a read-only root filesystem. Default
+                                              is false. Note that this field cannot
+                                              be set when spec.os.name is windows.
+                                            type: boolean
+                                          runAsGroup:
+                                            description: The GID to run the entrypoint
+                                              of the container process. Uses runtime
+                                              default if unset. May also be set in
+                                              PodSecurityContext.  If set in both
+                                              SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence. Note that this field
+                                              cannot be set when spec.os.name is windows.
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            description: Indicates that the container
+                                              must run as a non-root user. If true,
+                                              the Kubelet will validate the image
+                                              at runtime to ensure that it does not
+                                              run as UID 0 (root) and fail to start
+                                              the container if it does. If unset or
+                                              false, no such validation will be performed.
+                                              May also be set in PodSecurityContext.  If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence.
+                                            type: boolean
+                                          runAsUser:
+                                            description: The UID to run the entrypoint
+                                              of the container process. Defaults to
+                                              user specified in image metadata if
+                                              unspecified. May also be set in PodSecurityContext.  If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence. Note that this field
+                                              cannot be set when spec.os.name is windows.
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            description: The SELinux context to be
+                                              applied to the container. If unspecified,
+                                              the container runtime will allocate
+                                              a random SELinux context for each container.  May
+                                              also be set in PodSecurityContext.  If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence. Note that this field
+                                              cannot be set when spec.os.name is windows.
+                                            properties:
+                                              level:
+                                                description: Level is SELinux level
+                                                  label that applies to the container.
+                                                type: string
+                                              role:
+                                                description: Role is a SELinux role
+                                                  label that applies to the container.
+                                                type: string
+                                              type:
+                                                description: Type is a SELinux type
+                                                  label that applies to the container.
+                                                type: string
+                                              user:
+                                                description: User is a SELinux user
+                                                  label that applies to the container.
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            description: The seccomp options to use
+                                              by this container. If seccomp options
+                                              are provided at both the pod & container
+                                              level, the container options override
+                                              the pod options. Note that this field
+                                              cannot be set when spec.os.name is windows.
+                                            properties:
+                                              localhostProfile:
+                                                description: localhostProfile indicates
+                                                  a profile defined in a file on the
+                                                  node should be used. The profile
+                                                  must be preconfigured on the node
+                                                  to work. Must be a descending path,
+                                                  relative to the kubelet's configured
+                                                  seccomp profile location. Must only
+                                                  be set if type is "Localhost".
+                                                type: string
+                                              type:
+                                                description: "type indicates which
+                                                  kind of seccomp profile will be
+                                                  applied. Valid options are: \n Localhost
+                                                  - a profile defined in a file on
+                                                  the node should be used. RuntimeDefault
+                                                  - the container runtime default
+                                                  profile should be used. Unconfined
+                                                  - no profile should be applied."
+                                                type: string
+                                            required:
+                                            - type
+                                            type: object
+                                          windowsOptions:
+                                            description: The Windows specific settings
+                                              applied to all containers. If unspecified,
+                                              the options from the PodSecurityContext
+                                              will be used. If set in both SecurityContext
+                                              and PodSecurityContext, the value specified
+                                              in SecurityContext takes precedence.
+                                              Note that this field cannot be set when
+                                              spec.os.name is linux.
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                description: GMSACredentialSpec is
+                                                  where the GMSA admission webhook
+                                                  (https://github.com/kubernetes-sigs/windows-gmsa)
+                                                  inlines the contents of the GMSA
+                                                  credential spec named by the GMSACredentialSpecName
+                                                  field.
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                description: GMSACredentialSpecName
+                                                  is the name of the GMSA credential
+                                                  spec to use.
+                                                type: string
+                                              hostProcess:
+                                                description: HostProcess determines
+                                                  if a container should be run as
+                                                  a 'Host Process' container. This
+                                                  field is alpha-level and will only
+                                                  be honored by components that enable
+                                                  the WindowsHostProcessContainers
+                                                  feature flag. Setting this field
+                                                  without the feature flag will result
+                                                  in errors when validating the Pod.
+                                                  All of a Pod's containers must have
+                                                  the same effective HostProcess value
+                                                  (it is not allowed to have a mix
+                                                  of HostProcess containers and non-HostProcess
+                                                  containers).  In addition, if HostProcess
+                                                  is true then HostNetwork must also
+                                                  be set to true.
+                                                type: boolean
+                                              runAsUserName:
+                                                description: The UserName in Windows
+                                                  to run the entrypoint of the container
+                                                  process. Defaults to the user specified
+                                                  in image metadata if unspecified.
+                                                  May also be set in PodSecurityContext.
+                                                  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified
+                                                  in SecurityContext takes precedence.
+                                                type: string
+                                            type: object
+                                        type: object
+                                      startupProbe:
+                                        description: 'Deprecated. This field will
+                                          be removed in a future release. DeprecatedStartupProbe
+                                          indicates that the Pod this Step runs in
+                                          has successfully initialized. If specified,
+                                          no other probes are executed until this
+                                          completes successfully. If this probe fails,
+                                          the Pod will be restarted, just as if the
+                                          livenessProbe failed. This can be used to
+                                          provide different probe parameters at the
+                                          beginning of a Pod''s lifecycle, when it
+                                          might take a long time to load data or warm
+                                          a cache, than during steady-state operation.
+                                          This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures
+                                              for the probe to be considered failed
+                                              after having succeeded. Defaults to
+                                              3. Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          grpc:
+                                            description: GRPC specifies an action
+                                              involving a GRPC port. This is a beta
+                                              field and requires enabling GRPCContainerProbe
+                                              feature gate.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC
+                                                  service. Number must be in the range
+                                                  1 to 65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                description: "Service is the name
+                                                  of the service to place in the gRPC
+                                                  HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                  \n If this is not specified, the
+                                                  default behavior is defined by gRPC."
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: 'Number of seconds after
+                                              the container has started before liveness
+                                              probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: How often (in seconds) to
+                                              perform the probe. Default to 10 seconds.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes
+                                              for the probe to be considered successful
+                                              after having failed. Defaults to 1.
+                                              Must be 1 for liveness and startup.
+                                              Minimum value is 1.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds
+                                              the pod needs to terminate gracefully
+                                              upon probe failure. The grace period
+                                              is the duration in seconds after the
+                                              processes running in the pod are sent
+                                              a termination signal and the time when
+                                              the processes are forcibly halted with
+                                              a kill signal. Set this value longer
+                                              than the expected cleanup time for your
+                                              process. If this value is nil, the pod's
+                                              terminationGracePeriodSeconds will be
+                                              used. Otherwise, this value overrides
+                                              the value provided by the pod spec.
+                                              Value must be non-negative integer.
+                                              The value zero indicates stop immediately
+                                              via the kill signal (no opportunity
+                                              to shut down). This is a beta field
+                                              and requires enabling ProbeTerminationGracePeriod
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
+                                            format: int64
+                                            type: integer
+                                          timeoutSeconds:
+                                            description: 'Number of seconds after
+                                              which the probe times out. Defaults
+                                              to 1 second. Minimum value is 1. More
+                                              info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      stderrConfig:
+                                        description: Stores configuration for the
+                                          stderr stream of the step.
+                                        properties:
+                                          path:
+                                            description: Path to duplicate stdout
+                                              stream to on container's local filesystem.
+                                            type: string
+                                        type: object
+                                      stdin:
+                                        description: Deprecated. This field will be
+                                          removed in a future release. Whether this
+                                          container should allocate a buffer for stdin
+                                          in the container runtime. If this is not
+                                          set, reads from stdin in the container will
+                                          always result in EOF. Default is false.
+                                        type: boolean
+                                      stdinOnce:
+                                        description: Deprecated. This field will be
+                                          removed in a future release. Whether the
+                                          container runtime should close the stdin
+                                          channel after it has been opened by a single
+                                          attach. When stdin is true the stdin stream
+                                          will remain open across multiple attach
+                                          sessions. If stdinOnce is set to true, stdin
+                                          is opened on container start, is empty until
+                                          the first client attaches to stdin, and
+                                          then remains open and accepts data until
+                                          the client disconnects, at which time stdin
+                                          is closed and remains closed until the container
+                                          is restarted. If this flag is false, a container
+                                          processes that reads from stdin will never
+                                          receive an EOF. Default is false
+                                        type: boolean
+                                      stdoutConfig:
+                                        description: Stores configuration for the
+                                          stdout stream of the step.
+                                        properties:
+                                          path:
+                                            description: Path to duplicate stdout
+                                              stream to on container's local filesystem.
+                                            type: string
+                                        type: object
+                                      terminationMessagePath:
+                                        description: Deprecated. This field will be
+                                          removed in a future release and can't be
+                                          meaningfully used.
+                                        type: string
+                                      terminationMessagePolicy:
+                                        description: Deprecated. This field will be
+                                          removed in a future release and can't be
+                                          meaningfully used.
+                                        type: string
+                                      timeout:
+                                        description: 'Timeout is the time after which
+                                          the step times out. Defaults to never. Refer
+                                          to Go''s ParseDuration documentation for
+                                          expected format: https://golang.org/pkg/time/#ParseDuration'
+                                        type: string
+                                      tty:
+                                        description: Deprecated. This field will be
+                                          removed in a future release. Whether this
+                                          container should allocate a DeprecatedTTY
+                                          for itself, also requires 'stdin' to be
+                                          true. Default is false.
+                                        type: boolean
+                                      volumeDevices:
+                                        description: volumeDevices is the list of
+                                          block devices to be used by the Step.
+                                        items:
+                                          description: volumeDevice describes a mapping
+                                            of a raw block device within a container.
+                                          properties:
+                                            devicePath:
+                                              description: devicePath is the path
+                                                inside of the container that the device
+                                                will be mapped to.
+                                              type: string
+                                            name:
+                                              description: name must match the name
+                                                of a persistentVolumeClaim in the
+                                                pod
+                                              type: string
+                                          required:
+                                          - devicePath
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      volumeMounts:
+                                        description: Volumes to mount into the Step's
+                                          filesystem. Cannot be updated.
+                                        items:
+                                          description: VolumeMount describes a mounting
+                                            of a Volume within a container.
+                                          properties:
+                                            mountPath:
+                                              description: Path within the container
+                                                at which the volume should be mounted.  Must
+                                                not contain ':'.
+                                              type: string
+                                            mountPropagation:
+                                              description: mountPropagation determines
+                                                how mounts are propagated from the
+                                                host to container and the other way
+                                                around. When not set, MountPropagationNone
+                                                is used. This field is beta in 1.10.
+                                              type: string
+                                            name:
+                                              description: This must match the Name
+                                                of a Volume.
+                                              type: string
+                                            readOnly:
+                                              description: Mounted read-only if true,
+                                                read-write otherwise (false or unspecified).
+                                                Defaults to false.
+                                              type: boolean
+                                            subPath:
+                                              description: Path within the volume
+                                                from which the container's volume
+                                                should be mounted. Defaults to ""
+                                                (volume's root).
+                                              type: string
+                                            subPathExpr:
+                                              description: Expanded path within the
+                                                volume from which the container's
+                                                volume should be mounted. Behaves
+                                                similarly to SubPath but environment
+                                                variable references $(VAR_NAME) are
+                                                expanded using the container's environment.
+                                                Defaults to "" (volume's root). SubPathExpr
+                                                and SubPath are mutually exclusive.
+                                              type: string
+                                          required:
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      workingDir:
+                                        description: Step's working directory. If
+                                          not specified, the container runtime's default
+                                          will be used, which might be configured
+                                          in the container image. Cannot be updated.
+                                        type: string
+                                      workspaces:
+                                        description: "This is an alpha field. You
+                                          must set the \"enable-api-fields\" feature
+                                          flag to \"alpha\" for this field to be supported.
+                                          \n Workspaces is a list of workspaces from
+                                          the Task that this Step wants exclusive
+                                          access to. Adding a workspace to this list
+                                          means that any other Step or Sidecar that
+                                          does not also request this Workspace will
+                                          not have access to it."
+                                        items:
+                                          description: WorkspaceUsage is used by a
+                                            Step or Sidecar to declare that it wants
+                                            isolated access to a Workspace defined
+                                            in a Task.
+                                          properties:
+                                            mountPath:
+                                              description: MountPath is the path that
+                                                the workspace should be mounted to
+                                                inside the Step or Sidecar, overriding
+                                                any MountPath specified in the Task's
+                                                WorkspaceDeclaration.
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                workspace this Step or Sidecar wants
+                                                access to.
+                                              type: string
+                                          required:
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                volumes:
+                                  description: Volumes is a collection of volumes
+                                    that are available to mount into the steps of
+                                    the build.
+                                  items:
+                                    description: Volume represents a named volume
+                                      in a pod that may be accessed by any container
+                                      in the pod.
+                                    properties:
+                                      awsElasticBlockStore:
+                                        description: 'awsElasticBlockStore represents
+                                          an AWS Disk resource that is attached to
+                                          a kubelet''s host machine and then exposed
+                                          to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        properties:
+                                          fsType:
+                                            description: 'fsType is the filesystem
+                                              type of the volume that you want to
+                                              mount. Tip: Ensure that the filesystem
+                                              type is supported by the host operating
+                                              system. Examples: "ext4", "xfs", "ntfs".
+                                              Implicitly inferred to be "ext4" if
+                                              unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                              TODO: how do we prevent errors in the
+                                              filesystem from compromising the machine'
+                                            type: string
+                                          partition:
+                                            description: 'partition is the partition
+                                              in the volume that you want to mount.
+                                              If omitted, the default is to mount
+                                              by volume name. Examples: For volume
+                                              /dev/sda1, you specify the partition
+                                              as "1". Similarly, the volume partition
+                                              for /dev/sda is "0" (or you can leave
+                                              the property empty).'
+                                            format: int32
+                                            type: integer
+                                          readOnly:
+                                            description: 'readOnly value true will
+                                              force the readOnly setting in VolumeMounts.
+                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                            type: boolean
+                                          volumeID:
+                                            description: 'volumeID is unique ID of
+                                              the persistent disk resource in AWS
+                                              (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                            type: string
+                                        required:
+                                        - volumeID
+                                        type: object
+                                      azureDisk:
+                                        description: azureDisk represents an Azure
+                                          Data Disk mount on the host and bind mount
+                                          to the pod.
+                                        properties:
+                                          cachingMode:
+                                            description: 'cachingMode is the Host
+                                              Caching mode: None, Read Only, Read
+                                              Write.'
+                                            type: string
+                                          diskName:
+                                            description: diskName is the Name of the
+                                              data disk in the blob storage
+                                            type: string
+                                          diskURI:
+                                            description: diskURI is the URI of data
+                                              disk in the blob storage
+                                            type: string
+                                          fsType:
+                                            description: fsType is Filesystem type
+                                              to mount. Must be a filesystem type
+                                              supported by the host operating system.
+                                              Ex. "ext4", "xfs", "ntfs". Implicitly
+                                              inferred to be "ext4" if unspecified.
+                                            type: string
+                                          kind:
+                                            description: 'kind expected values are
+                                              Shared: multiple blob disks per storage
+                                              account  Dedicated: single blob disk
+                                              per storage account  Managed: azure
+                                              managed data disk (only in managed availability
+                                              set). defaults to shared'
+                                            type: string
+                                          readOnly:
+                                            description: readOnly Defaults to false
+                                              (read/write). ReadOnly here will force
+                                              the ReadOnly setting in VolumeMounts.
+                                            type: boolean
+                                        required:
+                                        - diskName
+                                        - diskURI
+                                        type: object
+                                      azureFile:
+                                        description: azureFile represents an Azure
+                                          File Service mount on the host and bind
+                                          mount to the pod.
+                                        properties:
+                                          readOnly:
+                                            description: readOnly defaults to false
+                                              (read/write). ReadOnly here will force
+                                              the ReadOnly setting in VolumeMounts.
+                                            type: boolean
+                                          secretName:
+                                            description: secretName is the  name of
+                                              secret that contains Azure Storage Account
+                                              Name and Key
+                                            type: string
+                                          shareName:
+                                            description: shareName is the azure share
+                                              Name
+                                            type: string
+                                        required:
+                                        - secretName
+                                        - shareName
+                                        type: object
+                                      cephfs:
+                                        description: cephFS represents a Ceph FS mount
+                                          on the host that shares a pod's lifetime
+                                        properties:
+                                          monitors:
+                                            description: 'monitors is Required: Monitors
+                                              is a collection of Ceph monitors More
+                                              info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                            items:
+                                              type: string
+                                            type: array
+                                          path:
+                                            description: 'path is Optional: Used as
+                                              the mounted root, rather than the full
+                                              Ceph tree, default is /'
+                                            type: string
+                                          readOnly:
+                                            description: 'readOnly is Optional: Defaults
+                                              to false (read/write). ReadOnly here
+                                              will force the ReadOnly setting in VolumeMounts.
+                                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                            type: boolean
+                                          secretFile:
+                                            description: 'secretFile is Optional:
+                                              SecretFile is the path to key ring for
+                                              User, default is /etc/ceph/user.secret
+                                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                            type: string
+                                          secretRef:
+                                            description: 'secretRef is Optional: SecretRef
+                                              is reference to the authentication secret
+                                              for User, default is empty. More info:
+                                              https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                            type: object
+                                          user:
+                                            description: 'user is optional: User is
+                                              the rados user name, default is admin
+                                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                            type: string
+                                        required:
+                                        - monitors
+                                        type: object
+                                      cinder:
+                                        description: 'cinder represents a cinder volume
+                                          attached and mounted on kubelets host machine.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        properties:
+                                          fsType:
+                                            description: 'fsType is the filesystem
+                                              type to mount. Must be a filesystem
+                                              type supported by the host operating
+                                              system. Examples: "ext4", "xfs", "ntfs".
+                                              Implicitly inferred to be "ext4" if
+                                              unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                            type: string
+                                          readOnly:
+                                            description: 'readOnly defaults to false
+                                              (read/write). ReadOnly here will force
+                                              the ReadOnly setting in VolumeMounts.
+                                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                            type: boolean
+                                          secretRef:
+                                            description: 'secretRef is optional: points
+                                              to a secret object containing parameters
+                                              used to connect to OpenStack.'
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                            type: object
+                                          volumeID:
+                                            description: 'volumeID used to identify
+                                              the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                            type: string
+                                        required:
+                                        - volumeID
+                                        type: object
+                                      configMap:
+                                        description: configMap represents a configMap
+                                          that should populate this volume
+                                        properties:
+                                          defaultMode:
+                                            description: 'defaultMode is optional:
+                                              mode bits used to set permissions on
+                                              created files by default. Must be an
+                                              octal value between 0000 and 0777 or
+                                              a decimal value between 0 and 511. YAML
+                                              accepts both octal and decimal values,
+                                              JSON requires decimal values for mode
+                                              bits. Defaults to 0644. Directories
+                                              within the path are not affected by
+                                              this setting. This might be in conflict
+                                              with other options that affect the file
+                                              mode, like fsGroup, and the result can
+                                              be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          items:
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced ConfigMap will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the ConfigMap, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                      csi:
+                                        description: csi (Container Storage Interface)
+                                          represents ephemeral storage that is handled
+                                          by certain external CSI drivers (Beta feature).
+                                        properties:
+                                          driver:
+                                            description: driver is the name of the
+                                              CSI driver that handles this volume.
+                                              Consult with your admin for the correct
+                                              name as registered in the cluster.
+                                            type: string
+                                          fsType:
+                                            description: fsType to mount. Ex. "ext4",
+                                              "xfs", "ntfs". If not provided, the
+                                              empty value is passed to the associated
+                                              CSI driver which will determine the
+                                              default filesystem to apply.
+                                            type: string
+                                          nodePublishSecretRef:
+                                            description: nodePublishSecretRef is a
+                                              reference to the secret object containing
+                                              sensitive information to pass to the
+                                              CSI driver to complete the CSI NodePublishVolume
+                                              and NodeUnpublishVolume calls. This
+                                              field is optional, and  may be empty
+                                              if no secret is required. If the secret
+                                              object contains more than one secret,
+                                              all secret references are passed.
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                            type: object
+                                          readOnly:
+                                            description: readOnly specifies a read-only
+                                              configuration for the volume. Defaults
+                                              to false (read/write).
+                                            type: boolean
+                                          volumeAttributes:
+                                            additionalProperties:
+                                              type: string
+                                            description: volumeAttributes stores driver-specific
+                                              properties that are passed to the CSI
+                                              driver. Consult your driver's documentation
+                                              for supported values.
+                                            type: object
+                                        required:
+                                        - driver
+                                        type: object
+                                      downwardAPI:
+                                        description: downwardAPI represents downward
+                                          API about the pod that should populate this
+                                          volume
+                                        properties:
+                                          defaultMode:
+                                            description: 'Optional: mode bits to use
+                                              on created files by default. Must be
+                                              a Optional: mode bits used to set permissions
+                                              on created files by default. Must be
+                                              an octal value between 0000 and 0777
+                                              or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal
+                                              values, JSON requires decimal values
+                                              for mode bits. Defaults to 0644. Directories
+                                              within the path are not affected by
+                                              this setting. This might be in conflict
+                                              with other options that affect the file
+                                              mode, like fsGroup, and the result can
+                                              be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          items:
+                                            description: Items is a list of downward
+                                              API volume file
+                                            items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
+                                              properties:
+                                                fieldRef:
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name and namespace are
+                                                    supported.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                mode:
+                                                  description: 'Optional: mode bits
+                                                    used to set permissions on this
+                                                    file, must be an octal value between
+                                                    0000 and 0777 or a decimal value
+                                                    between 0 and 511. YAML accepts
+                                                    both octal and decimal values,
+                                                    JSON requires decimal values for
+                                                    mode bits. If not specified, the
+                                                    volume defaultMode will be used.
+                                                    This might be in conflict with
+                                                    other options that affect the
+                                                    file mode, like fsGroup, and the
+                                                    result can be other mode bits
+                                                    set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path. Must
+                                                    be utf-8 encoded. The first item
+                                                    of the relative path must not
+                                                    start with ''..'''
+                                                  type: string
+                                                resourceFieldRef:
+                                                  description: 'Selects a resource
+                                                    of the container: only resources
+                                                    limits and requests (limits.cpu,
+                                                    limits.memory, requests.cpu and
+                                                    requests.memory) are currently
+                                                    supported.'
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                              required:
+                                              - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      emptyDir:
+                                        description: 'emptyDir represents a temporary
+                                          directory that shares a pod''s lifetime.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        properties:
+                                          medium:
+                                            description: 'medium represents what type
+                                              of storage medium should back this directory.
+                                              The default is "" which means to use
+                                              the node''s default medium. Must be
+                                              an empty string (default) or Memory.
+                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                            type: string
+                                          sizeLimit:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: 'sizeLimit is the total amount
+                                              of local storage required for this EmptyDir
+                                              volume. The size limit is also applicable
+                                              for memory medium. The maximum usage
+                                              on memory medium EmptyDir would be the
+                                              minimum value between the SizeLimit
+                                              specified here and the sum of memory
+                                              limits of all containers in a pod. The
+                                              default is nil which means that the
+                                              limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      ephemeral:
+                                        description: "ephemeral represents a volume
+                                          that is handled by a cluster storage driver.
+                                          The volume's lifecycle is tied to the pod
+                                          that defines it - it will be created before
+                                          the pod starts, and deleted when the pod
+                                          is removed. \n Use this if: a) the volume
+                                          is only needed while the pod runs, b) features
+                                          of normal volumes like restoring from snapshot
+                                          or capacity    tracking are needed, c) the
+                                          storage driver is specified through a storage
+                                          class, and d) the storage driver supports
+                                          dynamic volume provisioning through    a
+                                          PersistentVolumeClaim (see EphemeralVolumeSource
+                                          for more    information on the connection
+                                          between this volume type    and PersistentVolumeClaim).
+                                          \n Use PersistentVolumeClaim or one of the
+                                          vendor-specific APIs for volumes that persist
+                                          for longer than the lifecycle of an individual
+                                          pod. \n Use CSI for light-weight local ephemeral
+                                          volumes if the CSI driver is meant to be
+                                          used that way - see the documentation of
+                                          the driver for more information. \n A pod
+                                          can use both types of ephemeral volumes
+                                          and persistent volumes at the same time."
+                                        properties:
+                                          volumeClaimTemplate:
+                                            description: "Will be used to create a
+                                              stand-alone PVC to provision the volume.
+                                              The pod in which this EphemeralVolumeSource
+                                              is embedded will be the owner of the
+                                              PVC, i.e. the PVC will be deleted together
+                                              with the pod.  The name of the PVC will
+                                              be `<pod name>-<volume name>` where
+                                              `<volume name>` is the name from the
+                                              `PodSpec.Volumes` array entry. Pod validation
+                                              will reject the pod if the concatenated
+                                              name is not valid for a PVC (for example,
+                                              too long). \n An existing PVC with that
+                                              name that is not owned by the pod will
+                                              *not* be used for the pod to avoid using
+                                              an unrelated volume by mistake. Starting
+                                              the pod is then blocked until the unrelated
+                                              PVC is removed. If such a pre-created
+                                              PVC is meant to be used by the pod,
+                                              the PVC has to updated with an owner
+                                              reference to the pod once the pod exists.
+                                              Normally this should not be necessary,
+                                              but it may be useful when manually reconstructing
+                                              a broken cluster. \n This field is read-only
+                                              and no changes will be made by Kubernetes
+                                              to the PVC after it has been created.
+                                              \n Required, must not be nil."
+                                            properties:
+                                              metadata:
+                                                description: May contain labels and
+                                                  annotations that will be copied
+                                                  into the PVC when creating it. No
+                                                  other fields are allowed and will
+                                                  be rejected during validation.
+                                                type: object
+                                              spec:
+                                                description: The specification for
+                                                  the PersistentVolumeClaim. The entire
+                                                  content is copied unchanged into
+                                                  the PVC that gets created from this
+                                                  template. The same fields as in
+                                                  a PersistentVolumeClaim are also
+                                                  valid here.
+                                                properties:
+                                                  accessModes:
+                                                    description: 'accessModes contains
+                                                      the desired access modes the
+                                                      volume should have. More info:
+                                                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  dataSource:
+                                                    description: 'dataSource field
+                                                      can be used to specify either:
+                                                      * An existing VolumeSnapshot
+                                                      object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                      * An existing PVC (PersistentVolumeClaim)
+                                                      If the provisioner or an external
+                                                      controller can support the specified
+                                                      data source, it will create
+                                                      a new volume based on the contents
+                                                      of the specified data source.
+                                                      If the AnyVolumeDataSource feature
+                                                      gate is enabled, this field
+                                                      will always have the same contents
+                                                      as the DataSourceRef field.'
+                                                    properties:
+                                                      apiGroup:
+                                                        description: APIGroup is the
+                                                          group for the resource being
+                                                          referenced. If APIGroup
+                                                          is not specified, the specified
+                                                          Kind must be in the core
+                                                          API group. For any other
+                                                          third-party types, APIGroup
+                                                          is required.
+                                                        type: string
+                                                      kind:
+                                                        description: Kind is the type
+                                                          of resource being referenced
+                                                        type: string
+                                                      name:
+                                                        description: Name is the name
+                                                          of resource being referenced
+                                                        type: string
+                                                    required:
+                                                    - kind
+                                                    - name
+                                                    type: object
+                                                  dataSourceRef:
+                                                    description: 'dataSourceRef specifies
+                                                      the object from which to populate
+                                                      the volume with data, if a non-empty
+                                                      volume is desired. This may
+                                                      be any local object from a non-empty
+                                                      API group (non core object)
+                                                      or a PersistentVolumeClaim object.
+                                                      When this field is specified,
+                                                      volume binding will only succeed
+                                                      if the type of the specified
+                                                      object matches some installed
+                                                      volume populator or dynamic
+                                                      provisioner. This field will
+                                                      replace the functionality of
+                                                      the DataSource field and as
+                                                      such if both fields are non-empty,
+                                                      they must have the same value.
+                                                      For backwards compatibility,
+                                                      both fields (DataSource and
+                                                      DataSourceRef) will be set to
+                                                      the same value automatically
+                                                      if one of them is empty and
+                                                      the other is non-empty. There
+                                                      are two important differences
+                                                      between DataSource and DataSourceRef:
+                                                      * While DataSource only allows
+                                                      two specific types of objects,
+                                                      DataSourceRef   allows any non-core
+                                                      object, as well as PersistentVolumeClaim
+                                                      objects. * While DataSource
+                                                      ignores disallowed values (dropping
+                                                      them), DataSourceRef   preserves
+                                                      all values, and generates an
+                                                      error if a disallowed value
+                                                      is   specified. (Beta) Using
+                                                      this field requires the AnyVolumeDataSource
+                                                      feature gate to be enabled.'
+                                                    properties:
+                                                      apiGroup:
+                                                        description: APIGroup is the
+                                                          group for the resource being
+                                                          referenced. If APIGroup
+                                                          is not specified, the specified
+                                                          Kind must be in the core
+                                                          API group. For any other
+                                                          third-party types, APIGroup
+                                                          is required.
+                                                        type: string
+                                                      kind:
+                                                        description: Kind is the type
+                                                          of resource being referenced
+                                                        type: string
+                                                      name:
+                                                        description: Name is the name
+                                                          of resource being referenced
+                                                        type: string
+                                                    required:
+                                                    - kind
+                                                    - name
+                                                    type: object
+                                                  resources:
+                                                    description: 'resources represents
+                                                      the minimum resources the volume
+                                                      should have. If RecoverVolumeExpansionFailure
+                                                      feature is enabled users are
+                                                      allowed to specify resource
+                                                      requirements that are lower
+                                                      than previous value but must
+                                                      still be higher than capacity
+                                                      recorded in the status field
+                                                      of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                    properties:
+                                                      limits:
+                                                        additionalProperties:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        description: 'Limits describes
+                                                          the maximum amount of compute
+                                                          resources allowed. More
+                                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                        type: object
+                                                      requests:
+                                                        additionalProperties:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        description: 'Requests describes
+                                                          the minimum amount of compute
+                                                          resources required. If Requests
+                                                          is omitted for a container,
+                                                          it defaults to Limits if
+                                                          that is explicitly specified,
+                                                          otherwise to an implementation-defined
+                                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                        type: object
+                                                    type: object
+                                                  selector:
+                                                    description: selector is a label
+                                                      query over volumes to consider
+                                                      for binding.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions
+                                                          is a list of label selector
+                                                          requirements. The requirements
+                                                          are ANDed.
+                                                        items:
+                                                          description: A label selector
+                                                            requirement is a selector
+                                                            that contains values,
+                                                            a key, and an operator
+                                                            that relates the key and
+                                                            values.
+                                                          properties:
+                                                            key:
+                                                              description: key is
+                                                                the label key that
+                                                                the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator
+                                                                represents a key's
+                                                                relationship to a
+                                                                set of values. Valid
+                                                                operators are In,
+                                                                NotIn, Exists and
+                                                                DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values
+                                                                is an array of string
+                                                                values. If the operator
+                                                                is In or NotIn, the
+                                                                values array must
+                                                                be non-empty. If the
+                                                                operator is Exists
+                                                                or DoesNotExist, the
+                                                                values array must
+                                                                be empty. This array
+                                                                is replaced during
+                                                                a strategic merge
+                                                                patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: matchLabels is
+                                                          a map of {key,value} pairs.
+                                                          A single {key,value} in
+                                                          the matchLabels map is equivalent
+                                                          to an element of matchExpressions,
+                                                          whose key field is "key",
+                                                          the operator is "In", and
+                                                          the values array contains
+                                                          only "value". The requirements
+                                                          are ANDed.
+                                                        type: object
+                                                    type: object
+                                                  storageClassName:
+                                                    description: 'storageClassName
+                                                      is the name of the StorageClass
+                                                      required by the claim. More
+                                                      info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                    type: string
+                                                  volumeMode:
+                                                    description: volumeMode defines
+                                                      what type of volume is required
+                                                      by the claim. Value of Filesystem
+                                                      is implied when not included
+                                                      in claim spec.
+                                                    type: string
+                                                  volumeName:
+                                                    description: volumeName is the
+                                                      binding reference to the PersistentVolume
+                                                      backing this claim.
+                                                    type: string
+                                                type: object
+                                            required:
+                                            - spec
+                                            type: object
+                                        type: object
+                                      fc:
+                                        description: fc represents a Fibre Channel
+                                          resource that is attached to a kubelet's
+                                          host machine and then exposed to the pod.
+                                        properties:
+                                          fsType:
+                                            description: 'fsType is the filesystem
+                                              type to mount. Must be a filesystem
+                                              type supported by the host operating
+                                              system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                              inferred to be "ext4" if unspecified.
+                                              TODO: how do we prevent errors in the
+                                              filesystem from compromising the machine'
+                                            type: string
+                                          lun:
+                                            description: 'lun is Optional: FC target
+                                              lun number'
+                                            format: int32
+                                            type: integer
+                                          readOnly:
+                                            description: 'readOnly is Optional: Defaults
+                                              to false (read/write). ReadOnly here
+                                              will force the ReadOnly setting in VolumeMounts.'
+                                            type: boolean
+                                          targetWWNs:
+                                            description: 'targetWWNs is Optional:
+                                              FC target worldwide names (WWNs)'
+                                            items:
+                                              type: string
+                                            type: array
+                                          wwids:
+                                            description: 'wwids Optional: FC volume
+                                              world wide identifiers (wwids) Either
+                                              wwids or combination of targetWWNs and
+                                              lun must be set, but not both simultaneously.'
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      flexVolume:
+                                        description: flexVolume represents a generic
+                                          volume resource that is provisioned/attached
+                                          using an exec based plugin.
+                                        properties:
+                                          driver:
+                                            description: driver is the name of the
+                                              driver to use for this volume.
+                                            type: string
+                                          fsType:
+                                            description: fsType is the filesystem
+                                              type to mount. Must be a filesystem
+                                              type supported by the host operating
+                                              system. Ex. "ext4", "xfs", "ntfs". The
+                                              default filesystem depends on FlexVolume
+                                              script.
+                                            type: string
+                                          options:
+                                            additionalProperties:
+                                              type: string
+                                            description: 'options is Optional: this
+                                              field holds extra command options if
+                                              any.'
+                                            type: object
+                                          readOnly:
+                                            description: 'readOnly is Optional: defaults
+                                              to false (read/write). ReadOnly here
+                                              will force the ReadOnly setting in VolumeMounts.'
+                                            type: boolean
+                                          secretRef:
+                                            description: 'secretRef is Optional: secretRef
+                                              is reference to the secret object containing
+                                              sensitive information to pass to the
+                                              plugin scripts. This may be empty if
+                                              no secret object is specified. If the
+                                              secret object contains more than one
+                                              secret, all secrets are passed to the
+                                              plugin scripts.'
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                            type: object
+                                        required:
+                                        - driver
+                                        type: object
+                                      flocker:
+                                        description: flocker represents a Flocker
+                                          volume attached to a kubelet's host machine.
+                                          This depends on the Flocker control service
+                                          being running
+                                        properties:
+                                          datasetName:
+                                            description: datasetName is Name of the
+                                              dataset stored as metadata -> name on
+                                              the dataset for Flocker should be considered
+                                              as deprecated
+                                            type: string
+                                          datasetUUID:
+                                            description: datasetUUID is the UUID of
+                                              the dataset. This is unique identifier
+                                              of a Flocker dataset
+                                            type: string
+                                        type: object
+                                      gcePersistentDisk:
+                                        description: 'gcePersistentDisk represents
+                                          a GCE Disk resource that is attached to
+                                          a kubelet''s host machine and then exposed
+                                          to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        properties:
+                                          fsType:
+                                            description: 'fsType is filesystem type
+                                              of the volume that you want to mount.
+                                              Tip: Ensure that the filesystem type
+                                              is supported by the host operating system.
+                                              Examples: "ext4", "xfs", "ntfs". Implicitly
+                                              inferred to be "ext4" if unspecified.
+                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                              TODO: how do we prevent errors in the
+                                              filesystem from compromising the machine'
+                                            type: string
+                                          partition:
+                                            description: 'partition is the partition
+                                              in the volume that you want to mount.
+                                              If omitted, the default is to mount
+                                              by volume name. Examples: For volume
+                                              /dev/sda1, you specify the partition
+                                              as "1". Similarly, the volume partition
+                                              for /dev/sda is "0" (or you can leave
+                                              the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                            format: int32
+                                            type: integer
+                                          pdName:
+                                            description: 'pdName is unique name of
+                                              the PD resource in GCE. Used to identify
+                                              the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                            type: string
+                                          readOnly:
+                                            description: 'readOnly here will force
+                                              the ReadOnly setting in VolumeMounts.
+                                              Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                            type: boolean
+                                        required:
+                                        - pdName
+                                        type: object
+                                      gitRepo:
+                                        description: 'gitRepo represents a git repository
+                                          at a particular revision. DEPRECATED: GitRepo
+                                          is deprecated. To provision a container
+                                          with a git repo, mount an EmptyDir into
+                                          an InitContainer that clones the repo using
+                                          git, then mount the EmptyDir into the Pod''s
+                                          container.'
+                                        properties:
+                                          directory:
+                                            description: directory is the target directory
+                                              name. Must not contain or start with
+                                              '..'.  If '.' is supplied, the volume
+                                              directory will be the git repository.  Otherwise,
+                                              if specified, the volume will contain
+                                              the git repository in the subdirectory
+                                              with the given name.
+                                            type: string
+                                          repository:
+                                            description: repository is the URL
+                                            type: string
+                                          revision:
+                                            description: revision is the commit hash
+                                              for the specified revision.
+                                            type: string
+                                        required:
+                                        - repository
+                                        type: object
+                                      glusterfs:
+                                        description: 'glusterfs represents a Glusterfs
+                                          mount on the host that shares a pod''s lifetime.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                        properties:
+                                          endpoints:
+                                            description: 'endpoints is the endpoint
+                                              name that details Glusterfs topology.
+                                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                            type: string
+                                          path:
+                                            description: 'path is the Glusterfs volume
+                                              path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                            type: string
+                                          readOnly:
+                                            description: 'readOnly here will force
+                                              the Glusterfs volume to be mounted with
+                                              read-only permissions. Defaults to false.
+                                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                            type: boolean
+                                        required:
+                                        - endpoints
+                                        - path
+                                        type: object
+                                      hostPath:
+                                        description: 'hostPath represents a pre-existing
+                                          file or directory on the host machine that
+                                          is directly exposed to the container. This
+                                          is generally used for system agents or other
+                                          privileged things that are allowed to see
+                                          the host machine. Most containers will NOT
+                                          need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                          --- TODO(jonesdl) We need to restrict who
+                                          can use host directory mounts and who can/can
+                                          not mount host directories as read/write.'
+                                        properties:
+                                          path:
+                                            description: 'path of the directory on
+                                              the host. If the path is a symlink,
+                                              it will follow the link to the real
+                                              path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                            type: string
+                                          type:
+                                            description: 'type for HostPath Volume
+                                              Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                      iscsi:
+                                        description: 'iscsi represents an ISCSI Disk
+                                          resource that is attached to a kubelet''s
+                                          host machine and then exposed to the pod.
+                                          More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                        properties:
+                                          chapAuthDiscovery:
+                                            description: chapAuthDiscovery defines
+                                              whether support iSCSI Discovery CHAP
+                                              authentication
+                                            type: boolean
+                                          chapAuthSession:
+                                            description: chapAuthSession defines whether
+                                              support iSCSI Session CHAP authentication
+                                            type: boolean
+                                          fsType:
+                                            description: 'fsType is the filesystem
+                                              type of the volume that you want to
+                                              mount. Tip: Ensure that the filesystem
+                                              type is supported by the host operating
+                                              system. Examples: "ext4", "xfs", "ntfs".
+                                              Implicitly inferred to be "ext4" if
+                                              unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                              TODO: how do we prevent errors in the
+                                              filesystem from compromising the machine'
+                                            type: string
+                                          initiatorName:
+                                            description: initiatorName is the custom
+                                              iSCSI Initiator Name. If initiatorName
+                                              is specified with iscsiInterface simultaneously,
+                                              new iSCSI interface <target portal>:<volume
+                                              name> will be created for the connection.
+                                            type: string
+                                          iqn:
+                                            description: iqn is the target iSCSI Qualified
+                                              Name.
+                                            type: string
+                                          iscsiInterface:
+                                            description: iscsiInterface is the interface
+                                              Name that uses an iSCSI transport. Defaults
+                                              to 'default' (tcp).
+                                            type: string
+                                          lun:
+                                            description: lun represents iSCSI Target
+                                              Lun number.
+                                            format: int32
+                                            type: integer
+                                          portals:
+                                            description: portals is the iSCSI Target
+                                              Portal List. The portal is either an
+                                              IP or ip_addr:port if the port is other
+                                              than default (typically TCP ports 860
+                                              and 3260).
+                                            items:
+                                              type: string
+                                            type: array
+                                          readOnly:
+                                            description: readOnly here will force
+                                              the ReadOnly setting in VolumeMounts.
+                                              Defaults to false.
+                                            type: boolean
+                                          secretRef:
+                                            description: secretRef is the CHAP Secret
+                                              for iSCSI target and initiator authentication
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                            type: object
+                                          targetPortal:
+                                            description: targetPortal is iSCSI Target
+                                              Portal. The Portal is either an IP or
+                                              ip_addr:port if the port is other than
+                                              default (typically TCP ports 860 and
+                                              3260).
+                                            type: string
+                                        required:
+                                        - iqn
+                                        - lun
+                                        - targetPortal
+                                        type: object
+                                      name:
+                                        description: 'name of the volume. Must be
+                                          a DNS_LABEL and unique within the pod. More
+                                          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      nfs:
+                                        description: 'nfs represents an NFS mount
+                                          on the host that shares a pod''s lifetime
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        properties:
+                                          path:
+                                            description: 'path that is exported by
+                                              the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                            type: string
+                                          readOnly:
+                                            description: 'readOnly here will force
+                                              the NFS export to be mounted with read-only
+                                              permissions. Defaults to false. More
+                                              info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                            type: boolean
+                                          server:
+                                            description: 'server is the hostname or
+                                              IP address of the NFS server. More info:
+                                              https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                            type: string
+                                        required:
+                                        - path
+                                        - server
+                                        type: object
+                                      persistentVolumeClaim:
+                                        description: 'persistentVolumeClaimVolumeSource
+                                          represents a reference to a PersistentVolumeClaim
+                                          in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        properties:
+                                          claimName:
+                                            description: 'claimName is the name of
+                                              a PersistentVolumeClaim in the same
+                                              namespace as the pod using this volume.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                            type: string
+                                          readOnly:
+                                            description: readOnly Will force the ReadOnly
+                                              setting in VolumeMounts. Default false.
+                                            type: boolean
+                                        required:
+                                        - claimName
+                                        type: object
+                                      photonPersistentDisk:
+                                        description: photonPersistentDisk represents
+                                          a PhotonController persistent disk attached
+                                          and mounted on kubelets host machine
+                                        properties:
+                                          fsType:
+                                            description: fsType is the filesystem
+                                              type to mount. Must be a filesystem
+                                              type supported by the host operating
+                                              system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                              inferred to be "ext4" if unspecified.
+                                            type: string
+                                          pdID:
+                                            description: pdID is the ID that identifies
+                                              Photon Controller persistent disk
+                                            type: string
+                                        required:
+                                        - pdID
+                                        type: object
+                                      portworxVolume:
+                                        description: portworxVolume represents a portworx
+                                          volume attached and mounted on kubelets
+                                          host machine
+                                        properties:
+                                          fsType:
+                                            description: fSType represents the filesystem
+                                              type to mount Must be a filesystem type
+                                              supported by the host operating system.
+                                              Ex. "ext4", "xfs". Implicitly inferred
+                                              to be "ext4" if unspecified.
+                                            type: string
+                                          readOnly:
+                                            description: readOnly defaults to false
+                                              (read/write). ReadOnly here will force
+                                              the ReadOnly setting in VolumeMounts.
+                                            type: boolean
+                                          volumeID:
+                                            description: volumeID uniquely identifies
+                                              a Portworx volume
+                                            type: string
+                                        required:
+                                        - volumeID
+                                        type: object
+                                      projected:
+                                        description: projected items for all in one
+                                          resources secrets, configmaps, and downward
+                                          API
+                                        properties:
+                                          defaultMode:
+                                            description: defaultMode are the mode
+                                              bits used to set permissions on created
+                                              files by default. Must be an octal value
+                                              between 0000 and 0777 or a decimal value
+                                              between 0 and 511. YAML accepts both
+                                              octal and decimal values, JSON requires
+                                              decimal values for mode bits. Directories
+                                              within the path are not affected by
+                                              this setting. This might be in conflict
+                                              with other options that affect the file
+                                              mode, like fsGroup, and the result can
+                                              be other mode bits set.
+                                            format: int32
+                                            type: integer
+                                          sources:
+                                            description: sources is the list of volume
+                                              projections
+                                            items:
+                                              description: Projection that may be
+                                                projected along with other supported
+                                                volume types
+                                              properties:
+                                                configMap:
+                                                  description: configMap information
+                                                    about the configMap data to project
+                                                  properties:
+                                                    items:
+                                                      description: items if unspecified,
+                                                        each key-value pair in the
+                                                        Data field of the referenced
+                                                        ConfigMap will be projected
+                                                        into the volume as a file
+                                                        whose name is the key and
+                                                        content is the value. If specified,
+                                                        the listed keys will be projected
+                                                        into the specified paths,
+                                                        and unlisted keys will not
+                                                        be present. If a key is specified
+                                                        which is not present in the
+                                                        ConfigMap, the volume setup
+                                                        will error unless it is marked
+                                                        optional. Paths must be relative
+                                                        and may not contain the '..'
+                                                        path or start with '..'.
+                                                      items:
+                                                        description: Maps a string
+                                                          key to a path within a volume.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              key to project.
+                                                            type: string
+                                                          mode:
+                                                            description: 'mode is
+                                                              Optional: mode bits
+                                                              used to set permissions
+                                                              on this file. Must be
+                                                              an octal value between
+                                                              0000 and 0777 or a decimal
+                                                              value between 0 and
+                                                              511. YAML accepts both
+                                                              octal and decimal values,
+                                                              JSON requires decimal
+                                                              values for mode bits.
+                                                              If not specified, the
+                                                              volume defaultMode will
+                                                              be used. This might
+                                                              be in conflict with
+                                                              other options that affect
+                                                              the file mode, like
+                                                              fsGroup, and the result
+                                                              can be other mode bits
+                                                              set.'
+                                                            format: int32
+                                                            type: integer
+                                                          path:
+                                                            description: path is the
+                                                              relative path of the
+                                                              file to map the key
+                                                              to. May not be an absolute
+                                                              path. May not contain
+                                                              the path element '..'.
+                                                              May not start with the
+                                                              string '..'.
+                                                            type: string
+                                                        required:
+                                                        - key
+                                                        - path
+                                                        type: object
+                                                      type: array
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: optional specify
+                                                        whether the ConfigMap or its
+                                                        keys must be defined
+                                                      type: boolean
+                                                  type: object
+                                                downwardAPI:
+                                                  description: downwardAPI information
+                                                    about the downwardAPI data to
+                                                    project
+                                                  properties:
+                                                    items:
+                                                      description: Items is a list
+                                                        of DownwardAPIVolume file
+                                                      items:
+                                                        description: DownwardAPIVolumeFile
+                                                          represents information to
+                                                          create the file containing
+                                                          the pod field
+                                                        properties:
+                                                          fieldRef:
+                                                            description: 'Required:
+                                                              Selects a field of the
+                                                              pod: only annotations,
+                                                              labels, name and namespace
+                                                              are supported.'
+                                                            properties:
+                                                              apiVersion:
+                                                                description: Version
+                                                                  of the schema the
+                                                                  FieldPath is written
+                                                                  in terms of, defaults
+                                                                  to "v1".
+                                                                type: string
+                                                              fieldPath:
+                                                                description: Path
+                                                                  of the field to
+                                                                  select in the specified
+                                                                  API version.
+                                                                type: string
+                                                            required:
+                                                            - fieldPath
+                                                            type: object
+                                                          mode:
+                                                            description: 'Optional:
+                                                              mode bits used to set
+                                                              permissions on this
+                                                              file, must be an octal
+                                                              value between 0000 and
+                                                              0777 or a decimal value
+                                                              between 0 and 511. YAML
+                                                              accepts both octal and
+                                                              decimal values, JSON
+                                                              requires decimal values
+                                                              for mode bits. If not
+                                                              specified, the volume
+                                                              defaultMode will be
+                                                              used. This might be
+                                                              in conflict with other
+                                                              options that affect
+                                                              the file mode, like
+                                                              fsGroup, and the result
+                                                              can be other mode bits
+                                                              set.'
+                                                            format: int32
+                                                            type: integer
+                                                          path:
+                                                            description: 'Required:
+                                                              Path is  the relative
+                                                              path name of the file
+                                                              to be created. Must
+                                                              not be absolute or contain
+                                                              the ''..'' path. Must
+                                                              be utf-8 encoded. The
+                                                              first item of the relative
+                                                              path must not start
+                                                              with ''..'''
+                                                            type: string
+                                                          resourceFieldRef:
+                                                            description: 'Selects
+                                                              a resource of the container:
+                                                              only resources limits
+                                                              and requests (limits.cpu,
+                                                              limits.memory, requests.cpu
+                                                              and requests.memory)
+                                                              are currently supported.'
+                                                            properties:
+                                                              containerName:
+                                                                description: 'Container
+                                                                  name: required for
+                                                                  volumes, optional
+                                                                  for env vars'
+                                                                type: string
+                                                              divisor:
+                                                                anyOf:
+                                                                - type: integer
+                                                                - type: string
+                                                                description: Specifies
+                                                                  the output format
+                                                                  of the exposed resources,
+                                                                  defaults to "1"
+                                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                x-kubernetes-int-or-string: true
+                                                              resource:
+                                                                description: 'Required:
+                                                                  resource to select'
+                                                                type: string
+                                                            required:
+                                                            - resource
+                                                            type: object
+                                                        required:
+                                                        - path
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                secret:
+                                                  description: secret information
+                                                    about the secret data to project
+                                                  properties:
+                                                    items:
+                                                      description: items if unspecified,
+                                                        each key-value pair in the
+                                                        Data field of the referenced
+                                                        Secret will be projected into
+                                                        the volume as a file whose
+                                                        name is the key and content
+                                                        is the value. If specified,
+                                                        the listed keys will be projected
+                                                        into the specified paths,
+                                                        and unlisted keys will not
+                                                        be present. If a key is specified
+                                                        which is not present in the
+                                                        Secret, the volume setup will
+                                                        error unless it is marked
+                                                        optional. Paths must be relative
+                                                        and may not contain the '..'
+                                                        path or start with '..'.
+                                                      items:
+                                                        description: Maps a string
+                                                          key to a path within a volume.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              key to project.
+                                                            type: string
+                                                          mode:
+                                                            description: 'mode is
+                                                              Optional: mode bits
+                                                              used to set permissions
+                                                              on this file. Must be
+                                                              an octal value between
+                                                              0000 and 0777 or a decimal
+                                                              value between 0 and
+                                                              511. YAML accepts both
+                                                              octal and decimal values,
+                                                              JSON requires decimal
+                                                              values for mode bits.
+                                                              If not specified, the
+                                                              volume defaultMode will
+                                                              be used. This might
+                                                              be in conflict with
+                                                              other options that affect
+                                                              the file mode, like
+                                                              fsGroup, and the result
+                                                              can be other mode bits
+                                                              set.'
+                                                            format: int32
+                                                            type: integer
+                                                          path:
+                                                            description: path is the
+                                                              relative path of the
+                                                              file to map the key
+                                                              to. May not be an absolute
+                                                              path. May not contain
+                                                              the path element '..'.
+                                                              May not start with the
+                                                              string '..'.
+                                                            type: string
+                                                        required:
+                                                        - key
+                                                        - path
+                                                        type: object
+                                                      type: array
+                                                    name:
+                                                      description: 'Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields.
+                                                        apiVersion, kind, uid?'
+                                                      type: string
+                                                    optional:
+                                                      description: optional field
+                                                        specify whether the Secret
+                                                        or its key must be defined
+                                                      type: boolean
+                                                  type: object
+                                                serviceAccountToken:
+                                                  description: serviceAccountToken
+                                                    is information about the serviceAccountToken
+                                                    data to project
+                                                  properties:
+                                                    audience:
+                                                      description: audience is the
+                                                        intended audience of the token.
+                                                        A recipient of a token must
+                                                        identify itself with an identifier
+                                                        specified in the audience
+                                                        of the token, and otherwise
+                                                        should reject the token. The
+                                                        audience defaults to the identifier
+                                                        of the apiserver.
+                                                      type: string
+                                                    expirationSeconds:
+                                                      description: expirationSeconds
+                                                        is the requested duration
+                                                        of validity of the service
+                                                        account token. As the token
+                                                        approaches expiration, the
+                                                        kubelet volume plugin will
+                                                        proactively rotate the service
+                                                        account token. The kubelet
+                                                        will start trying to rotate
+                                                        the token if the token is
+                                                        older than 80 percent of its
+                                                        time to live or if the token
+                                                        is older than 24 hours.Defaults
+                                                        to 1 hour and must be at least
+                                                        10 minutes.
+                                                      format: int64
+                                                      type: integer
+                                                    path:
+                                                      description: path is the path
+                                                        relative to the mount point
+                                                        of the file to project the
+                                                        token into.
+                                                      type: string
+                                                  required:
+                                                  - path
+                                                  type: object
+                                              type: object
+                                            type: array
+                                        type: object
+                                      quobyte:
+                                        description: quobyte represents a Quobyte
+                                          mount on the host that shares a pod's lifetime
+                                        properties:
+                                          group:
+                                            description: group to map volume access
+                                              to Default is no group
+                                            type: string
+                                          readOnly:
+                                            description: readOnly here will force
+                                              the Quobyte volume to be mounted with
+                                              read-only permissions. Defaults to false.
+                                            type: boolean
+                                          registry:
+                                            description: registry represents a single
+                                              or multiple Quobyte Registry services
+                                              specified as a string as host:port pair
+                                              (multiple entries are separated with
+                                              commas) which acts as the central registry
+                                              for volumes
+                                            type: string
+                                          tenant:
+                                            description: tenant owning the given Quobyte
+                                              volume in the Backend Used with dynamically
+                                              provisioned Quobyte volumes, value is
+                                              set by the plugin
+                                            type: string
+                                          user:
+                                            description: user to map volume access
+                                              to Defaults to serivceaccount user
+                                            type: string
+                                          volume:
+                                            description: volume is a string that references
+                                              an already created Quobyte volume by
+                                              name.
+                                            type: string
+                                        required:
+                                        - registry
+                                        - volume
+                                        type: object
+                                      rbd:
+                                        description: 'rbd represents a Rados Block
+                                          Device mount on the host that shares a pod''s
+                                          lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                        properties:
+                                          fsType:
+                                            description: 'fsType is the filesystem
+                                              type of the volume that you want to
+                                              mount. Tip: Ensure that the filesystem
+                                              type is supported by the host operating
+                                              system. Examples: "ext4", "xfs", "ntfs".
+                                              Implicitly inferred to be "ext4" if
+                                              unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                              TODO: how do we prevent errors in the
+                                              filesystem from compromising the machine'
+                                            type: string
+                                          image:
+                                            description: 'image is the rados image
+                                              name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                            type: string
+                                          keyring:
+                                            description: 'keyring is the path to key
+                                              ring for RBDUser. Default is /etc/ceph/keyring.
+                                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                            type: string
+                                          monitors:
+                                            description: 'monitors is a collection
+                                              of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                            items:
+                                              type: string
+                                            type: array
+                                          pool:
+                                            description: 'pool is the rados pool name.
+                                              Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                            type: string
+                                          readOnly:
+                                            description: 'readOnly here will force
+                                              the ReadOnly setting in VolumeMounts.
+                                              Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                            type: boolean
+                                          secretRef:
+                                            description: 'secretRef is name of the
+                                              authentication secret for RBDUser. If
+                                              provided overrides keyring. Default
+                                              is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                            type: object
+                                          user:
+                                            description: 'user is the rados user name.
+                                              Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                            type: string
+                                        required:
+                                        - image
+                                        - monitors
+                                        type: object
+                                      scaleIO:
+                                        description: scaleIO represents a ScaleIO
+                                          persistent volume attached and mounted on
+                                          Kubernetes nodes.
+                                        properties:
+                                          fsType:
+                                            description: fsType is the filesystem
+                                              type to mount. Must be a filesystem
+                                              type supported by the host operating
+                                              system. Ex. "ext4", "xfs", "ntfs". Default
+                                              is "xfs".
+                                            type: string
+                                          gateway:
+                                            description: gateway is the host address
+                                              of the ScaleIO API Gateway.
+                                            type: string
+                                          protectionDomain:
+                                            description: protectionDomain is the name
+                                              of the ScaleIO Protection Domain for
+                                              the configured storage.
+                                            type: string
+                                          readOnly:
+                                            description: readOnly Defaults to false
+                                              (read/write). ReadOnly here will force
+                                              the ReadOnly setting in VolumeMounts.
+                                            type: boolean
+                                          secretRef:
+                                            description: secretRef references to the
+                                              secret for ScaleIO user and other sensitive
+                                              information. If this is not provided,
+                                              Login operation will fail.
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                            type: object
+                                          sslEnabled:
+                                            description: sslEnabled Flag enable/disable
+                                              SSL communication with Gateway, default
+                                              false
+                                            type: boolean
+                                          storageMode:
+                                            description: storageMode indicates whether
+                                              the storage for a volume should be ThickProvisioned
+                                              or ThinProvisioned. Default is ThinProvisioned.
+                                            type: string
+                                          storagePool:
+                                            description: storagePool is the ScaleIO
+                                              Storage Pool associated with the protection
+                                              domain.
+                                            type: string
+                                          system:
+                                            description: system is the name of the
+                                              storage system as configured in ScaleIO.
+                                            type: string
+                                          volumeName:
+                                            description: volumeName is the name of
+                                              a volume already created in the ScaleIO
+                                              system that is associated with this
+                                              volume source.
+                                            type: string
+                                        required:
+                                        - gateway
+                                        - secretRef
+                                        - system
+                                        type: object
+                                      secret:
+                                        description: 'secret represents a secret that
+                                          should populate this volume. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        properties:
+                                          defaultMode:
+                                            description: 'defaultMode is Optional:
+                                              mode bits used to set permissions on
+                                              created files by default. Must be an
+                                              octal value between 0000 and 0777 or
+                                              a decimal value between 0 and 511. YAML
+                                              accepts both octal and decimal values,
+                                              JSON requires decimal values for mode
+                                              bits. Defaults to 0644. Directories
+                                              within the path are not affected by
+                                              this setting. This might be in conflict
+                                              with other options that affect the file
+                                              mode, like fsGroup, and the result can
+                                              be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          items:
+                                            description: items If unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced Secret will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the Secret, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          optional:
+                                            description: optional field specify whether
+                                              the Secret or its keys must be defined
+                                            type: boolean
+                                          secretName:
+                                            description: 'secretName is the name of
+                                              the secret in the pod''s namespace to
+                                              use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                            type: string
+                                        type: object
+                                      storageos:
+                                        description: storageOS represents a StorageOS
+                                          volume attached and mounted on Kubernetes
+                                          nodes.
+                                        properties:
+                                          fsType:
+                                            description: fsType is the filesystem
+                                              type to mount. Must be a filesystem
+                                              type supported by the host operating
+                                              system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                              inferred to be "ext4" if unspecified.
+                                            type: string
+                                          readOnly:
+                                            description: readOnly defaults to false
+                                              (read/write). ReadOnly here will force
+                                              the ReadOnly setting in VolumeMounts.
+                                            type: boolean
+                                          secretRef:
+                                            description: secretRef specifies the secret
+                                              to use for obtaining the StorageOS API
+                                              credentials.  If not specified, default
+                                              values will be attempted.
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                            type: object
+                                          volumeName:
+                                            description: volumeName is the human-readable
+                                              name of the StorageOS volume.  Volume
+                                              names are only unique within a namespace.
+                                            type: string
+                                          volumeNamespace:
+                                            description: volumeNamespace specifies
+                                              the scope of the volume within StorageOS.  If
+                                              no namespace is specified then the Pod's
+                                              namespace will be used.  This allows
+                                              the Kubernetes name scoping to be mirrored
+                                              within StorageOS for tighter integration.
+                                              Set VolumeName to any name to override
+                                              the default behaviour. Set to "default"
+                                              if you are not using namespaces within
+                                              StorageOS. Namespaces that do not pre-exist
+                                              within StorageOS will be created.
+                                            type: string
+                                        type: object
+                                      vsphereVolume:
+                                        description: vsphereVolume represents a vSphere
+                                          volume attached and mounted on kubelets
+                                          host machine
+                                        properties:
+                                          fsType:
+                                            description: fsType is filesystem type
+                                              to mount. Must be a filesystem type
+                                              supported by the host operating system.
+                                              Ex. "ext4", "xfs", "ntfs". Implicitly
+                                              inferred to be "ext4" if unspecified.
+                                            type: string
+                                          storagePolicyID:
+                                            description: storagePolicyID is the storage
+                                              Policy Based Management (SPBM) profile
+                                              ID associated with the StoragePolicyName.
+                                            type: string
+                                          storagePolicyName:
+                                            description: storagePolicyName is the
+                                              storage Policy Based Management (SPBM)
+                                              profile name.
+                                            type: string
+                                          volumePath:
+                                            description: volumePath is the path that
+                                              identifies vSphere volume vmdk
+                                            type: string
+                                        required:
+                                        - volumePath
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                workspaces:
+                                  description: Workspaces are the volumes that this
+                                    Task requires.
+                                  items:
+                                    description: WorkspaceDeclaration is a declaration
+                                      of a volume that a Task requires.
+                                    properties:
+                                      description:
+                                        description: Description is an optional human
+                                          readable description of this volume.
+                                        type: string
+                                      mountPath:
+                                        description: MountPath overrides the directory
+                                          that the volume will be made available at.
+                                        type: string
+                                      name:
+                                        description: Name is the name by which you
+                                          can bind the volume at runtime.
+                                        type: string
+                                      optional:
+                                        description: Optional marks a Workspace as
+                                          not being required in TaskRuns. By default
+                                          this field is false and so declared workspaces
+                                          are required.
+                                        type: boolean
+                                      readOnly:
+                                        description: ReadOnly dictates whether a mounted
+                                          volume is writable. By default this field
+                                          is false and so mounted volumes are writable.
+                                        type: boolean
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            timeout:
+                              description: 'Time after which the TaskRun times out.
+                                Defaults to 1 hour. Specified TaskRun timeout should
+                                be less than 24h. Refer Go''s ParseDuration documentation
+                                for expected format: https://golang.org/pkg/time/#ParseDuration'
+                              type: string
+                            when:
+                              description: WhenExpressions is a list of when expressions
+                                that need to be true for the task to run
+                              items:
+                                description: WhenExpression allows a PipelineTask
+                                  to declare expressions to be evaluated before the
+                                  Task is run to determine whether the Task should
+                                  be executed or skipped
+                                properties:
+                                  input:
+                                    description: Input is the string for guard checking
+                                      which can be a static input or an output from
+                                      a parent Task
+                                    type: string
+                                  operator:
+                                    description: Operator that represents an Input's
+                                      relationship to the values
+                                    type: string
+                                  values:
+                                    description: Values is an array of strings, which
+                                      is compared against the input, for guard checking
+                                      It must be non-empty
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - input
+                                - operator
+                                - values
+                                type: object
+                              type: array
+                            workspaces:
+                              description: Workspaces maps workspaces from the pipeline
+                                spec to the workspaces declared in the Task.
+                              items:
+                                description: WorkspacePipelineTaskBinding describes
+                                  how a workspace passed into the pipeline should
+                                  be mapped to a task's declared workspace.
+                                properties:
+                                  name:
+                                    description: Name is the name of the workspace
+                                      as declared by the task
+                                    type: string
+                                  subPath:
+                                    description: SubPath is optionally a directory
+                                      on the volume which should be used for this
+                                      binding (i.e. the volume will be mounted at
+                                      this sub directory).
+                                    type: string
+                                  workspace:
+                                    description: Workspace is the name of the workspace
+                                      declared by the pipeline
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       workspaces:
                         description: Workspaces declares a set of named workspaces
                           that are expected to be provided by a PipelineRun.
@@ -7965,6 +14796,7 @@ spec:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                     type: object
                   podTemplate:
                     description: PodTemplate holds pod specific configuration
@@ -8915,6 +15747,122 @@ spec:
                           variables, matching the syntax of Docker links. Optional:
                           Defaults to true.'
                         type: boolean
+                      env:
+                        description: List of environment variables that can be provided
+                          to the containers belonging to the pod.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       hostAliases:
                         description: HostAliases is an optional list of hosts and
                           IPs that will be injected into the pod's hosts file if specified.
@@ -9204,6 +16152,191 @@ spec:
                                 matches to. If the operator is Exists, the value should
                                 be empty, otherwise just a regular string.
                               type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      topologySpreadConstraints:
+                        description: TopologySpreadConstraints controls how Pods are
+                          spread across your cluster among failure-domains such as
+                          regions, zones, nodes, and other user-defined topology domains.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: LabelSelector is used to find matching
+                                pods. Pods that match this label selector are counted
+                                to determine the number of pods in their corresponding
+                                topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            matchLabelKeys:
+                              description: MatchLabelKeys is a set of pod label keys
+                                to select the pods over which spreading will be calculated.
+                                The keys are used to lookup values from the incoming
+                                pod labels, those key-value labels are ANDed with
+                                labelSelector to select the group of existing pods
+                                over which spreading will be calculated for the incoming
+                                pod. Keys that don't exist in the incoming pod labels
+                                will be ignored. A null or empty list means only match
+                                against labelSelector.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: 'MaxSkew describes the degree to which
+                                pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                it is the maximum permitted difference between the
+                                number of matching pods in the target topology and
+                                the global minimum. The global minimum is the minimum
+                                number of matching pods in an eligible domain or zero
+                                if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to
+                                1, and pods with the same labelSelector spread as
+                                2/2/1: In this case, the global minimum is 1. | zone1
+                                | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                is 1, incoming pod can only be scheduled to zone3
+                                to become 2/2/2; scheduling it onto zone1(zone2) would
+                                make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto
+                                any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                it is used to give higher precedence to topologies
+                                that satisfy it. It''s a required field. Default value
+                                is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: "MinDomains indicates a minimum number
+                                of eligible domains. When the number of eligible domains
+                                with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats \"global minimum\" as 0,
+                                and then the calculation of Skew is performed. And
+                                when the number of eligible domains with matching
+                                topology keys equals or greater than minDomains, this
+                                value has no effect on scheduling. As a result, when
+                                the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to
+                                those domains. If value is nil, the constraint behaves
+                                as if MinDomains is equal to 1. Valid values are integers
+                                greater than 0. When value is not nil, WhenUnsatisfiable
+                                must be DoNotSchedule. \n For example, in a 3-zone
+                                cluster, MaxSkew is set to 2, MinDomains is set to
+                                5 and pods with the same labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains),
+                                so \"global minimum\" is treated as 0. In this situation,
+                                new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod
+                                is scheduled to any of the three zones, it will violate
+                                MaxSkew. \n This is a beta field and requires the
+                                MinDomainsInPodTopologySpread feature gate to be enabled
+                                (enabled by default)."
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: "NodeAffinityPolicy indicates how we will
+                                treat Pod's nodeAffinity/nodeSelector when calculating
+                                pod topology spread skew. Options are: - Honor: only
+                                nodes matching nodeAffinity/nodeSelector are included
+                                in the calculations. - Ignore: nodeAffinity/nodeSelector
+                                are ignored. All nodes are included in the calculations.
+                                \n If this value is nil, the behavior is equivalent
+                                to the Honor policy. This is a alpha-level feature
+                                enabled by the NodeInclusionPolicyInPodTopologySpread
+                                feature flag."
+                              type: string
+                            nodeTaintsPolicy:
+                              description: "NodeTaintsPolicy indicates how we will
+                                treat node taints when calculating pod topology spread
+                                skew. Options are: - Honor: nodes without taints,
+                                along with tainted nodes for which the incoming pod
+                                has a toleration, are included. - Ignore: node taints
+                                are ignored. All nodes are included. \n If this value
+                                is nil, the behavior is equivalent to the Ignore policy.
+                                This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread
+                                feature flag."
+                              type: string
+                            topologyKey:
+                              description: TopologyKey is the key of node labels.
+                                Nodes that have a label with this key and identical
+                                values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try
+                                to put balanced number of pods into each bucket. We
+                                define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose
+                                nodes meet the requirements of nodeAffinityPolicy
+                                and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                each Node is a domain of that topology. And, if TopologyKey
+                                is "topology.kubernetes.io/zone", each zone is a domain
+                                of that topology. It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: 'WhenUnsatisfiable indicates how to deal
+                                with a pod if it doesn''t satisfy the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not
+                                to schedule it. - ScheduleAnyway tells the scheduler
+                                to schedule the pod in any location,   but giving
+                                higher precedence to topologies that would help reduce
+                                the   skew. A constraint is considered "Unsatisfiable"
+                                for an incoming pod if and only if every possible
+                                node assignment for that pod would violate "MaxSkew"
+                                on some topology. For example, in a 3-zone cluster,
+                                MaxSkew is set to 1, and pods with the same labelSelector
+                                spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P
+                                |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule,
+                                incoming pod can only be scheduled to zone2(zone3)
+                                to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3)
+                                satisfies MaxSkew(1). In other words, the cluster
+                                can still be imbalanced, but scheduler won''t make
+                                it *more* imbalanced. It''s a required field.'
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
                           type: object
                         type: array
                         x-kubernetes-list-type: atomic
@@ -10916,30 +18049,147 @@ spec:
                           type: object
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   serviceAccountName:
                     type: string
-                  serviceAccountNames:
-                    items:
-                      description: PipelineRunSpecServiceAccountName can be used to
-                        configure specific ServiceAccountName for a concrete Task
-                      properties:
-                        serviceAccountName:
-                          type: string
-                        taskName:
-                          type: string
-                      type: object
-                    type: array
                   status:
                     description: Used for cancelling a pipelinerun (and maybe more
                       later on)
                     type: string
                   taskRunSpecs:
-                    description: TaskRunSpecs holds a set of task specific specs
+                    description: TaskRunSpecs holds a set of runtime specs
                     items:
-                      description: PipelineTaskRunSpec holds task specific specs
+                      description: PipelineTaskRunSpec  can be used to configure specific
+                        specs for a concrete Task
                       properties:
+                        computeResources:
+                          description: Compute resources to use for this TaskRun
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        metadata:
+                          description: PipelineTaskMetadata contains the labels or
+                            annotations for an EmbeddedTask
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
                         pipelineTaskName:
                           type: string
+                        sidecarOverrides:
+                          items:
+                            description: TaskRunSidecarOverride is used to override
+                              the values of a Sidecar in the corresponding Task.
+                            properties:
+                              name:
+                                description: The name of the Sidecar to override.
+                                type: string
+                              resources:
+                                description: The resource requirements to apply to
+                                  the Sidecar.
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. More info:
+                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            - resources
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        stepOverrides:
+                          items:
+                            description: TaskRunStepOverride is used to override the
+                              values of a Step in the corresponding Task.
+                            properties:
+                              name:
+                                description: The name of the Step to override.
+                                type: string
+                              resources:
+                                description: The resource requirements to apply to
+                                  the Step.
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. More info:
+                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            - resources
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         taskPodTemplate:
                           description: Template holds pod specific configuration
                           properties:
@@ -11975,6 +19225,126 @@ spec:
                                 variables, matching the syntax of Docker links. Optional:
                                 Defaults to true.'
                               type: boolean
+                            env:
+                              description: List of environment variables that can
+                                be provided to the containers belonging to the pod.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             hostAliases:
                               description: HostAliases is an optional list of hosts
                                 and IPs that will be injected into the pod's hosts
@@ -12283,6 +19653,209 @@ spec:
                                       matches to. If the operator is Exists, the value
                                       should be empty, otherwise just a regular string.
                                     type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologySpreadConstraints:
+                              description: TopologySpreadConstraints controls how
+                                Pods are spread across your cluster among failure-domains
+                                such as regions, zones, nodes, and other user-defined
+                                topology domains.
+                              items:
+                                description: TopologySpreadConstraint specifies how
+                                  to spread matching pods among the given topology.
+                                properties:
+                                  labelSelector:
+                                    description: LabelSelector is used to find matching
+                                      pods. Pods that match this label selector are
+                                      counted to determine the number of pods in their
+                                      corresponding topology domain.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  matchLabelKeys:
+                                    description: MatchLabelKeys is a set of pod label
+                                      keys to select the pods over which spreading
+                                      will be calculated. The keys are used to lookup
+                                      values from the incoming pod labels, those key-value
+                                      labels are ANDed with labelSelector to select
+                                      the group of existing pods over which spreading
+                                      will be calculated for the incoming pod. Keys
+                                      that don't exist in the incoming pod labels
+                                      will be ignored. A null or empty list means
+                                      only match against labelSelector.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  maxSkew:
+                                    description: 'MaxSkew describes the degree to
+                                      which pods may be unevenly distributed. When
+                                      `whenUnsatisfiable=DoNotSchedule`, it is the
+                                      maximum permitted difference between the number
+                                      of matching pods in the target topology and
+                                      the global minimum. The global minimum is the
+                                      minimum number of matching pods in an eligible
+                                      domain or zero if the number of eligible domains
+                                      is less than MinDomains. For example, in a 3-zone
+                                      cluster, MaxSkew is set to 1, and pods with
+                                      the same labelSelector spread as 2/2/1: In this
+                                      case, the global minimum is 1. | zone1 | zone2
+                                      | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                      is 1, incoming pod can only be scheduled to
+                                      zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                                      would make the ActualSkew(3-1) on zone1(zone2)
+                                      violate MaxSkew(1). - if MaxSkew is 2, incoming
+                                      pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                      it is used to give higher precedence to topologies
+                                      that satisfy it. It''s a required field. Default
+                                      value is 1 and 0 is not allowed.'
+                                    format: int32
+                                    type: integer
+                                  minDomains:
+                                    description: "MinDomains indicates a minimum number
+                                      of eligible domains. When the number of eligible
+                                      domains with matching topology keys is less
+                                      than minDomains, Pod Topology Spread treats
+                                      \"global minimum\" as 0, and then the calculation
+                                      of Skew is performed. And when the number of
+                                      eligible domains with matching topology keys
+                                      equals or greater than minDomains, this value
+                                      has no effect on scheduling. As a result, when
+                                      the number of eligible domains is less than
+                                      minDomains, scheduler won't schedule more than
+                                      maxSkew Pods to those domains. If value is nil,
+                                      the constraint behaves as if MinDomains is equal
+                                      to 1. Valid values are integers greater than
+                                      0. When value is not nil, WhenUnsatisfiable
+                                      must be DoNotSchedule. \n For example, in a
+                                      3-zone cluster, MaxSkew is set to 2, MinDomains
+                                      is set to 5 and pods with the same labelSelector
+                                      spread as 2/2/2: | zone1 | zone2 | zone3 | |
+                                      \ P P  |  P P  |  P P  | The number of domains
+                                      is less than 5(MinDomains), so \"global minimum\"
+                                      is treated as 0. In this situation, new pod
+                                      with the same labelSelector cannot be scheduled,
+                                      because computed skew will be 3(3 - 0) if new
+                                      Pod is scheduled to any of the three zones,
+                                      it will violate MaxSkew. \n This is a beta field
+                                      and requires the MinDomainsInPodTopologySpread
+                                      feature gate to be enabled (enabled by default)."
+                                    format: int32
+                                    type: integer
+                                  nodeAffinityPolicy:
+                                    description: "NodeAffinityPolicy indicates how
+                                      we will treat Pod's nodeAffinity/nodeSelector
+                                      when calculating pod topology spread skew. Options
+                                      are: - Honor: only nodes matching nodeAffinity/nodeSelector
+                                      are included in the calculations. - Ignore:
+                                      nodeAffinity/nodeSelector are ignored. All nodes
+                                      are included in the calculations. \n If this
+                                      value is nil, the behavior is equivalent to
+                                      the Honor policy. This is a alpha-level feature
+                                      enabled by the NodeInclusionPolicyInPodTopologySpread
+                                      feature flag."
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    description: "NodeTaintsPolicy indicates how we
+                                      will treat node taints when calculating pod
+                                      topology spread skew. Options are: - Honor:
+                                      nodes without taints, along with tainted nodes
+                                      for which the incoming pod has a toleration,
+                                      are included. - Ignore: node taints are ignored.
+                                      All nodes are included. \n If this value is
+                                      nil, the behavior is equivalent to the Ignore
+                                      policy. This is a alpha-level feature enabled
+                                      by the NodeInclusionPolicyInPodTopologySpread
+                                      feature flag."
+                                    type: string
+                                  topologyKey:
+                                    description: TopologyKey is the key of node labels.
+                                      Nodes that have a label with this key and identical
+                                      values are considered to be in the same topology.
+                                      We consider each <key, value> as a "bucket",
+                                      and try to put balanced number of pods into
+                                      each bucket. We define a domain as a particular
+                                      instance of a topology. Also, we define an eligible
+                                      domain as a domain whose nodes meet the requirements
+                                      of nodeAffinityPolicy and nodeTaintsPolicy.
+                                      e.g. If TopologyKey is "kubernetes.io/hostname",
+                                      each Node is a domain of that topology. And,
+                                      if TopologyKey is "topology.kubernetes.io/zone",
+                                      each zone is a domain of that topology. It's
+                                      a required field.
+                                    type: string
+                                  whenUnsatisfiable:
+                                    description: 'WhenUnsatisfiable indicates how
+                                      to deal with a pod if it doesn''t satisfy the
+                                      spread constraint. - DoNotSchedule (default)
+                                      tells the scheduler not to schedule it. - ScheduleAnyway
+                                      tells the scheduler to schedule the pod in any
+                                      location,   but giving higher precedence to
+                                      topologies that would help reduce the   skew.
+                                      A constraint is considered "Unsatisfiable" for
+                                      an incoming pod if and only if every possible
+                                      node assignment for that pod would violate "MaxSkew"
+                                      on some topology. For example, in a 3-zone cluster,
+                                      MaxSkew is set to 1, and pods with the same
+                                      labelSelector spread as 3/1/1: | zone1 | zone2
+                                      | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
+                                      is set to DoNotSchedule, incoming pod can only
+                                      be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
+                                      as ActualSkew(2-1) on zone2(zone3) satisfies
+                                      MaxSkew(1). In other words, the cluster can
+                                      still be imbalanced, but scheduler won''t make
+                                      it *more* imbalanced. It''s a required field.'
+                                    type: string
+                                required:
+                                - maxSkew
+                                - topologyKey
+                                - whenUnsatisfiable
                                 type: object
                               type: array
                               x-kubernetes-list-type: atomic
@@ -14042,11 +21615,32 @@ spec:
                           type: string
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   timeout:
-                    description: 'Time after which the Pipeline times out. Defaults
-                      to never. Refer to Go''s ParseDuration documentation for expected
+                    description: 'Timeout Deprecated: use pipelineRunSpec.Timeouts.Pipeline
+                      instead Time after which the Pipeline times out. Defaults to
+                      never. Refer to Go''s ParseDuration documentation for expected
                       format: https://golang.org/pkg/time/#ParseDuration'
                     type: string
+                  timeouts:
+                    description: Time after which the Pipeline times out. Currently
+                      three keys are accepted in the map pipeline, tasks and finally
+                      with Timeouts.pipeline >= Timeouts.tasks + Timeouts.finally
+                    properties:
+                      finally:
+                        description: Finally sets the maximum allowed duration of
+                          this pipeline's finally
+                        type: string
+                      pipeline:
+                        description: Pipeline sets the maximum allowed duration for
+                          execution of the entire pipeline. The sum of individual
+                          timeouts for tasks and finally must not exceed this value.
+                        type: string
+                      tasks:
+                        description: Tasks sets the maximum allowed duration of this
+                          pipeline's tasks
+                        type: string
+                    type: object
                   workspaces:
                     description: Workspaces holds a set of workspace bindings that
                       must match names with those declared in the pipeline.
@@ -14122,6 +21716,51 @@ spec:
                                 or its keys must be defined
                               type: boolean
                           type: object
+                        csi:
+                          description: CSI (Container Storage Interface) represents
+                            ephemeral storage that is handled by certain external
+                            CSI drivers.
+                          properties:
+                            driver:
+                              description: driver is the name of the CSI driver that
+                                handles this volume. Consult with your admin for the
+                                correct name as registered in the cluster.
+                              type: string
+                            fsType:
+                              description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                If not provided, the empty value is passed to the
+                                associated CSI driver which will determine the default
+                                filesystem to apply.
+                              type: string
+                            nodePublishSecretRef:
+                              description: nodePublishSecretRef is a reference to
+                                the secret object containing sensitive information
+                                to pass to the CSI driver to complete the CSI NodePublishVolume
+                                and NodeUnpublishVolume calls. This field is optional,
+                                and  may be empty if no secret is required. If the
+                                secret object contains more than one secret, all secret
+                                references are passed.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                              type: object
+                            readOnly:
+                              description: readOnly specifies a read-only configuration
+                                for the volume. Defaults to false (read/write).
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              description: volumeAttributes stores driver-specific
+                                properties that are passed to the CSI driver. Consult
+                                your driver's documentation for supported values.
+                              type: object
+                          required:
+                          - driver
+                          type: object
                         emptyDir:
                           description: 'EmptyDir represents a temporary directory
                             that shares a Task''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
@@ -14169,6 +21808,273 @@ spec:
                               type: boolean
                           required:
                           - claimName
+                          type: object
+                        projected:
+                          description: Projected represents a projected volume that
+                            should populate this workspace.
+                          properties:
+                            defaultMode:
+                              description: defaultMode are the mode bits used to set
+                                permissions on created files by default. Must be an
+                                octal value between 0000 and 0777 or a decimal value
+                                between 0 and 511. YAML accepts both octal and decimal
+                                values, JSON requires decimal values for mode bits.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.
+                              format: int32
+                              type: integer
+                            sources:
+                              description: sources is the list of volume projections
+                              items:
+                                description: Projection that may be projected along
+                                  with other supported volume types
+                                properties:
+                                  configMap:
+                                    description: configMap information about the configMap
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: items if unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the ConfigMap, the volume setup will
+                                          error unless it is marked optional. Paths
+                                          must be relative and may not contain the
+                                          '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                  downwardAPI:
+                                    description: downwardAPI information about the
+                                      downwardAPI data to project
+                                    properties:
+                                      items:
+                                        description: Items is a list of DownwardAPIVolume
+                                          file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name and namespace are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            mode:
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file, must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                requests.cpu and requests.memory)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                    type: object
+                                  secret:
+                                    description: secret information about the secret
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: items if unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          Secret will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the Secret, the volume setup will error
+                                          unless it is marked optional. Paths must
+                                          be relative and may not contain the '..'
+                                          path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: optional field specify whether
+                                          the Secret or its key must be defined
+                                        type: boolean
+                                    type: object
+                                  serviceAccountToken:
+                                    description: serviceAccountToken is information
+                                      about the serviceAccountToken data to project
+                                    properties:
+                                      audience:
+                                        description: audience is the intended audience
+                                          of the token. A recipient of a token must
+                                          identify itself with an identifier specified
+                                          in the audience of the token, and otherwise
+                                          should reject the token. The audience defaults
+                                          to the identifier of the apiserver.
+                                        type: string
+                                      expirationSeconds:
+                                        description: expirationSeconds is the requested
+                                          duration of validity of the service account
+                                          token. As the token approaches expiration,
+                                          the kubelet volume plugin will proactively
+                                          rotate the service account token. The kubelet
+                                          will start trying to rotate the token if
+                                          the token is older than 80 percent of its
+                                          time to live or if the token is older than
+                                          24 hours.Defaults to 1 hour and must be
+                                          at least 10 minutes.
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        description: path is the path relative to
+                                          the mount point of the file to project the
+                                          token into.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
                           type: object
                         secret:
                           description: Secret represents a secret that should populate
@@ -14556,6 +22462,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                 type: object
               pod_spec:
                 description: PodSpec provides the basis for running the test under
@@ -15995,13 +23902,13 @@ spec:
                           type: string
                         ports:
                           description: List of ports to expose from the container.
-                            Exposing a port here gives the system additional information
-                            about the network connections a container uses, but is
-                            primarily informational. Not specifying a port here DOES
-                            NOT prevent that port from being exposed. Any port which
-                            is listening on the default "0.0.0.0" address inside a
-                            container will be accessible from the network. Cannot
-                            be updated.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
                           items:
                             description: ContainerPort represents a network port in
                               a single container.
@@ -16731,9 +24638,7 @@ spec:
                       actions such as debugging. This list cannot be specified when
                       creating a pod, and it cannot be modified by updating the pod
                       spec. In order to add an ephemeral container to an existing
-                      pod, use the pod's ephemeralcontainers subresource. This field
-                      is beta-level and available on clusters that haven't disabled
-                      the EphemeralContainers feature gate.
+                      pod, use the pod's ephemeralcontainers subresource.
                     items:
                       description: "An EphemeralContainer is a temporary container
                         that you may add to an existing Pod for user-initiated activities
@@ -16743,9 +24648,7 @@ spec:
                         may evict a Pod if an ephemeral container causes the Pod to
                         exceed its resource allocation. \n To add an ephemeral container,
                         use the ephemeralcontainers subresource of an existing Pod.
-                        Ephemeral containers may not be removed or restarted. \n This
-                        is a beta feature available on clusters that haven't disabled
-                        the EphemeralContainers feature gate."
+                        Ephemeral containers may not be removed or restarted."
                       properties:
                         args:
                           description: 'Arguments to the entrypoint. The image''s
@@ -18005,6 +25908,18 @@ spec:
                     description: 'Use the host''s pid namespace. Optional: Default
                       to false.'
                     type: boolean
+                  hostUsers:
+                    description: 'Use the host''s user namespace. Optional: Default
+                      to true. If set to true or not present, the pod will be run
+                      in the host user namespace, useful for when the pod needs a
+                      feature only available to the host user namespace, such as loading
+                      a kernel module with CAP_SYS_MODULE. When set to false, a new
+                      userns is created for the pod. Setting false is useful for mitigating
+                      container breakout vulnerabilities even allowing users to run
+                      their containers as root without actually having root privileges
+                      on the host. This field is alpha-level and is only honored by
+                      servers that enable the UserNamespacesSupport feature.'
+                    type: boolean
                   hostname:
                     description: Specifies the hostname of the Pod If not specified,
                       the pod's hostname will be set to a system-defined value.
@@ -18601,13 +26516,13 @@ spec:
                           type: string
                         ports:
                           description: List of ports to expose from the container.
-                            Exposing a port here gives the system additional information
-                            about the network connections a container uses, but is
-                            primarily informational. Not specifying a port here DOES
-                            NOT prevent that port from being exposed. Any port which
-                            is listening on the default "0.0.0.0" address inside a
-                            container will be accessible from the network. Cannot
-                            be updated.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
                           items:
                             description: ContainerPort represents a network port in
                               a single container.
@@ -19302,7 +27217,7 @@ spec:
                       the OS field is set to linux, the following fields must be unset:
                       -securityContext.windowsOptions \n If the OS field is set to
                       windows, following fields must be unset: - spec.hostPID - spec.hostIPC
-                      - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
+                      - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
                       - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
                       - spec.securityContext.sysctls - spec.shareProcessNamespace
                       - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
@@ -19311,8 +27226,7 @@ spec:
                       - spec.containers[*].securityContext.readOnlyRootFilesystem
                       - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation
                       - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                      - spec.containers[*].securityContext.runAsGroup This is a beta
-                      field and requires the IdentifyPodOS feature"
+                      - spec.containers[*].securityContext.runAsGroup"
                     properties:
                       name:
                         description: 'Name is the name of the operating system. The
@@ -19711,6 +27625,19 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                        matchLabelKeys:
+                          description: MatchLabelKeys is a set of pod label keys to
+                            select the pods over which spreading will be calculated.
+                            The keys are used to lookup values from the incoming pod
+                            labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading
+                            will be calculated for the incoming pod. Keys that don't
+                            exist in the incoming pod labels will be ignored. A null
+                            or empty list means only match against labelSelector.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
                         maxSkew:
                           description: 'MaxSkew describes the degree to which pods
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
@@ -19753,11 +27680,33 @@ spec:
                             as 0. In this situation, new pod with the same labelSelector
                             cannot be scheduled, because computed skew will be 3(3
                             - 0) if new Pod is scheduled to any of the three zones,
-                            it will violate MaxSkew. \n This is an alpha field and
-                            requires enabling MinDomainsInPodTopologySpread feature
-                            gate."
+                            it will violate MaxSkew. \n This is a beta field and requires
+                            the MinDomainsInPodTopologySpread feature gate to be enabled
+                            (enabled by default)."
                           format: int32
                           type: integer
+                        nodeAffinityPolicy:
+                          description: "NodeAffinityPolicy indicates how we will treat
+                            Pod's nodeAffinity/nodeSelector when calculating pod topology
+                            spread skew. Options are: - Honor: only nodes matching
+                            nodeAffinity/nodeSelector are included in the calculations.
+                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes
+                            are included in the calculations. \n If this value is
+                            nil, the behavior is equivalent to the Honor policy. This
+                            is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
+                        nodeTaintsPolicy:
+                          description: "NodeTaintsPolicy indicates how we will treat
+                            node taints when calculating pod topology spread skew.
+                            Options are: - Honor: nodes without taints, along with
+                            tainted nodes for which the incoming pod has a toleration,
+                            are included. - Ignore: node taints are ignored. All nodes
+                            are included. \n If this value is nil, the behavior is
+                            equivalent to the Ignore policy. This is a alpha-level
+                            feature enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
@@ -19765,11 +27714,11 @@ spec:
                             <key, value> as a "bucket", and try to put balanced number
                             of pods into each bucket. We define a domain as a particular
                             instance of a topology. Also, we define an eligible domain
-                            as a domain whose nodes match the node selector. e.g.
-                            If TopologyKey is "kubernetes.io/hostname", each Node
-                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
-                            each zone is a domain of that topology. It's a required
-                            field.
+                            as a domain whose nodes meet the requirements of nodeAffinityPolicy
+                            and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                            each Node is a domain of that topology. And, if TopologyKey
+                            is "topology.kubernetes.io/zone", each zone is a domain
+                            of that topology. It's a required field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -21550,19 +29499,16 @@ spec:
                       params:
                         description: Params is a list of parameter names and values.
                         items:
-                          description: Param declares an ArrayOrString to use for
-                            the parameter called name.
+                          description: Param declares an ParamValues to use for the
+                            parameter called name.
                           properties:
                             name:
                               type: string
                             value:
-                              description: 'ArrayOrString is a type that can hold
-                                a single string or string array. Used in JSON unmarshalling
+                              description: ParamValue is a type that can hold a single
+                                string or string array. Used in JSON unmarshalling
                                 so that a single JSON field can accept either an individual
-                                string or an array of strings. TODO (@chuangw6): This
-                                struct will be renamed or be embedded in a new struct
-                                to take into consideration the object case after the
-                                community reaches an agreement on it.'
+                                string or an array of strings.
                               properties:
                                 arrayVal:
                                   items:
@@ -21593,47 +29539,71 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       pipelineRef:
-                        description: 'PipelineRef can be used to refer to a specific
-                          instance of a Pipeline. Copied from CrossVersionObjectReference:
-                          https://github.com/kubernetes/kubernetes/blob/169df7434155cbbc22f1532cba8e0a9588e29ad8/pkg/apis/autoscaling/types.go#L64'
+                        description: PipelineRef can be used to refer to a specific
+                          instance of a Pipeline.
                         properties:
                           apiVersion:
                             description: API version of the referent
                             type: string
                           bundle:
-                            description: Bundle url reference to a Tekton Bundle.
+                            description: 'Bundle url reference to a Tekton Bundle.
+                              Deprecated: Please use ResolverRef with the bundles
+                              resolver instead.'
                             type: string
                           name:
                             description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                             type: string
-                          resolver:
-                            description: Resolver is the name of the resolver that
-                              should perform resolution of the referenced Tekton resource,
-                              such as "git".
-                            type: string
-                          resource:
-                            description: Resource contains the parameters used to
-                              identify the referenced Tekton resource. Example entries
-                              might include "repo" or "path" but the set of params
-                              ultimately depends on the chosen resolver.
+                          params:
+                            description: Params contains the parameters used to identify
+                              the referenced Tekton resource. Example entries might
+                              include "repo" or "path" but the set of params ultimately
+                              depends on the chosen resolver.
                             items:
-                              description: ResolverParam is a single parameter passed
-                                to a resolver.
+                              description: Param declares an ParamValues to use for
+                                the parameter called name.
                               properties:
                                 name:
-                                  description: Name is the name of the parameter that
-                                    will be passed to the resolver.
                                   type: string
                                 value:
-                                  description: Value is the string value of the parameter
-                                    that will be passed to the resolver.
-                                  type: string
+                                  description: ParamValue is a type that can hold
+                                    a single string or string array. Used in JSON
+                                    unmarshalling so that a single JSON field can
+                                    accept either an individual string or an array
+                                    of strings.
+                                  properties:
+                                    arrayVal:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    objectVal:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    stringVal:
+                                      type: string
+                                    type:
+                                      description: ParamType indicates the type of
+                                        an input parameter; Used to distinguish between
+                                        a single string and an array of strings.
+                                      type: string
+                                  required:
+                                  - arrayVal
+                                  - objectVal
+                                  - stringVal
+                                  - type
+                                  type: object
                               required:
                               - name
                               - value
                               type: object
                             type: array
                             x-kubernetes-list-type: atomic
+                          resolver:
+                            description: Resolver is the name of the resolver that
+                              should perform resolution of the referenced Tekton resource,
+                              such as "git".
+                            type: string
                         type: object
                       pipelineSpec:
                         description: PipelineSpec defines the desired state of Pipeline.
@@ -21652,160 +29622,64 @@ spec:
                                 passing inputs from both Params and from the output
                                 of previous tasks.
                               properties:
-                                conditions:
-                                  description: Conditions is a list of conditions
-                                    that need to be true for the task to run Conditions
-                                    are deprecated, use WhenExpressions instead
-                                  items:
-                                    description: PipelineTaskCondition allows a PipelineTask
-                                      to declare a Condition to be evaluated before
-                                      the Task is run.
-                                    properties:
-                                      conditionRef:
-                                        description: ConditionRef is the name of the
-                                          Condition to use for the conditionCheck
-                                        type: string
-                                      params:
-                                        description: Params declare parameters passed
-                                          to this Condition
-                                        items:
-                                          description: Param declares an ArrayOrString
-                                            to use for the parameter called name.
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              description: 'ArrayOrString is a type
-                                                that can hold a single string or string
-                                                array. Used in JSON unmarshalling
-                                                so that a single JSON field can accept
-                                                either an individual string or an
-                                                array of strings. TODO (@chuangw6):
-                                                This struct will be renamed or be
-                                                embedded in a new struct to take into
-                                                consideration the object case after
-                                                the community reaches an agreement
-                                                on it.'
-                                              properties:
-                                                arrayVal:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                                objectVal:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                                stringVal:
-                                                  type: string
-                                                type:
-                                                  description: ParamType indicates
-                                                    the type of an input parameter;
-                                                    Used to distinguish between a
-                                                    single string and an array of
-                                                    strings.
-                                                  type: string
-                                              required:
-                                              - arrayVal
-                                              - objectVal
-                                              - stringVal
-                                              - type
-                                              type: object
-                                          required:
-                                          - name
-                                          - value
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      resources:
-                                        description: Resources declare the resources
-                                          provided to this Condition as input
-                                        items:
-                                          description: PipelineTaskInputResource maps
-                                            the name of a declared PipelineResource
-                                            input dependency in a Task to the resource
-                                            in the Pipeline's DeclaredPipelineResources
-                                            that should be used. This input may come
-                                            from a previous task.
-                                          properties:
-                                            from:
-                                              description: From is the list of PipelineTask
-                                                names that the resource has to come
-                                                from. (Implies an ordering in the
-                                                execution graph.)
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                            name:
-                                              description: Name is the name of the
-                                                PipelineResource as declared by the
-                                                Task.
-                                              type: string
-                                            resource:
-                                              description: Resource is the name of
-                                                the DeclaredPipelineResource to use.
-                                              type: string
-                                          required:
-                                          - name
-                                          - resource
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    required:
-                                    - conditionRef
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
                                 matrix:
                                   description: Matrix declares parameters used to
                                     fan out this task.
-                                  items:
-                                    description: Param declares an ArrayOrString to
-                                      use for the parameter called name.
-                                    properties:
-                                      name:
-                                        type: string
-                                      value:
-                                        description: 'ArrayOrString is a type that
-                                          can hold a single string or string array.
-                                          Used in JSON unmarshalling so that a single
-                                          JSON field can accept either an individual
-                                          string or an array of strings. TODO (@chuangw6):
-                                          This struct will be renamed or be embedded
-                                          in a new struct to take into consideration
-                                          the object case after the community reaches
-                                          an agreement on it.'
+                                  properties:
+                                    params:
+                                      description: Params is a list of parameters
+                                        used to fan out the pipelineTask Params takes
+                                        only `Parameters` of type `"array"` Each array
+                                        element is supplied to the `PipelineTask`
+                                        by substituting `params` of type `"string"`
+                                        in the underlying `Task`. The names of the
+                                        `params` in the `Matrix` must match the names
+                                        of the `params` in the underlying `Task` that
+                                        they will be substituting.
+                                      items:
+                                        description: Param declares an ParamValues
+                                          to use for the parameter called name.
                                         properties:
-                                          arrayVal:
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          objectVal:
-                                            additionalProperties:
-                                              type: string
+                                          name:
+                                            type: string
+                                          value:
+                                            description: ParamValue is a type that
+                                              can hold a single string or string array.
+                                              Used in JSON unmarshalling so that a
+                                              single JSON field can accept either
+                                              an individual string or an array of
+                                              strings.
+                                            properties:
+                                              arrayVal:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              objectVal:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              stringVal:
+                                                type: string
+                                              type:
+                                                description: ParamType indicates the
+                                                  type of an input parameter; Used
+                                                  to distinguish between a single
+                                                  string and an array of strings.
+                                                type: string
+                                            required:
+                                            - arrayVal
+                                            - objectVal
+                                            - stringVal
+                                            - type
                                             type: object
-                                          stringVal:
-                                            type: string
-                                          type:
-                                            description: ParamType indicates the type
-                                              of an input parameter; Used to distinguish
-                                              between a single string and an array
-                                              of strings.
-                                            type: string
                                         required:
-                                        - arrayVal
-                                        - objectVal
-                                        - stringVal
-                                        - type
+                                        - name
+                                        - value
                                         type: object
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
                                 name:
                                   description: Name is the name of this task within
                                     the context of a Pipeline. Name is used as a coordinate
@@ -21816,21 +29690,17 @@ spec:
                                   description: Parameters declares parameters passed
                                     to this task.
                                   items:
-                                    description: Param declares an ArrayOrString to
+                                    description: Param declares an ParamValues to
                                       use for the parameter called name.
                                     properties:
                                       name:
                                         type: string
                                       value:
-                                        description: 'ArrayOrString is a type that
-                                          can hold a single string or string array.
-                                          Used in JSON unmarshalling so that a single
-                                          JSON field can accept either an individual
-                                          string or an array of strings. TODO (@chuangw6):
-                                          This struct will be renamed or be embedded
-                                          in a new struct to take into consideration
-                                          the object case after the community reaches
-                                          an agreement on it.'
+                                        description: ParamValue is a type that can
+                                          hold a single string or string array. Used
+                                          in JSON unmarshalling so that a single JSON
+                                          field can accept either an individual string
+                                          or an array of strings.
                                         properties:
                                           arrayVal:
                                             items:
@@ -21949,8 +29819,9 @@ spec:
                                       description: API version of the referent
                                       type: string
                                     bundle:
-                                      description: Bundle url reference to a Tekton
-                                        Bundle.
+                                      description: 'Bundle url reference to a Tekton
+                                        Bundle. Deprecated: Please use ResolverRef
+                                        with the bundles resolver instead.'
                                       type: string
                                     kind:
                                       description: TaskKind indicates the kind of
@@ -21960,36 +29831,60 @@ spec:
                                       description: 'Name of the referent; More info:
                                         http://kubernetes.io/docs/user-guide/identifiers#names'
                                       type: string
-                                    resolver:
-                                      description: Resolver is the name of the resolver
-                                        that should perform resolution of the referenced
-                                        Tekton resource, such as "git".
-                                      type: string
-                                    resource:
-                                      description: Resource contains the parameters
+                                    params:
+                                      description: Params contains the parameters
                                         used to identify the referenced Tekton resource.
                                         Example entries might include "repo" or "path"
                                         but the set of params ultimately depends on
                                         the chosen resolver.
                                       items:
-                                        description: ResolverParam is a single parameter
-                                          passed to a resolver.
+                                        description: Param declares an ParamValues
+                                          to use for the parameter called name.
                                         properties:
                                           name:
-                                            description: Name is the name of the parameter
-                                              that will be passed to the resolver.
                                             type: string
                                           value:
-                                            description: Value is the string value
-                                              of the parameter that will be passed
-                                              to the resolver.
-                                            type: string
+                                            description: ParamValue is a type that
+                                              can hold a single string or string array.
+                                              Used in JSON unmarshalling so that a
+                                              single JSON field can accept either
+                                              an individual string or an array of
+                                              strings.
+                                            properties:
+                                              arrayVal:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              objectVal:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              stringVal:
+                                                type: string
+                                              type:
+                                                description: ParamType indicates the
+                                                  type of an input parameter; Used
+                                                  to distinguish between a single
+                                                  string and an array of strings.
+                                                type: string
+                                            required:
+                                            - arrayVal
+                                            - objectVal
+                                            - stringVal
+                                            - type
+                                            type: object
                                         required:
                                         - name
                                         - value
                                         type: object
                                       type: array
                                       x-kubernetes-list-type: atomic
+                                    resolver:
+                                      description: Resolver is the name of the resolver
+                                        that should perform resolution of the referenced
+                                        Tekton resource, such as "git".
+                                      type: string
                                   type: object
                                 taskSpec:
                                   description: TaskSpec is a specification of a task
@@ -22221,6 +30116,23 @@ spec:
                                           name:
                                             description: Name the given name
                                             type: string
+                                          properties:
+                                            additionalProperties:
+                                              description: PropertySpec defines the
+                                                struct for object keys
+                                              properties:
+                                                type:
+                                                  description: ParamType indicates
+                                                    the type of an input parameter;
+                                                    Used to distinguish between a
+                                                    single string and an array of
+                                                    strings.
+                                                  type: string
+                                              type: object
+                                            description: Properties is the JSON Schema
+                                              properties to support key-value pairs
+                                              results.
+                                            type: object
                                           type:
                                             description: Type is the user-specified
                                               type of the result. The possible type
@@ -22243,9 +30155,9 @@ spec:
                                         properties:
                                           args:
                                             description: 'Arguments to the entrypoint.
-                                              The docker image''s CMD is used if this
-                                              is not provided. Variable references
-                                              $(VAR_NAME) are expanded using the container''s
+                                              The image''s CMD is used if this is
+                                              not provided. Variable references $(VAR_NAME)
+                                              are expanded using the container''s
                                               environment. If a variable cannot be
                                               resolved, the reference in the input
                                               string will be unchanged. Double $$
@@ -22262,27 +30174,26 @@ spec:
                                             x-kubernetes-list-type: atomic
                                           command:
                                             description: 'Entrypoint array. Not executed
-                                              within a shell. The docker image''s
-                                              ENTRYPOINT is used if this is not provided.
-                                              Variable references $(VAR_NAME) are
-                                              expanded using the container''s environment.
-                                              If a variable cannot be resolved, the
-                                              reference in the input string will be
-                                              unchanged. Double $$ are reduced to
-                                              a single $, which allows for escaping
-                                              the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                              will produce the string literal "$(VAR_NAME)".
-                                              Escaped references will never be expanded,
-                                              regardless of whether the variable exists
-                                              or not. Cannot be updated. More info:
-                                              https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                              within a shell. The image''s ENTRYPOINT
+                                              is used if this is not provided. Variable
+                                              references $(VAR_NAME) are expanded
+                                              using the Sidecar''s environment. If
+                                              a variable cannot be resolved, the reference
+                                              in the input string will be unchanged.
+                                              Double $$ are reduced to a single $,
+                                              which allows for escaping the $(VAR_NAME)
+                                              syntax: i.e. "$$(VAR_NAME)" will produce
+                                              the string literal "$(VAR_NAME)". Escaped
+                                              references will never be expanded, regardless
+                                              of whether the variable exists or not.
+                                              Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                             items:
                                               type: string
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           env:
                                             description: List of environment variables
-                                              to set in the container. Cannot be updated.
+                                              to set in the Sidecar. Cannot be updated.
                                             items:
                                               description: EnvVar represents an environment
                                                 variable present in a Container.
@@ -22423,11 +30334,11 @@ spec:
                                             x-kubernetes-list-type: atomic
                                           envFrom:
                                             description: List of sources to populate
-                                              environment variables in the container.
+                                              environment variables in the Sidecar.
                                               The keys defined within a source must
                                               be a C_IDENTIFIER. All invalid keys
                                               will be reported as an event when the
-                                              container is starting. When a key exists
+                                              Sidecar is starting. When a key exists
                                               in multiple sources, the value associated
                                               with the last source will take precedence.
                                               Values defined by an Env with a duplicate
@@ -22476,12 +30387,8 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           image:
-                                            description: 'Docker image name. More
-                                              info: https://kubernetes.io/docs/concepts/containers/images
-                                              This field is optional to allow higher
-                                              level config management to default or
-                                              override container images in workload
-                                              controllers like Deployments and StatefulSets.'
+                                            description: 'Image name to be used by
+                                              the Sidecar. More info: https://kubernetes.io/docs/concepts/containers/images'
                                             type: string
                                           imagePullPolicy:
                                             description: 'Image pull policy. One of
@@ -22492,7 +30399,7 @@ spec:
                                             type: string
                                           lifecycle:
                                             description: Actions that the management
-                                              system should take in response to container
+                                              system should take in response to Sidecar
                                               lifecycle events. Cannot be updated.
                                             properties:
                                               postStart:
@@ -22741,7 +30648,7 @@ spec:
                                                 type: object
                                             type: object
                                           livenessProbe:
-                                            description: 'Periodic probe of container
+                                            description: 'Periodic probe of Sidecar
                                               liveness. Container will be restarted
                                               if the probe fails. Cannot be updated.
                                               More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
@@ -22930,16 +30837,16 @@ spec:
                                                 type: integer
                                             type: object
                                           name:
-                                            description: Name of the container specified
-                                              as a DNS_LABEL. Each container in a
-                                              pod must have a unique name (DNS_LABEL).
+                                            description: Name of the Sidecar specified
+                                              as a DNS_LABEL. Each Sidecar in a Task
+                                              must have a unique name (DNS_LABEL).
                                               Cannot be updated.
                                             type: string
                                           ports:
                                             description: List of ports to expose from
-                                              the container. Exposing a port here
-                                              gives the system additional information
-                                              about the network connections a container
+                                              the Sidecar. Exposing a port here gives
+                                              the system additional information about
+                                              the network connections a container
                                               uses, but is primarily informational.
                                               Not specifying a port here DOES NOT
                                               prevent that port from being exposed.
@@ -22994,7 +30901,7 @@ spec:
                                             - protocol
                                             x-kubernetes-list-type: map
                                           readinessProbe:
-                                            description: 'Periodic probe of container
+                                            description: 'Periodic probe of Sidecar
                                               service readiness. Container will be
                                               removed from service endpoints if the
                                               probe fails. Cannot be updated. More
@@ -23185,7 +31092,7 @@ spec:
                                             type: object
                                           resources:
                                             description: 'Compute Resources required
-                                              by this container. Cannot be updated.
+                                              by this Sidecar. Cannot be updated.
                                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                             properties:
                                               limits:
@@ -23223,7 +31130,7 @@ spec:
                                             type: string
                                           securityContext:
                                             description: 'SecurityContext defines
-                                              the security options the container should
+                                              the security options the Sidecar should
                                               be run with. If set, the fields of SecurityContext
                                               override the equivalent fields of PodSecurityContext.
                                               More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
@@ -23456,17 +31363,18 @@ spec:
                                             type: object
                                           startupProbe:
                                             description: 'StartupProbe indicates that
-                                              the Pod has successfully initialized.
-                                              If specified, no other probes are executed
-                                              until this completes successfully. If
-                                              this probe fails, the Pod will be restarted,
-                                              just as if the livenessProbe failed.
-                                              This can be used to provide different
-                                              probe parameters at the beginning of
-                                              a Pod''s lifecycle, when it might take
-                                              a long time to load data or warm a cache,
-                                              than during steady-state operation.
-                                              This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                              the Pod the Sidecar is running in has
+                                              successfully initialized. If specified,
+                                              no other probes are executed until this
+                                              completes successfully. If this probe
+                                              fails, the Pod will be restarted, just
+                                              as if the livenessProbe failed. This
+                                              can be used to provide different probe
+                                              parameters at the beginning of a Pod''s
+                                              lifecycle, when it might take a long
+                                              time to load data or warm a cache, than
+                                              during steady-state operation. This
+                                              cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                             properties:
                                               exec:
                                                 description: Exec specifies the action
@@ -23652,10 +31560,10 @@ spec:
                                                 type: integer
                                             type: object
                                           stdin:
-                                            description: Whether this container should
+                                            description: Whether this Sidecar should
                                               allocate a buffer for stdin in the container
                                               runtime. If this is not set, reads from
-                                              stdin in the container will always result
+                                              stdin in the Sidecar will always result
                                               in EOF. Default is false.
                                             type: boolean
                                           stdinOnce:
@@ -23665,51 +31573,51 @@ spec:
                                               When stdin is true the stdin stream
                                               will remain open across multiple attach
                                               sessions. If stdinOnce is set to true,
-                                              stdin is opened on container start,
-                                              is empty until the first client attaches
+                                              stdin is opened on Sidecar start, is
+                                              empty until the first client attaches
                                               to stdin, and then remains open and
                                               accepts data until the client disconnects,
                                               at which time stdin is closed and remains
-                                              closed until the container is restarted.
+                                              closed until the Sidecar is restarted.
                                               If this flag is false, a container processes
                                               that reads from stdin will never receive
                                               an EOF. Default is false
                                             type: boolean
                                           terminationMessagePath:
                                             description: 'Optional: Path at which
-                                              the file to which the container''s termination
+                                              the file to which the Sidecar''s termination
                                               message will be written is mounted into
-                                              the container''s filesystem. Message
-                                              written is intended to be brief final
-                                              status, such as an assertion failure
-                                              message. Will be truncated by the node
-                                              if greater than 4096 bytes. The total
-                                              message length across all containers
-                                              will be limited to 12kb. Defaults to
-                                              /dev/termination-log. Cannot be updated.'
+                                              the Sidecar''s filesystem. Message written
+                                              is intended to be brief final status,
+                                              such as an assertion failure message.
+                                              Will be truncated by the node if greater
+                                              than 4096 bytes. The total message length
+                                              across all containers will be limited
+                                              to 12kb. Defaults to /dev/termination-log.
+                                              Cannot be updated.'
                                             type: string
                                           terminationMessagePolicy:
                                             description: Indicate how the termination
                                               message should be populated. File will
                                               use the contents of terminationMessagePath
-                                              to populate the container status message
+                                              to populate the Sidecar status message
                                               on both success and failure. FallbackToLogsOnError
-                                              will use the last chunk of container
-                                              log output if the termination message
-                                              file is empty and the container exited
-                                              with an error. The log output is limited
+                                              will use the last chunk of Sidecar log
+                                              output if the termination message file
+                                              is empty and the Sidecar exited with
+                                              an error. The log output is limited
                                               to 2048 bytes or 80 lines, whichever
                                               is smaller. Defaults to File. Cannot
                                               be updated.
                                             type: string
                                           tty:
-                                            description: Whether this container should
+                                            description: Whether this Sidecar should
                                               allocate a TTY for itself, also requires
                                               'stdin' to be true. Default is false.
                                             type: boolean
                                           volumeDevices:
                                             description: volumeDevices is the list
-                                              of block devices to be used by the container.
+                                              of block devices to be used by the Sidecar.
                                             items:
                                               description: volumeDevice describes
                                                 a mapping of a raw block device within
@@ -23732,9 +31640,8 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           volumeMounts:
-                                            description: Pod volumes to mount into
-                                              the container's filesystem. Cannot be
-                                              updated.
+                                            description: Volumes to mount into the
+                                              Sidecar's filesystem. Cannot be updated.
                                             items:
                                               description: VolumeMount describes a
                                                 mounting of a Volume within a container.
@@ -23785,7 +31692,7 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           workingDir:
-                                            description: Container's working directory.
+                                            description: Sidecar's working directory.
                                               If not specified, the container runtime's
                                               default will be used, which might be
                                               configured in the container image. Cannot
@@ -23843,9 +31750,9 @@ spec:
                                       properties:
                                         args:
                                           description: 'Arguments to the entrypoint.
-                                            The docker image''s CMD is used if this
-                                            is not provided. Variable references $(VAR_NAME)
-                                            are expanded using the container''s environment.
+                                            The image''s CMD is used if this is not
+                                            provided. Variable references $(VAR_NAME)
+                                            are expanded using the Step''s environment.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
                                             unchanged. Double $$ are reduced to a
@@ -23865,7 +31772,7 @@ spec:
                                             within a shell. The docker image''s ENTRYPOINT
                                             is used if this is not provided. Variable
                                             references $(VAR_NAME) are expanded using
-                                            the container''s environment. If a variable
+                                            the Step''s environment. If a variable
                                             cannot be resolved, the reference in the
                                             input string will be unchanged. Double
                                             $$ are reduced to a single $, which allows
@@ -24017,10 +31924,10 @@ spec:
                                           x-kubernetes-list-type: atomic
                                         envFrom:
                                           description: List of sources to populate
-                                            environment variables in the container.
-                                            The keys defined within a source must
-                                            be a C_IDENTIFIER. All invalid keys will
-                                            be reported as an event when the container
+                                            environment variables in the Step. The
+                                            keys defined within a source must be a
+                                            C_IDENTIFIER. All invalid keys will be
+                                            reported as an event when the container
                                             is starting. When a key exists in multiple
                                             sources, the value associated with the
                                             last source will take precedence. Values
@@ -24069,8 +31976,8 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         image:
-                                          description: 'Docker image name. More info:
-                                            https://kubernetes.io/docs/concepts/containers/images
+                                          description: 'Default image name to use
+                                            for each Step. More info: https://kubernetes.io/docs/concepts/containers/images
                                             This field is optional to allow higher
                                             level config management to default or
                                             override container images in workload
@@ -24515,23 +32422,24 @@ spec:
                                           type: object
                                         name:
                                           description: Deprecated. This field will
-                                            be removed in a future release. DeprecatedName
-                                            of the container specified as a DNS_LABEL.
-                                            Each container in a pod must have a unique
-                                            name (DNS_LABEL). Cannot be updated.
+                                            be removed in a future release. Default
+                                            name for each Step specified as a DNS_LABEL.
+                                            Each Step in a Task must have a unique
+                                            name. Cannot be updated.
                                           type: string
                                         ports:
                                           description: Deprecated. This field will
                                             be removed in a future release. List of
-                                            ports to expose from the container. Exposing
-                                            a port here gives the system additional
-                                            information about the network connections
-                                            a container uses, but is primarily informational.
-                                            Not specifying a port here DOES NOT prevent
-                                            that port from being exposed. Any port
-                                            which is listening on the default "0.0.0.0"
-                                            address inside a container will be accessible
-                                            from the network. Cannot be updated.
+                                            ports to expose from the Step's container.
+                                            Exposing a port here gives the system
+                                            additional information about the network
+                                            connections a container uses, but is primarily
+                                            informational. Not specifying a port here
+                                            DOES NOT prevent that port from being
+                                            exposed. Any port which is listening on
+                                            the default "0.0.0.0" address inside a
+                                            container will be accessible from the
+                                            network. Cannot be updated.
                                           items:
                                             description: ContainerPort represents
                                               a network port in a single container.
@@ -24765,8 +32673,8 @@ spec:
                                           type: object
                                         resources:
                                           description: 'Compute Resources required
-                                            by this container. Cannot be updated.
-                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            by this Step. Cannot be updated. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -24797,8 +32705,8 @@ spec:
                                           type: object
                                         securityContext:
                                           description: 'SecurityContext defines the
-                                            security options the container should
-                                            be run with. If set, the fields of SecurityContext
+                                            security options the Step should be run
+                                            with. If set, the fields of SecurityContext
                                             override the equivalent fields of PodSecurityContext.
                                             More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                           properties:
@@ -25213,11 +33121,11 @@ spec:
                                         stdin:
                                           description: Deprecated. This field will
                                             be removed in a future release. Whether
-                                            this container should allocate a buffer
-                                            for stdin in the container runtime. If
-                                            this is not set, reads from stdin in the
-                                            container will always result in EOF. Default
-                                            is false.
+                                            this Step should allocate a buffer for
+                                            stdin in the container runtime. If this
+                                            is not set, reads from stdin in the Step
+                                            will always result in EOF. Default is
+                                            false.
                                           type: boolean
                                         stdinOnce:
                                           description: Deprecated. This field will
@@ -25238,44 +33146,25 @@ spec:
                                             an EOF. Default is false
                                           type: boolean
                                         terminationMessagePath:
-                                          description: 'Deprecated. This field will
-                                            be removed in a future release. Optional:
-                                            Path at which the file to which the container''s
-                                            termination message will be written is
-                                            mounted into the container''s filesystem.
-                                            Message written is intended to be brief
-                                            final status, such as an assertion failure
-                                            message. Will be truncated by the node
-                                            if greater than 4096 bytes. The total
-                                            message length across all containers will
-                                            be limited to 12kb. Defaults to /dev/termination-log.
-                                            Cannot be updated.'
+                                          description: Deprecated. This field will
+                                            be removed in a future release and cannot
+                                            be meaningfully used.
                                           type: string
                                         terminationMessagePolicy:
                                           description: Deprecated. This field will
-                                            be removed in a future release. Indicate
-                                            how the termination message should be
-                                            populated. File will use the contents
-                                            of terminationMessagePath to populate
-                                            the container status message on both success
-                                            and failure. FallbackToLogsOnError will
-                                            use the last chunk of container log output
-                                            if the termination message file is empty
-                                            and the container exited with an error.
-                                            The log output is limited to 2048 bytes
-                                            or 80 lines, whichever is smaller. Defaults
-                                            to File. Cannot be updated.
+                                            be removed in a future release and cannot
+                                            be meaningfully used.
                                           type: string
                                         tty:
                                           description: Deprecated. This field will
                                             be removed in a future release. Whether
-                                            this container should allocate a DeprecatedTTY
+                                            this Step should allocate a DeprecatedTTY
                                             for itself, also requires 'stdin' to be
                                             true. Default is false.
                                           type: boolean
                                         volumeDevices:
                                           description: volumeDevices is the list of
-                                            block devices to be used by the container.
+                                            block devices to be used by the Step.
                                           items:
                                             description: volumeDevice describes a
                                               mapping of a raw block device within
@@ -25298,8 +33187,8 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         volumeMounts:
-                                          description: Pod volumes to mount into the
-                                            container's filesystem. Cannot be updated.
+                                          description: Volumes to mount into the Step's
+                                            filesystem. Cannot be updated.
                                           items:
                                             description: VolumeMount describes a mounting
                                               of a Volume within a container.
@@ -25349,8 +33238,8 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         workingDir:
-                                          description: Container's working directory.
-                                            If not specified, the container runtime's
+                                          description: Step's working directory. If
+                                            not specified, the container runtime's
                                             default will be used, which might be configured
                                             in the container image. Cannot be updated.
                                           type: string
@@ -25367,9 +33256,9 @@ spec:
                                         properties:
                                           args:
                                             description: 'Arguments to the entrypoint.
-                                              The docker image''s CMD is used if this
-                                              is not provided. Variable references
-                                              $(VAR_NAME) are expanded using the container''s
+                                              The image''s CMD is used if this is
+                                              not provided. Variable references $(VAR_NAME)
+                                              are expanded using the container''s
                                               environment. If a variable cannot be
                                               resolved, the reference in the input
                                               string will be unchanged. Double $$
@@ -25386,10 +33275,10 @@ spec:
                                             x-kubernetes-list-type: atomic
                                           command:
                                             description: 'Entrypoint array. Not executed
-                                              within a shell. The docker image''s
-                                              ENTRYPOINT is used if this is not provided.
-                                              Variable references $(VAR_NAME) are
-                                              expanded using the container''s environment.
+                                              within a shell. The image''s ENTRYPOINT
+                                              is used if this is not provided. Variable
+                                              references $(VAR_NAME) are expanded
+                                              using the container''s environment.
                                               If a variable cannot be resolved, the
                                               reference in the input string will be
                                               unchanged. Double $$ are reduced to
@@ -25600,12 +33489,8 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           image:
-                                            description: 'Docker image name. More
-                                              info: https://kubernetes.io/docs/concepts/containers/images
-                                              This field is optional to allow higher
-                                              level config management to default or
-                                              override container images in workload
-                                              controllers like Deployments and StatefulSets.'
+                                            description: 'Image reference name to
+                                              run for this Step. More info: https://kubernetes.io/docs/concepts/containers/images'
                                             type: string
                                           imagePullPolicy:
                                             description: 'Image pull policy. One of
@@ -25869,9 +33754,9 @@ spec:
                                           livenessProbe:
                                             description: 'Deprecated. This field will
                                               be removed in a future release. Periodic
-                                              probe of container liveness. Container
-                                              will be restarted if the probe fails.
-                                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                              probe of container liveness. Step will
+                                              be restarted if the probe fails. Cannot
+                                              be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                             properties:
                                               exec:
                                                 description: Exec specifies the action
@@ -26057,25 +33942,19 @@ spec:
                                                 type: integer
                                             type: object
                                           name:
-                                            description: Name of the container specified
-                                              as a DNS_LABEL. Each container in a
-                                              pod must have a unique name (DNS_LABEL).
-                                              Cannot be updated.
+                                            description: Name of the Step specified
+                                              as a DNS_LABEL. Each Step in a Task
+                                              must have a unique name.
                                             type: string
                                           onError:
                                             description: OnError defines the exiting
                                               behavior of a container on error can
                                               be set to [ continue | stopAndFail ]
-                                              stopAndFail indicates exit the taskRun
-                                              if the container exits with non-zero
-                                              exit code continue indicates continue
-                                              executing the rest of the steps irrespective
-                                              of the container exit code
                                             type: string
                                           ports:
                                             description: Deprecated. This field will
                                               be removed in a future release. List
-                                              of ports to expose from the container.
+                                              of ports to expose from the Step's container.
                                               Exposing a port here gives the system
                                               additional information about the network
                                               connections a container uses, but is
@@ -26135,9 +34014,9 @@ spec:
                                             description: 'Deprecated. This field will
                                               be removed in a future release. Periodic
                                               probe of container service readiness.
-                                              Container will be removed from service
-                                              endpoints if the probe fails. Cannot
-                                              be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                              Step will be removed from service endpoints
+                                              if the probe fails. Cannot be updated.
+                                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                             properties:
                                               exec:
                                                 description: Exec specifies the action
@@ -26324,8 +34203,8 @@ spec:
                                             type: object
                                           resources:
                                             description: 'Compute Resources required
-                                              by this container. Cannot be updated.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              by this Step. Cannot be updated. More
+                                              info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -26363,7 +34242,7 @@ spec:
                                             type: string
                                           securityContext:
                                             description: 'SecurityContext defines
-                                              the security options the container should
+                                              the security options the Step should
                                               be run with. If set, the fields of SecurityContext
                                               override the equivalent fields of PodSecurityContext.
                                               More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
@@ -26597,18 +34476,18 @@ spec:
                                           startupProbe:
                                             description: 'Deprecated. This field will
                                               be removed in a future release. DeprecatedStartupProbe
-                                              indicates that the Pod has successfully
-                                              initialized. If specified, no other
-                                              probes are executed until this completes
-                                              successfully. If this probe fails, the
-                                              Pod will be restarted, just as if the
-                                              livenessProbe failed. This can be used
-                                              to provide different probe parameters
-                                              at the beginning of a Pod''s lifecycle,
-                                              when it might take a long time to load
-                                              data or warm a cache, than during steady-state
-                                              operation. This cannot be updated. More
-                                              info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                              indicates that the Pod this Step runs
+                                              in has successfully initialized. If
+                                              specified, no other probes are executed
+                                              until this completes successfully. If
+                                              this probe fails, the Pod will be restarted,
+                                              just as if the livenessProbe failed.
+                                              This can be used to provide different
+                                              probe parameters at the beginning of
+                                              a Pod''s lifecycle, when it might take
+                                              a long time to load data or warm a cache,
+                                              than during steady-state operation.
+                                              This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                             properties:
                                               exec:
                                                 description: Exec specifies the action
@@ -26793,6 +34672,15 @@ spec:
                                                 format: int32
                                                 type: integer
                                             type: object
+                                          stderrConfig:
+                                            description: Stores configuration for
+                                              the stderr stream of the step.
+                                            properties:
+                                              path:
+                                                description: Path to duplicate stdout
+                                                  stream to on container's local filesystem.
+                                                type: string
+                                            type: object
                                           stdin:
                                             description: Deprecated. This field will
                                               be removed in a future release. Whether
@@ -26821,36 +34709,24 @@ spec:
                                               reads from stdin will never receive
                                               an EOF. Default is false
                                             type: boolean
+                                          stdoutConfig:
+                                            description: Stores configuration for
+                                              the stdout stream of the step.
+                                            properties:
+                                              path:
+                                                description: Path to duplicate stdout
+                                                  stream to on container's local filesystem.
+                                                type: string
+                                            type: object
                                           terminationMessagePath:
-                                            description: 'Deprecated. This field will
-                                              be removed in a future release. Optional:
-                                              Path at which the file to which the
-                                              container''s termination message will
-                                              be written is mounted into the container''s
-                                              filesystem. Message written is intended
-                                              to be brief final status, such as an
-                                              assertion failure message. Will be truncated
-                                              by the node if greater than 4096 bytes.
-                                              The total message length across all
-                                              containers will be limited to 12kb.
-                                              Defaults to /dev/termination-log. Cannot
-                                              be updated.'
+                                            description: Deprecated. This field will
+                                              be removed in a future release and can't
+                                              be meaningfully used.
                                             type: string
                                           terminationMessagePolicy:
                                             description: Deprecated. This field will
-                                              be removed in a future release. Indicate
-                                              how the termination message should be
-                                              populated. File will use the contents
-                                              of terminationMessagePath to populate
-                                              the container status message on both
-                                              success and failure. FallbackToLogsOnError
-                                              will use the last chunk of container
-                                              log output if the termination message
-                                              file is empty and the container exited
-                                              with an error. The log output is limited
-                                              to 2048 bytes or 80 lines, whichever
-                                              is smaller. Defaults to File. Cannot
-                                              be updated.
+                                              be removed in a future release and can't
+                                              be meaningfully used.
                                             type: string
                                           timeout:
                                             description: 'Timeout is the time after
@@ -26867,7 +34743,7 @@ spec:
                                             type: boolean
                                           volumeDevices:
                                             description: volumeDevices is the list
-                                              of block devices to be used by the container.
+                                              of block devices to be used by the Step.
                                             items:
                                               description: volumeDevice describes
                                                 a mapping of a raw block device within
@@ -26890,9 +34766,8 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           volumeMounts:
-                                            description: Pod volumes to mount into
-                                              the container's filesystem. Cannot be
-                                              updated.
+                                            description: Volumes to mount into the
+                                              Step's filesystem. Cannot be updated.
                                             items:
                                               description: VolumeMount describes a
                                                 mounting of a Volume within a container.
@@ -26943,7 +34818,7 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           workingDir:
-                                            description: Container's working directory.
+                                            description: Step's working directory.
                                               If not specified, the container runtime's
                                               default will be used, which might be
                                               configured in the container image. Cannot
@@ -29228,10 +37103,38 @@ spec:
                                 name:
                                   description: Name the given name
                                   type: string
+                                type:
+                                  description: Type is the user-specified type of
+                                    the result. The possible types are 'string', 'array',
+                                    and 'object', with 'string' as the default. 'array'
+                                    and 'object' types are alpha features.
+                                  type: string
                                 value:
                                   description: Value the expression used to retrieve
                                     the value
-                                  type: string
+                                  properties:
+                                    arrayVal:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    objectVal:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    stringVal:
+                                      type: string
+                                    type:
+                                      description: ParamType indicates the type of
+                                        an input parameter; Used to distinguish between
+                                        a single string and an array of strings.
+                                      type: string
+                                  required:
+                                  - arrayVal
+                                  - objectVal
+                                  - stringVal
+                                  - type
+                                  type: object
                               required:
                               - name
                               - value
@@ -29246,160 +37149,64 @@ spec:
                                 passing inputs from both Params and from the output
                                 of previous tasks.
                               properties:
-                                conditions:
-                                  description: Conditions is a list of conditions
-                                    that need to be true for the task to run Conditions
-                                    are deprecated, use WhenExpressions instead
-                                  items:
-                                    description: PipelineTaskCondition allows a PipelineTask
-                                      to declare a Condition to be evaluated before
-                                      the Task is run.
-                                    properties:
-                                      conditionRef:
-                                        description: ConditionRef is the name of the
-                                          Condition to use for the conditionCheck
-                                        type: string
-                                      params:
-                                        description: Params declare parameters passed
-                                          to this Condition
-                                        items:
-                                          description: Param declares an ArrayOrString
-                                            to use for the parameter called name.
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              description: 'ArrayOrString is a type
-                                                that can hold a single string or string
-                                                array. Used in JSON unmarshalling
-                                                so that a single JSON field can accept
-                                                either an individual string or an
-                                                array of strings. TODO (@chuangw6):
-                                                This struct will be renamed or be
-                                                embedded in a new struct to take into
-                                                consideration the object case after
-                                                the community reaches an agreement
-                                                on it.'
-                                              properties:
-                                                arrayVal:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                                objectVal:
-                                                  additionalProperties:
-                                                    type: string
-                                                  type: object
-                                                stringVal:
-                                                  type: string
-                                                type:
-                                                  description: ParamType indicates
-                                                    the type of an input parameter;
-                                                    Used to distinguish between a
-                                                    single string and an array of
-                                                    strings.
-                                                  type: string
-                                              required:
-                                              - arrayVal
-                                              - objectVal
-                                              - stringVal
-                                              - type
-                                              type: object
-                                          required:
-                                          - name
-                                          - value
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      resources:
-                                        description: Resources declare the resources
-                                          provided to this Condition as input
-                                        items:
-                                          description: PipelineTaskInputResource maps
-                                            the name of a declared PipelineResource
-                                            input dependency in a Task to the resource
-                                            in the Pipeline's DeclaredPipelineResources
-                                            that should be used. This input may come
-                                            from a previous task.
-                                          properties:
-                                            from:
-                                              description: From is the list of PipelineTask
-                                                names that the resource has to come
-                                                from. (Implies an ordering in the
-                                                execution graph.)
-                                              items:
-                                                type: string
-                                              type: array
-                                              x-kubernetes-list-type: atomic
-                                            name:
-                                              description: Name is the name of the
-                                                PipelineResource as declared by the
-                                                Task.
-                                              type: string
-                                            resource:
-                                              description: Resource is the name of
-                                                the DeclaredPipelineResource to use.
-                                              type: string
-                                          required:
-                                          - name
-                                          - resource
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    required:
-                                    - conditionRef
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
                                 matrix:
                                   description: Matrix declares parameters used to
                                     fan out this task.
-                                  items:
-                                    description: Param declares an ArrayOrString to
-                                      use for the parameter called name.
-                                    properties:
-                                      name:
-                                        type: string
-                                      value:
-                                        description: 'ArrayOrString is a type that
-                                          can hold a single string or string array.
-                                          Used in JSON unmarshalling so that a single
-                                          JSON field can accept either an individual
-                                          string or an array of strings. TODO (@chuangw6):
-                                          This struct will be renamed or be embedded
-                                          in a new struct to take into consideration
-                                          the object case after the community reaches
-                                          an agreement on it.'
+                                  properties:
+                                    params:
+                                      description: Params is a list of parameters
+                                        used to fan out the pipelineTask Params takes
+                                        only `Parameters` of type `"array"` Each array
+                                        element is supplied to the `PipelineTask`
+                                        by substituting `params` of type `"string"`
+                                        in the underlying `Task`. The names of the
+                                        `params` in the `Matrix` must match the names
+                                        of the `params` in the underlying `Task` that
+                                        they will be substituting.
+                                      items:
+                                        description: Param declares an ParamValues
+                                          to use for the parameter called name.
                                         properties:
-                                          arrayVal:
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          objectVal:
-                                            additionalProperties:
-                                              type: string
+                                          name:
+                                            type: string
+                                          value:
+                                            description: ParamValue is a type that
+                                              can hold a single string or string array.
+                                              Used in JSON unmarshalling so that a
+                                              single JSON field can accept either
+                                              an individual string or an array of
+                                              strings.
+                                            properties:
+                                              arrayVal:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              objectVal:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              stringVal:
+                                                type: string
+                                              type:
+                                                description: ParamType indicates the
+                                                  type of an input parameter; Used
+                                                  to distinguish between a single
+                                                  string and an array of strings.
+                                                type: string
+                                            required:
+                                            - arrayVal
+                                            - objectVal
+                                            - stringVal
+                                            - type
                                             type: object
-                                          stringVal:
-                                            type: string
-                                          type:
-                                            description: ParamType indicates the type
-                                              of an input parameter; Used to distinguish
-                                              between a single string and an array
-                                              of strings.
-                                            type: string
                                         required:
-                                        - arrayVal
-                                        - objectVal
-                                        - stringVal
-                                        - type
+                                        - name
+                                        - value
                                         type: object
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
                                 name:
                                   description: Name is the name of this task within
                                     the context of a Pipeline. Name is used as a coordinate
@@ -29410,21 +37217,17 @@ spec:
                                   description: Parameters declares parameters passed
                                     to this task.
                                   items:
-                                    description: Param declares an ArrayOrString to
+                                    description: Param declares an ParamValues to
                                       use for the parameter called name.
                                     properties:
                                       name:
                                         type: string
                                       value:
-                                        description: 'ArrayOrString is a type that
-                                          can hold a single string or string array.
-                                          Used in JSON unmarshalling so that a single
-                                          JSON field can accept either an individual
-                                          string or an array of strings. TODO (@chuangw6):
-                                          This struct will be renamed or be embedded
-                                          in a new struct to take into consideration
-                                          the object case after the community reaches
-                                          an agreement on it.'
+                                        description: ParamValue is a type that can
+                                          hold a single string or string array. Used
+                                          in JSON unmarshalling so that a single JSON
+                                          field can accept either an individual string
+                                          or an array of strings.
                                         properties:
                                           arrayVal:
                                             items:
@@ -29543,8 +37346,9 @@ spec:
                                       description: API version of the referent
                                       type: string
                                     bundle:
-                                      description: Bundle url reference to a Tekton
-                                        Bundle.
+                                      description: 'Bundle url reference to a Tekton
+                                        Bundle. Deprecated: Please use ResolverRef
+                                        with the bundles resolver instead.'
                                       type: string
                                     kind:
                                       description: TaskKind indicates the kind of
@@ -29554,36 +37358,60 @@ spec:
                                       description: 'Name of the referent; More info:
                                         http://kubernetes.io/docs/user-guide/identifiers#names'
                                       type: string
-                                    resolver:
-                                      description: Resolver is the name of the resolver
-                                        that should perform resolution of the referenced
-                                        Tekton resource, such as "git".
-                                      type: string
-                                    resource:
-                                      description: Resource contains the parameters
+                                    params:
+                                      description: Params contains the parameters
                                         used to identify the referenced Tekton resource.
                                         Example entries might include "repo" or "path"
                                         but the set of params ultimately depends on
                                         the chosen resolver.
                                       items:
-                                        description: ResolverParam is a single parameter
-                                          passed to a resolver.
+                                        description: Param declares an ParamValues
+                                          to use for the parameter called name.
                                         properties:
                                           name:
-                                            description: Name is the name of the parameter
-                                              that will be passed to the resolver.
                                             type: string
                                           value:
-                                            description: Value is the string value
-                                              of the parameter that will be passed
-                                              to the resolver.
-                                            type: string
+                                            description: ParamValue is a type that
+                                              can hold a single string or string array.
+                                              Used in JSON unmarshalling so that a
+                                              single JSON field can accept either
+                                              an individual string or an array of
+                                              strings.
+                                            properties:
+                                              arrayVal:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              objectVal:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              stringVal:
+                                                type: string
+                                              type:
+                                                description: ParamType indicates the
+                                                  type of an input parameter; Used
+                                                  to distinguish between a single
+                                                  string and an array of strings.
+                                                type: string
+                                            required:
+                                            - arrayVal
+                                            - objectVal
+                                            - stringVal
+                                            - type
+                                            type: object
                                         required:
                                         - name
                                         - value
                                         type: object
                                       type: array
                                       x-kubernetes-list-type: atomic
+                                    resolver:
+                                      description: Resolver is the name of the resolver
+                                        that should perform resolution of the referenced
+                                        Tekton resource, such as "git".
+                                      type: string
                                   type: object
                                 taskSpec:
                                   description: TaskSpec is a specification of a task
@@ -29815,6 +37643,23 @@ spec:
                                           name:
                                             description: Name the given name
                                             type: string
+                                          properties:
+                                            additionalProperties:
+                                              description: PropertySpec defines the
+                                                struct for object keys
+                                              properties:
+                                                type:
+                                                  description: ParamType indicates
+                                                    the type of an input parameter;
+                                                    Used to distinguish between a
+                                                    single string and an array of
+                                                    strings.
+                                                  type: string
+                                              type: object
+                                            description: Properties is the JSON Schema
+                                              properties to support key-value pairs
+                                              results.
+                                            type: object
                                           type:
                                             description: Type is the user-specified
                                               type of the result. The possible type
@@ -29837,9 +37682,9 @@ spec:
                                         properties:
                                           args:
                                             description: 'Arguments to the entrypoint.
-                                              The docker image''s CMD is used if this
-                                              is not provided. Variable references
-                                              $(VAR_NAME) are expanded using the container''s
+                                              The image''s CMD is used if this is
+                                              not provided. Variable references $(VAR_NAME)
+                                              are expanded using the container''s
                                               environment. If a variable cannot be
                                               resolved, the reference in the input
                                               string will be unchanged. Double $$
@@ -29856,27 +37701,26 @@ spec:
                                             x-kubernetes-list-type: atomic
                                           command:
                                             description: 'Entrypoint array. Not executed
-                                              within a shell. The docker image''s
-                                              ENTRYPOINT is used if this is not provided.
-                                              Variable references $(VAR_NAME) are
-                                              expanded using the container''s environment.
-                                              If a variable cannot be resolved, the
-                                              reference in the input string will be
-                                              unchanged. Double $$ are reduced to
-                                              a single $, which allows for escaping
-                                              the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                              will produce the string literal "$(VAR_NAME)".
-                                              Escaped references will never be expanded,
-                                              regardless of whether the variable exists
-                                              or not. Cannot be updated. More info:
-                                              https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                              within a shell. The image''s ENTRYPOINT
+                                              is used if this is not provided. Variable
+                                              references $(VAR_NAME) are expanded
+                                              using the Sidecar''s environment. If
+                                              a variable cannot be resolved, the reference
+                                              in the input string will be unchanged.
+                                              Double $$ are reduced to a single $,
+                                              which allows for escaping the $(VAR_NAME)
+                                              syntax: i.e. "$$(VAR_NAME)" will produce
+                                              the string literal "$(VAR_NAME)". Escaped
+                                              references will never be expanded, regardless
+                                              of whether the variable exists or not.
+                                              Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                             items:
                                               type: string
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           env:
                                             description: List of environment variables
-                                              to set in the container. Cannot be updated.
+                                              to set in the Sidecar. Cannot be updated.
                                             items:
                                               description: EnvVar represents an environment
                                                 variable present in a Container.
@@ -30017,11 +37861,11 @@ spec:
                                             x-kubernetes-list-type: atomic
                                           envFrom:
                                             description: List of sources to populate
-                                              environment variables in the container.
+                                              environment variables in the Sidecar.
                                               The keys defined within a source must
                                               be a C_IDENTIFIER. All invalid keys
                                               will be reported as an event when the
-                                              container is starting. When a key exists
+                                              Sidecar is starting. When a key exists
                                               in multiple sources, the value associated
                                               with the last source will take precedence.
                                               Values defined by an Env with a duplicate
@@ -30070,12 +37914,8 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           image:
-                                            description: 'Docker image name. More
-                                              info: https://kubernetes.io/docs/concepts/containers/images
-                                              This field is optional to allow higher
-                                              level config management to default or
-                                              override container images in workload
-                                              controllers like Deployments and StatefulSets.'
+                                            description: 'Image name to be used by
+                                              the Sidecar. More info: https://kubernetes.io/docs/concepts/containers/images'
                                             type: string
                                           imagePullPolicy:
                                             description: 'Image pull policy. One of
@@ -30086,7 +37926,7 @@ spec:
                                             type: string
                                           lifecycle:
                                             description: Actions that the management
-                                              system should take in response to container
+                                              system should take in response to Sidecar
                                               lifecycle events. Cannot be updated.
                                             properties:
                                               postStart:
@@ -30335,7 +38175,7 @@ spec:
                                                 type: object
                                             type: object
                                           livenessProbe:
-                                            description: 'Periodic probe of container
+                                            description: 'Periodic probe of Sidecar
                                               liveness. Container will be restarted
                                               if the probe fails. Cannot be updated.
                                               More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
@@ -30524,16 +38364,16 @@ spec:
                                                 type: integer
                                             type: object
                                           name:
-                                            description: Name of the container specified
-                                              as a DNS_LABEL. Each container in a
-                                              pod must have a unique name (DNS_LABEL).
+                                            description: Name of the Sidecar specified
+                                              as a DNS_LABEL. Each Sidecar in a Task
+                                              must have a unique name (DNS_LABEL).
                                               Cannot be updated.
                                             type: string
                                           ports:
                                             description: List of ports to expose from
-                                              the container. Exposing a port here
-                                              gives the system additional information
-                                              about the network connections a container
+                                              the Sidecar. Exposing a port here gives
+                                              the system additional information about
+                                              the network connections a container
                                               uses, but is primarily informational.
                                               Not specifying a port here DOES NOT
                                               prevent that port from being exposed.
@@ -30588,7 +38428,7 @@ spec:
                                             - protocol
                                             x-kubernetes-list-type: map
                                           readinessProbe:
-                                            description: 'Periodic probe of container
+                                            description: 'Periodic probe of Sidecar
                                               service readiness. Container will be
                                               removed from service endpoints if the
                                               probe fails. Cannot be updated. More
@@ -30779,7 +38619,7 @@ spec:
                                             type: object
                                           resources:
                                             description: 'Compute Resources required
-                                              by this container. Cannot be updated.
+                                              by this Sidecar. Cannot be updated.
                                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                             properties:
                                               limits:
@@ -30817,7 +38657,7 @@ spec:
                                             type: string
                                           securityContext:
                                             description: 'SecurityContext defines
-                                              the security options the container should
+                                              the security options the Sidecar should
                                               be run with. If set, the fields of SecurityContext
                                               override the equivalent fields of PodSecurityContext.
                                               More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
@@ -31050,17 +38890,18 @@ spec:
                                             type: object
                                           startupProbe:
                                             description: 'StartupProbe indicates that
-                                              the Pod has successfully initialized.
-                                              If specified, no other probes are executed
-                                              until this completes successfully. If
-                                              this probe fails, the Pod will be restarted,
-                                              just as if the livenessProbe failed.
-                                              This can be used to provide different
-                                              probe parameters at the beginning of
-                                              a Pod''s lifecycle, when it might take
-                                              a long time to load data or warm a cache,
-                                              than during steady-state operation.
-                                              This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                              the Pod the Sidecar is running in has
+                                              successfully initialized. If specified,
+                                              no other probes are executed until this
+                                              completes successfully. If this probe
+                                              fails, the Pod will be restarted, just
+                                              as if the livenessProbe failed. This
+                                              can be used to provide different probe
+                                              parameters at the beginning of a Pod''s
+                                              lifecycle, when it might take a long
+                                              time to load data or warm a cache, than
+                                              during steady-state operation. This
+                                              cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                             properties:
                                               exec:
                                                 description: Exec specifies the action
@@ -31246,10 +39087,10 @@ spec:
                                                 type: integer
                                             type: object
                                           stdin:
-                                            description: Whether this container should
+                                            description: Whether this Sidecar should
                                               allocate a buffer for stdin in the container
                                               runtime. If this is not set, reads from
-                                              stdin in the container will always result
+                                              stdin in the Sidecar will always result
                                               in EOF. Default is false.
                                             type: boolean
                                           stdinOnce:
@@ -31259,51 +39100,51 @@ spec:
                                               When stdin is true the stdin stream
                                               will remain open across multiple attach
                                               sessions. If stdinOnce is set to true,
-                                              stdin is opened on container start,
-                                              is empty until the first client attaches
+                                              stdin is opened on Sidecar start, is
+                                              empty until the first client attaches
                                               to stdin, and then remains open and
                                               accepts data until the client disconnects,
                                               at which time stdin is closed and remains
-                                              closed until the container is restarted.
+                                              closed until the Sidecar is restarted.
                                               If this flag is false, a container processes
                                               that reads from stdin will never receive
                                               an EOF. Default is false
                                             type: boolean
                                           terminationMessagePath:
                                             description: 'Optional: Path at which
-                                              the file to which the container''s termination
+                                              the file to which the Sidecar''s termination
                                               message will be written is mounted into
-                                              the container''s filesystem. Message
-                                              written is intended to be brief final
-                                              status, such as an assertion failure
-                                              message. Will be truncated by the node
-                                              if greater than 4096 bytes. The total
-                                              message length across all containers
-                                              will be limited to 12kb. Defaults to
-                                              /dev/termination-log. Cannot be updated.'
+                                              the Sidecar''s filesystem. Message written
+                                              is intended to be brief final status,
+                                              such as an assertion failure message.
+                                              Will be truncated by the node if greater
+                                              than 4096 bytes. The total message length
+                                              across all containers will be limited
+                                              to 12kb. Defaults to /dev/termination-log.
+                                              Cannot be updated.'
                                             type: string
                                           terminationMessagePolicy:
                                             description: Indicate how the termination
                                               message should be populated. File will
                                               use the contents of terminationMessagePath
-                                              to populate the container status message
+                                              to populate the Sidecar status message
                                               on both success and failure. FallbackToLogsOnError
-                                              will use the last chunk of container
-                                              log output if the termination message
-                                              file is empty and the container exited
-                                              with an error. The log output is limited
+                                              will use the last chunk of Sidecar log
+                                              output if the termination message file
+                                              is empty and the Sidecar exited with
+                                              an error. The log output is limited
                                               to 2048 bytes or 80 lines, whichever
                                               is smaller. Defaults to File. Cannot
                                               be updated.
                                             type: string
                                           tty:
-                                            description: Whether this container should
+                                            description: Whether this Sidecar should
                                               allocate a TTY for itself, also requires
                                               'stdin' to be true. Default is false.
                                             type: boolean
                                           volumeDevices:
                                             description: volumeDevices is the list
-                                              of block devices to be used by the container.
+                                              of block devices to be used by the Sidecar.
                                             items:
                                               description: volumeDevice describes
                                                 a mapping of a raw block device within
@@ -31326,9 +39167,8 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           volumeMounts:
-                                            description: Pod volumes to mount into
-                                              the container's filesystem. Cannot be
-                                              updated.
+                                            description: Volumes to mount into the
+                                              Sidecar's filesystem. Cannot be updated.
                                             items:
                                               description: VolumeMount describes a
                                                 mounting of a Volume within a container.
@@ -31379,7 +39219,7 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           workingDir:
-                                            description: Container's working directory.
+                                            description: Sidecar's working directory.
                                               If not specified, the container runtime's
                                               default will be used, which might be
                                               configured in the container image. Cannot
@@ -31437,9 +39277,9 @@ spec:
                                       properties:
                                         args:
                                           description: 'Arguments to the entrypoint.
-                                            The docker image''s CMD is used if this
-                                            is not provided. Variable references $(VAR_NAME)
-                                            are expanded using the container''s environment.
+                                            The image''s CMD is used if this is not
+                                            provided. Variable references $(VAR_NAME)
+                                            are expanded using the Step''s environment.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
                                             unchanged. Double $$ are reduced to a
@@ -31459,7 +39299,7 @@ spec:
                                             within a shell. The docker image''s ENTRYPOINT
                                             is used if this is not provided. Variable
                                             references $(VAR_NAME) are expanded using
-                                            the container''s environment. If a variable
+                                            the Step''s environment. If a variable
                                             cannot be resolved, the reference in the
                                             input string will be unchanged. Double
                                             $$ are reduced to a single $, which allows
@@ -31611,10 +39451,10 @@ spec:
                                           x-kubernetes-list-type: atomic
                                         envFrom:
                                           description: List of sources to populate
-                                            environment variables in the container.
-                                            The keys defined within a source must
-                                            be a C_IDENTIFIER. All invalid keys will
-                                            be reported as an event when the container
+                                            environment variables in the Step. The
+                                            keys defined within a source must be a
+                                            C_IDENTIFIER. All invalid keys will be
+                                            reported as an event when the container
                                             is starting. When a key exists in multiple
                                             sources, the value associated with the
                                             last source will take precedence. Values
@@ -31663,8 +39503,8 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         image:
-                                          description: 'Docker image name. More info:
-                                            https://kubernetes.io/docs/concepts/containers/images
+                                          description: 'Default image name to use
+                                            for each Step. More info: https://kubernetes.io/docs/concepts/containers/images
                                             This field is optional to allow higher
                                             level config management to default or
                                             override container images in workload
@@ -32109,23 +39949,24 @@ spec:
                                           type: object
                                         name:
                                           description: Deprecated. This field will
-                                            be removed in a future release. DeprecatedName
-                                            of the container specified as a DNS_LABEL.
-                                            Each container in a pod must have a unique
-                                            name (DNS_LABEL). Cannot be updated.
+                                            be removed in a future release. Default
+                                            name for each Step specified as a DNS_LABEL.
+                                            Each Step in a Task must have a unique
+                                            name. Cannot be updated.
                                           type: string
                                         ports:
                                           description: Deprecated. This field will
                                             be removed in a future release. List of
-                                            ports to expose from the container. Exposing
-                                            a port here gives the system additional
-                                            information about the network connections
-                                            a container uses, but is primarily informational.
-                                            Not specifying a port here DOES NOT prevent
-                                            that port from being exposed. Any port
-                                            which is listening on the default "0.0.0.0"
-                                            address inside a container will be accessible
-                                            from the network. Cannot be updated.
+                                            ports to expose from the Step's container.
+                                            Exposing a port here gives the system
+                                            additional information about the network
+                                            connections a container uses, but is primarily
+                                            informational. Not specifying a port here
+                                            DOES NOT prevent that port from being
+                                            exposed. Any port which is listening on
+                                            the default "0.0.0.0" address inside a
+                                            container will be accessible from the
+                                            network. Cannot be updated.
                                           items:
                                             description: ContainerPort represents
                                               a network port in a single container.
@@ -32359,8 +40200,8 @@ spec:
                                           type: object
                                         resources:
                                           description: 'Compute Resources required
-                                            by this container. Cannot be updated.
-                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            by this Step. Cannot be updated. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -32391,8 +40232,8 @@ spec:
                                           type: object
                                         securityContext:
                                           description: 'SecurityContext defines the
-                                            security options the container should
-                                            be run with. If set, the fields of SecurityContext
+                                            security options the Step should be run
+                                            with. If set, the fields of SecurityContext
                                             override the equivalent fields of PodSecurityContext.
                                             More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                           properties:
@@ -32807,11 +40648,11 @@ spec:
                                         stdin:
                                           description: Deprecated. This field will
                                             be removed in a future release. Whether
-                                            this container should allocate a buffer
-                                            for stdin in the container runtime. If
-                                            this is not set, reads from stdin in the
-                                            container will always result in EOF. Default
-                                            is false.
+                                            this Step should allocate a buffer for
+                                            stdin in the container runtime. If this
+                                            is not set, reads from stdin in the Step
+                                            will always result in EOF. Default is
+                                            false.
                                           type: boolean
                                         stdinOnce:
                                           description: Deprecated. This field will
@@ -32832,44 +40673,25 @@ spec:
                                             an EOF. Default is false
                                           type: boolean
                                         terminationMessagePath:
-                                          description: 'Deprecated. This field will
-                                            be removed in a future release. Optional:
-                                            Path at which the file to which the container''s
-                                            termination message will be written is
-                                            mounted into the container''s filesystem.
-                                            Message written is intended to be brief
-                                            final status, such as an assertion failure
-                                            message. Will be truncated by the node
-                                            if greater than 4096 bytes. The total
-                                            message length across all containers will
-                                            be limited to 12kb. Defaults to /dev/termination-log.
-                                            Cannot be updated.'
+                                          description: Deprecated. This field will
+                                            be removed in a future release and cannot
+                                            be meaningfully used.
                                           type: string
                                         terminationMessagePolicy:
                                           description: Deprecated. This field will
-                                            be removed in a future release. Indicate
-                                            how the termination message should be
-                                            populated. File will use the contents
-                                            of terminationMessagePath to populate
-                                            the container status message on both success
-                                            and failure. FallbackToLogsOnError will
-                                            use the last chunk of container log output
-                                            if the termination message file is empty
-                                            and the container exited with an error.
-                                            The log output is limited to 2048 bytes
-                                            or 80 lines, whichever is smaller. Defaults
-                                            to File. Cannot be updated.
+                                            be removed in a future release and cannot
+                                            be meaningfully used.
                                           type: string
                                         tty:
                                           description: Deprecated. This field will
                                             be removed in a future release. Whether
-                                            this container should allocate a DeprecatedTTY
+                                            this Step should allocate a DeprecatedTTY
                                             for itself, also requires 'stdin' to be
                                             true. Default is false.
                                           type: boolean
                                         volumeDevices:
                                           description: volumeDevices is the list of
-                                            block devices to be used by the container.
+                                            block devices to be used by the Step.
                                           items:
                                             description: volumeDevice describes a
                                               mapping of a raw block device within
@@ -32892,8 +40714,8 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         volumeMounts:
-                                          description: Pod volumes to mount into the
-                                            container's filesystem. Cannot be updated.
+                                          description: Volumes to mount into the Step's
+                                            filesystem. Cannot be updated.
                                           items:
                                             description: VolumeMount describes a mounting
                                               of a Volume within a container.
@@ -32943,8 +40765,8 @@ spec:
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         workingDir:
-                                          description: Container's working directory.
-                                            If not specified, the container runtime's
+                                          description: Step's working directory. If
+                                            not specified, the container runtime's
                                             default will be used, which might be configured
                                             in the container image. Cannot be updated.
                                           type: string
@@ -32961,9 +40783,9 @@ spec:
                                         properties:
                                           args:
                                             description: 'Arguments to the entrypoint.
-                                              The docker image''s CMD is used if this
-                                              is not provided. Variable references
-                                              $(VAR_NAME) are expanded using the container''s
+                                              The image''s CMD is used if this is
+                                              not provided. Variable references $(VAR_NAME)
+                                              are expanded using the container''s
                                               environment. If a variable cannot be
                                               resolved, the reference in the input
                                               string will be unchanged. Double $$
@@ -32980,10 +40802,10 @@ spec:
                                             x-kubernetes-list-type: atomic
                                           command:
                                             description: 'Entrypoint array. Not executed
-                                              within a shell. The docker image''s
-                                              ENTRYPOINT is used if this is not provided.
-                                              Variable references $(VAR_NAME) are
-                                              expanded using the container''s environment.
+                                              within a shell. The image''s ENTRYPOINT
+                                              is used if this is not provided. Variable
+                                              references $(VAR_NAME) are expanded
+                                              using the container''s environment.
                                               If a variable cannot be resolved, the
                                               reference in the input string will be
                                               unchanged. Double $$ are reduced to
@@ -33194,12 +41016,8 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           image:
-                                            description: 'Docker image name. More
-                                              info: https://kubernetes.io/docs/concepts/containers/images
-                                              This field is optional to allow higher
-                                              level config management to default or
-                                              override container images in workload
-                                              controllers like Deployments and StatefulSets.'
+                                            description: 'Image reference name to
+                                              run for this Step. More info: https://kubernetes.io/docs/concepts/containers/images'
                                             type: string
                                           imagePullPolicy:
                                             description: 'Image pull policy. One of
@@ -33463,9 +41281,9 @@ spec:
                                           livenessProbe:
                                             description: 'Deprecated. This field will
                                               be removed in a future release. Periodic
-                                              probe of container liveness. Container
-                                              will be restarted if the probe fails.
-                                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                              probe of container liveness. Step will
+                                              be restarted if the probe fails. Cannot
+                                              be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                             properties:
                                               exec:
                                                 description: Exec specifies the action
@@ -33651,25 +41469,19 @@ spec:
                                                 type: integer
                                             type: object
                                           name:
-                                            description: Name of the container specified
-                                              as a DNS_LABEL. Each container in a
-                                              pod must have a unique name (DNS_LABEL).
-                                              Cannot be updated.
+                                            description: Name of the Step specified
+                                              as a DNS_LABEL. Each Step in a Task
+                                              must have a unique name.
                                             type: string
                                           onError:
                                             description: OnError defines the exiting
                                               behavior of a container on error can
                                               be set to [ continue | stopAndFail ]
-                                              stopAndFail indicates exit the taskRun
-                                              if the container exits with non-zero
-                                              exit code continue indicates continue
-                                              executing the rest of the steps irrespective
-                                              of the container exit code
                                             type: string
                                           ports:
                                             description: Deprecated. This field will
                                               be removed in a future release. List
-                                              of ports to expose from the container.
+                                              of ports to expose from the Step's container.
                                               Exposing a port here gives the system
                                               additional information about the network
                                               connections a container uses, but is
@@ -33729,9 +41541,9 @@ spec:
                                             description: 'Deprecated. This field will
                                               be removed in a future release. Periodic
                                               probe of container service readiness.
-                                              Container will be removed from service
-                                              endpoints if the probe fails. Cannot
-                                              be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                              Step will be removed from service endpoints
+                                              if the probe fails. Cannot be updated.
+                                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                             properties:
                                               exec:
                                                 description: Exec specifies the action
@@ -33918,8 +41730,8 @@ spec:
                                             type: object
                                           resources:
                                             description: 'Compute Resources required
-                                              by this container. Cannot be updated.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              by this Step. Cannot be updated. More
+                                              info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -33957,7 +41769,7 @@ spec:
                                             type: string
                                           securityContext:
                                             description: 'SecurityContext defines
-                                              the security options the container should
+                                              the security options the Step should
                                               be run with. If set, the fields of SecurityContext
                                               override the equivalent fields of PodSecurityContext.
                                               More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
@@ -34191,18 +42003,18 @@ spec:
                                           startupProbe:
                                             description: 'Deprecated. This field will
                                               be removed in a future release. DeprecatedStartupProbe
-                                              indicates that the Pod has successfully
-                                              initialized. If specified, no other
-                                              probes are executed until this completes
-                                              successfully. If this probe fails, the
-                                              Pod will be restarted, just as if the
-                                              livenessProbe failed. This can be used
-                                              to provide different probe parameters
-                                              at the beginning of a Pod''s lifecycle,
-                                              when it might take a long time to load
-                                              data or warm a cache, than during steady-state
-                                              operation. This cannot be updated. More
-                                              info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                              indicates that the Pod this Step runs
+                                              in has successfully initialized. If
+                                              specified, no other probes are executed
+                                              until this completes successfully. If
+                                              this probe fails, the Pod will be restarted,
+                                              just as if the livenessProbe failed.
+                                              This can be used to provide different
+                                              probe parameters at the beginning of
+                                              a Pod''s lifecycle, when it might take
+                                              a long time to load data or warm a cache,
+                                              than during steady-state operation.
+                                              This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                             properties:
                                               exec:
                                                 description: Exec specifies the action
@@ -34387,6 +42199,15 @@ spec:
                                                 format: int32
                                                 type: integer
                                             type: object
+                                          stderrConfig:
+                                            description: Stores configuration for
+                                              the stderr stream of the step.
+                                            properties:
+                                              path:
+                                                description: Path to duplicate stdout
+                                                  stream to on container's local filesystem.
+                                                type: string
+                                            type: object
                                           stdin:
                                             description: Deprecated. This field will
                                               be removed in a future release. Whether
@@ -34415,36 +42236,24 @@ spec:
                                               reads from stdin will never receive
                                               an EOF. Default is false
                                             type: boolean
+                                          stdoutConfig:
+                                            description: Stores configuration for
+                                              the stdout stream of the step.
+                                            properties:
+                                              path:
+                                                description: Path to duplicate stdout
+                                                  stream to on container's local filesystem.
+                                                type: string
+                                            type: object
                                           terminationMessagePath:
-                                            description: 'Deprecated. This field will
-                                              be removed in a future release. Optional:
-                                              Path at which the file to which the
-                                              container''s termination message will
-                                              be written is mounted into the container''s
-                                              filesystem. Message written is intended
-                                              to be brief final status, such as an
-                                              assertion failure message. Will be truncated
-                                              by the node if greater than 4096 bytes.
-                                              The total message length across all
-                                              containers will be limited to 12kb.
-                                              Defaults to /dev/termination-log. Cannot
-                                              be updated.'
+                                            description: Deprecated. This field will
+                                              be removed in a future release and can't
+                                              be meaningfully used.
                                             type: string
                                           terminationMessagePolicy:
                                             description: Deprecated. This field will
-                                              be removed in a future release. Indicate
-                                              how the termination message should be
-                                              populated. File will use the contents
-                                              of terminationMessagePath to populate
-                                              the container status message on both
-                                              success and failure. FallbackToLogsOnError
-                                              will use the last chunk of container
-                                              log output if the termination message
-                                              file is empty and the container exited
-                                              with an error. The log output is limited
-                                              to 2048 bytes or 80 lines, whichever
-                                              is smaller. Defaults to File. Cannot
-                                              be updated.
+                                              be removed in a future release and can't
+                                              be meaningfully used.
                                             type: string
                                           timeout:
                                             description: 'Timeout is the time after
@@ -34461,7 +42270,7 @@ spec:
                                             type: boolean
                                           volumeDevices:
                                             description: volumeDevices is the list
-                                              of block devices to be used by the container.
+                                              of block devices to be used by the Step.
                                             items:
                                               description: volumeDevice describes
                                                 a mapping of a raw block device within
@@ -34484,9 +42293,8 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           volumeMounts:
-                                            description: Pod volumes to mount into
-                                              the container's filesystem. Cannot be
-                                              updated.
+                                            description: Volumes to mount into the
+                                              Step's filesystem. Cannot be updated.
                                             items:
                                               description: VolumeMount describes a
                                                 mounting of a Volume within a container.
@@ -34537,7 +42345,7 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           workingDir:
-                                            description: Container's working directory.
+                                            description: Step's working directory.
                                               If not specified, the container runtime's
                                               default will be used, which might be
                                               configured in the container image. Cannot
@@ -37740,6 +45548,124 @@ spec:
                               variables, matching the syntax of Docker links. Optional:
                               Defaults to true.'
                             type: boolean
+                          env:
+                            description: List of environment variables that can be
+                              provided to the containers belonging to the pod.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
                           hostAliases:
                             description: HostAliases is an optional list of hosts
                               and IPs that will be injected into the pod's hosts file
@@ -38041,6 +45967,203 @@ spec:
                                     matches to. If the operator is Exists, the value
                                     should be empty, otherwise just a regular string.
                                   type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          topologySpreadConstraints:
+                            description: TopologySpreadConstraints controls how Pods
+                              are spread across your cluster among failure-domains
+                              such as regions, zones, nodes, and other user-defined
+                              topology domains.
+                            items:
+                              description: TopologySpreadConstraint specifies how
+                                to spread matching pods among the given topology.
+                              properties:
+                                labelSelector:
+                                  description: LabelSelector is used to find matching
+                                    pods. Pods that match this label selector are
+                                    counted to determine the number of pods in their
+                                    corresponding topology domain.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                matchLabelKeys:
+                                  description: MatchLabelKeys is a set of pod label
+                                    keys to select the pods over which spreading will
+                                    be calculated. The keys are used to lookup values
+                                    from the incoming pod labels, those key-value
+                                    labels are ANDed with labelSelector to select
+                                    the group of existing pods over which spreading
+                                    will be calculated for the incoming pod. Keys
+                                    that don't exist in the incoming pod labels will
+                                    be ignored. A null or empty list means only match
+                                    against labelSelector.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                maxSkew:
+                                  description: 'MaxSkew describes the degree to which
+                                    pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                    it is the maximum permitted difference between
+                                    the number of matching pods in the target topology
+                                    and the global minimum. The global minimum is
+                                    the minimum number of matching pods in an eligible
+                                    domain or zero if the number of eligible domains
+                                    is less than MinDomains. For example, in a 3-zone
+                                    cluster, MaxSkew is set to 1, and pods with the
+                                    same labelSelector spread as 2/2/1: In this case,
+                                    the global minimum is 1. | zone1 | zone2 | zone3
+                                    | |  P P  |  P P  |   P   | - if MaxSkew is 1,
+                                    incoming pod can only be scheduled to zone3 to
+                                    become 2/2/2; scheduling it onto zone1(zone2)
+                                    would make the ActualSkew(3-1) on zone1(zone2)
+                                    violate MaxSkew(1). - if MaxSkew is 2, incoming
+                                    pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                    it is used to give higher precedence to topologies
+                                    that satisfy it. It''s a required field. Default
+                                    value is 1 and 0 is not allowed.'
+                                  format: int32
+                                  type: integer
+                                minDomains:
+                                  description: "MinDomains indicates a minimum number
+                                    of eligible domains. When the number of eligible
+                                    domains with matching topology keys is less than
+                                    minDomains, Pod Topology Spread treats \"global
+                                    minimum\" as 0, and then the calculation of Skew
+                                    is performed. And when the number of eligible
+                                    domains with matching topology keys equals or
+                                    greater than minDomains, this value has no effect
+                                    on scheduling. As a result, when the number of
+                                    eligible domains is less than minDomains, scheduler
+                                    won't schedule more than maxSkew Pods to those
+                                    domains. If value is nil, the constraint behaves
+                                    as if MinDomains is equal to 1. Valid values are
+                                    integers greater than 0. When value is not nil,
+                                    WhenUnsatisfiable must be DoNotSchedule. \n For
+                                    example, in a 3-zone cluster, MaxSkew is set to
+                                    2, MinDomains is set to 5 and pods with the same
+                                    labelSelector spread as 2/2/2: | zone1 | zone2
+                                    | zone3 | |  P P  |  P P  |  P P  | The number
+                                    of domains is less than 5(MinDomains), so \"global
+                                    minimum\" is treated as 0. In this situation,
+                                    new pod with the same labelSelector cannot be
+                                    scheduled, because computed skew will be 3(3 -
+                                    0) if new Pod is scheduled to any of the three
+                                    zones, it will violate MaxSkew. \n This is a beta
+                                    field and requires the MinDomainsInPodTopologySpread
+                                    feature gate to be enabled (enabled by default)."
+                                  format: int32
+                                  type: integer
+                                nodeAffinityPolicy:
+                                  description: "NodeAffinityPolicy indicates how we
+                                    will treat Pod's nodeAffinity/nodeSelector when
+                                    calculating pod topology spread skew. Options
+                                    are: - Honor: only nodes matching nodeAffinity/nodeSelector
+                                    are included in the calculations. - Ignore: nodeAffinity/nodeSelector
+                                    are ignored. All nodes are included in the calculations.
+                                    \n If this value is nil, the behavior is equivalent
+                                    to the Honor policy. This is a alpha-level feature
+                                    enabled by the NodeInclusionPolicyInPodTopologySpread
+                                    feature flag."
+                                  type: string
+                                nodeTaintsPolicy:
+                                  description: "NodeTaintsPolicy indicates how we
+                                    will treat node taints when calculating pod topology
+                                    spread skew. Options are: - Honor: nodes without
+                                    taints, along with tainted nodes for which the
+                                    incoming pod has a toleration, are included. -
+                                    Ignore: node taints are ignored. All nodes are
+                                    included. \n If this value is nil, the behavior
+                                    is equivalent to the Ignore policy. This is a
+                                    alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread
+                                    feature flag."
+                                  type: string
+                                topologyKey:
+                                  description: TopologyKey is the key of node labels.
+                                    Nodes that have a label with this key and identical
+                                    values are considered to be in the same topology.
+                                    We consider each <key, value> as a "bucket", and
+                                    try to put balanced number of pods into each bucket.
+                                    We define a domain as a particular instance of
+                                    a topology. Also, we define an eligible domain
+                                    as a domain whose nodes meet the requirements
+                                    of nodeAffinityPolicy and nodeTaintsPolicy. e.g.
+                                    If TopologyKey is "kubernetes.io/hostname", each
+                                    Node is a domain of that topology. And, if TopologyKey
+                                    is "topology.kubernetes.io/zone", each zone is
+                                    a domain of that topology. It's a required field.
+                                  type: string
+                                whenUnsatisfiable:
+                                  description: 'WhenUnsatisfiable indicates how to
+                                    deal with a pod if it doesn''t satisfy the spread
+                                    constraint. - DoNotSchedule (default) tells the
+                                    scheduler not to schedule it. - ScheduleAnyway
+                                    tells the scheduler to schedule the pod in any
+                                    location,   but giving higher precedence to topologies
+                                    that would help reduce the   skew. A constraint
+                                    is considered "Unsatisfiable" for an incoming
+                                    pod if and only if every possible node assignment
+                                    for that pod would violate "MaxSkew" on some topology.
+                                    For example, in a 3-zone cluster, MaxSkew is set
+                                    to 1, and pods with the same labelSelector spread
+                                    as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
+                                    If WhenUnsatisfiable is set to DoNotSchedule,
+                                    incoming pod can only be scheduled to zone2(zone3)
+                                    to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3)
+                                    satisfies MaxSkew(1). In other words, the cluster
+                                    can still be imbalanced, but scheduler won''t
+                                    make it *more* imbalanced. It''s a required field.'
+                                  type: string
+                              required:
+                              - maxSkew
+                              - topologyKey
+                              - whenUnsatisfiable
                               type: object
                             type: array
                             x-kubernetes-list-type: atomic
@@ -39833,21 +47956,6 @@ spec:
                         x-kubernetes-list-type: atomic
                       serviceAccountName:
                         type: string
-                      serviceAccountNames:
-                        description: 'Deprecated: use taskRunSpecs.ServiceAccountName
-                          instead'
-                        items:
-                          description: PipelineRunSpecServiceAccountName can be used
-                            to configure specific ServiceAccountName for a concrete
-                            Task
-                          properties:
-                            serviceAccountName:
-                              type: string
-                            taskName:
-                              type: string
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
                       status:
                         description: Used for cancelling a pipelinerun (and maybe
                           more later on)
@@ -39858,6 +47966,33 @@ spec:
                           description: PipelineTaskRunSpec  can be used to configure
                             specific specs for a concrete Task
                           properties:
+                            computeResources:
+                              description: Compute resources to use for this TaskRun
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
                             metadata:
                               description: PipelineTaskMetadata contains the labels
                                 or annotations for an EmbeddedTask
@@ -41104,6 +49239,130 @@ spec:
                                     syntax of Docker links. Optional: Defaults to
                                     true.'
                                   type: boolean
+                                env:
+                                  description: List of environment variables that
+                                    can be provided to the containers belonging to
+                                    the pod.
+                                  items:
+                                    description: EnvVar represents an environment
+                                      variable present in a Container.
+                                    properties:
+                                      name:
+                                        description: Name of the environment variable.
+                                          Must be a C_IDENTIFIER.
+                                        type: string
+                                      value:
+                                        description: 'Variable references $(VAR_NAME)
+                                          are expanded using the previously defined
+                                          environment variables in the container and
+                                          any service environment variables. If a
+                                          variable cannot be resolved, the reference
+                                          in the input string will be unchanged. Double
+                                          $$ are reduced to a single $, which allows
+                                          for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal
+                                          "$(VAR_NAME)". Escaped references will never
+                                          be expanded, regardless of whether the variable
+                                          exists or not. Defaults to "".'
+                                        type: string
+                                      valueFrom:
+                                        description: Source for the environment variable's
+                                          value. Cannot be used if value is not empty.
+                                        properties:
+                                          configMapKeyRef:
+                                            description: Selects a key of a ConfigMap.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                          fieldRef:
+                                            description: 'Selects a field of the pod:
+                                              supports metadata.name, metadata.namespace,
+                                              `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                              spec.nodeName, spec.serviceAccountName,
+                                              status.hostIP, status.podIP, status.podIPs.'
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to
+                                                  select in the specified API version.
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          resourceFieldRef:
+                                            description: 'Selects a resource of the
+                                              container: only resources limits and
+                                              requests (limits.cpu, limits.memory,
+                                              limits.ephemeral-storage, requests.cpu,
+                                              requests.memory and requests.ephemeral-storage)
+                                              are currently supported.'
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to
+                                                  select'
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                          secretKeyRef:
+                                            description: Selects a key of a secret
+                                              in the pod's namespace
+                                            properties:
+                                              key:
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
+                                                type: string
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion,
+                                                  kind, uid?'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 hostAliases:
                                   description: HostAliases is an optional list of
                                     hosts and IPs that will be injected into the pod's
@@ -41426,6 +49685,222 @@ spec:
                                           Exists, the value should be empty, otherwise
                                           just a regular string.
                                         type: string
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologySpreadConstraints:
+                                  description: TopologySpreadConstraints controls
+                                    how Pods are spread across your cluster among
+                                    failure-domains such as regions, zones, nodes,
+                                    and other user-defined topology domains.
+                                  items:
+                                    description: TopologySpreadConstraint specifies
+                                      how to spread matching pods among the given
+                                      topology.
+                                    properties:
+                                      labelSelector:
+                                        description: LabelSelector is used to find
+                                          matching pods. Pods that match this label
+                                          selector are counted to determine the number
+                                          of pods in their corresponding topology
+                                          domain.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      matchLabelKeys:
+                                        description: MatchLabelKeys is a set of pod
+                                          label keys to select the pods over which
+                                          spreading will be calculated. The keys are
+                                          used to lookup values from the incoming
+                                          pod labels, those key-value labels are ANDed
+                                          with labelSelector to select the group of
+                                          existing pods over which spreading will
+                                          be calculated for the incoming pod. Keys
+                                          that don't exist in the incoming pod labels
+                                          will be ignored. A null or empty list means
+                                          only match against labelSelector.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      maxSkew:
+                                        description: 'MaxSkew describes the degree
+                                          to which pods may be unevenly distributed.
+                                          When `whenUnsatisfiable=DoNotSchedule`,
+                                          it is the maximum permitted difference between
+                                          the number of matching pods in the target
+                                          topology and the global minimum. The global
+                                          minimum is the minimum number of matching
+                                          pods in an eligible domain or zero if the
+                                          number of eligible domains is less than
+                                          MinDomains. For example, in a 3-zone cluster,
+                                          MaxSkew is set to 1, and pods with the same
+                                          labelSelector spread as 2/2/1: In this case,
+                                          the global minimum is 1. | zone1 | zone2
+                                          | zone3 | |  P P  |  P P  |   P   | - if
+                                          MaxSkew is 1, incoming pod can only be scheduled
+                                          to zone3 to become 2/2/2; scheduling it
+                                          onto zone1(zone2) would make the ActualSkew(3-1)
+                                          on zone1(zone2) violate MaxSkew(1). - if
+                                          MaxSkew is 2, incoming pod can be scheduled
+                                          onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                          it is used to give higher precedence to
+                                          topologies that satisfy it. It''s a required
+                                          field. Default value is 1 and 0 is not allowed.'
+                                        format: int32
+                                        type: integer
+                                      minDomains:
+                                        description: "MinDomains indicates a minimum
+                                          number of eligible domains. When the number
+                                          of eligible domains with matching topology
+                                          keys is less than minDomains, Pod Topology
+                                          Spread treats \"global minimum\" as 0, and
+                                          then the calculation of Skew is performed.
+                                          And when the number of eligible domains
+                                          with matching topology keys equals or greater
+                                          than minDomains, this value has no effect
+                                          on scheduling. As a result, when the number
+                                          of eligible domains is less than minDomains,
+                                          scheduler won't schedule more than maxSkew
+                                          Pods to those domains. If value is nil,
+                                          the constraint behaves as if MinDomains
+                                          is equal to 1. Valid values are integers
+                                          greater than 0. When value is not nil, WhenUnsatisfiable
+                                          must be DoNotSchedule. \n For example, in
+                                          a 3-zone cluster, MaxSkew is set to 2, MinDomains
+                                          is set to 5 and pods with the same labelSelector
+                                          spread as 2/2/2: | zone1 | zone2 | zone3
+                                          | |  P P  |  P P  |  P P  | The number of
+                                          domains is less than 5(MinDomains), so \"global
+                                          minimum\" is treated as 0. In this situation,
+                                          new pod with the same labelSelector cannot
+                                          be scheduled, because computed skew will
+                                          be 3(3 - 0) if new Pod is scheduled to any
+                                          of the three zones, it will violate MaxSkew.
+                                          \n This is a beta field and requires the
+                                          MinDomainsInPodTopologySpread feature gate
+                                          to be enabled (enabled by default)."
+                                        format: int32
+                                        type: integer
+                                      nodeAffinityPolicy:
+                                        description: "NodeAffinityPolicy indicates
+                                          how we will treat Pod's nodeAffinity/nodeSelector
+                                          when calculating pod topology spread skew.
+                                          Options are: - Honor: only nodes matching
+                                          nodeAffinity/nodeSelector are included in
+                                          the calculations. - Ignore: nodeAffinity/nodeSelector
+                                          are ignored. All nodes are included in the
+                                          calculations. \n If this value is nil, the
+                                          behavior is equivalent to the Honor policy.
+                                          This is a alpha-level feature enabled by
+                                          the NodeInclusionPolicyInPodTopologySpread
+                                          feature flag."
+                                        type: string
+                                      nodeTaintsPolicy:
+                                        description: "NodeTaintsPolicy indicates how
+                                          we will treat node taints when calculating
+                                          pod topology spread skew. Options are: -
+                                          Honor: nodes without taints, along with
+                                          tainted nodes for which the incoming pod
+                                          has a toleration, are included. - Ignore:
+                                          node taints are ignored. All nodes are included.
+                                          \n If this value is nil, the behavior is
+                                          equivalent to the Ignore policy. This is
+                                          a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread
+                                          feature flag."
+                                        type: string
+                                      topologyKey:
+                                        description: TopologyKey is the key of node
+                                          labels. Nodes that have a label with this
+                                          key and identical values are considered
+                                          to be in the same topology. We consider
+                                          each <key, value> as a "bucket", and try
+                                          to put balanced number of pods into each
+                                          bucket. We define a domain as a particular
+                                          instance of a topology. Also, we define
+                                          an eligible domain as a domain whose nodes
+                                          meet the requirements of nodeAffinityPolicy
+                                          and nodeTaintsPolicy. e.g. If TopologyKey
+                                          is "kubernetes.io/hostname", each Node is
+                                          a domain of that topology. And, if TopologyKey
+                                          is "topology.kubernetes.io/zone", each zone
+                                          is a domain of that topology. It's a required
+                                          field.
+                                        type: string
+                                      whenUnsatisfiable:
+                                        description: 'WhenUnsatisfiable indicates
+                                          how to deal with a pod if it doesn''t satisfy
+                                          the spread constraint. - DoNotSchedule (default)
+                                          tells the scheduler not to schedule it.
+                                          - ScheduleAnyway tells the scheduler to
+                                          schedule the pod in any location,   but
+                                          giving higher precedence to topologies that
+                                          would help reduce the   skew. A constraint
+                                          is considered "Unsatisfiable" for an incoming
+                                          pod if and only if every possible node assignment
+                                          for that pod would violate "MaxSkew" on
+                                          some topology. For example, in a 3-zone
+                                          cluster, MaxSkew is set to 1, and pods with
+                                          the same labelSelector spread as 3/1/1:
+                                          | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
+                                          If WhenUnsatisfiable is set to DoNotSchedule,
+                                          incoming pod can only be scheduled to zone2(zone3)
+                                          to become 3/2/1(3/1/2) as ActualSkew(2-1)
+                                          on zone2(zone3) satisfies MaxSkew(1). In
+                                          other words, the cluster can still be imbalanced,
+                                          but scheduler won''t make it *more* imbalanced.
+                                          It''s a required field.'
+                                        type: string
+                                    required:
+                                    - maxSkew
+                                    - topologyKey
+                                    - whenUnsatisfiable
                                     type: object
                                   type: array
                                   x-kubernetes-list-type: atomic
@@ -43402,6 +51877,54 @@ spec:
                                     or its keys must be defined
                                   type: boolean
                               type: object
+                            csi:
+                              description: CSI (Container Storage Interface) represents
+                                ephemeral storage that is handled by certain external
+                                CSI drivers.
+                              properties:
+                                driver:
+                                  description: driver is the name of the CSI driver
+                                    that handles this volume. Consult with your admin
+                                    for the correct name as registered in the cluster.
+                                  type: string
+                                fsType:
+                                  description: fsType to mount. Ex. "ext4", "xfs",
+                                    "ntfs". If not provided, the empty value is passed
+                                    to the associated CSI driver which will determine
+                                    the default filesystem to apply.
+                                  type: string
+                                nodePublishSecretRef:
+                                  description: nodePublishSecretRef is a reference
+                                    to the secret object containing sensitive information
+                                    to pass to the CSI driver to complete the CSI
+                                    NodePublishVolume and NodeUnpublishVolume calls.
+                                    This field is optional, and  may be empty if no
+                                    secret is required. If the secret object contains
+                                    more than one secret, all secret references are
+                                    passed.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                readOnly:
+                                  description: readOnly specifies a read-only configuration
+                                    for the volume. Defaults to false (read/write).
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  description: volumeAttributes stores driver-specific
+                                    properties that are passed to the CSI driver.
+                                    Consult your driver's documentation for supported
+                                    values.
+                                  type: object
+                              required:
+                              - driver
+                              type: object
                             emptyDir:
                               description: 'EmptyDir represents a temporary directory
                                 that shares a Task''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
@@ -43449,6 +51972,290 @@ spec:
                                   type: boolean
                               required:
                               - claimName
+                              type: object
+                            projected:
+                              description: Projected represents a projected volume
+                                that should populate this workspace.
+                              properties:
+                                defaultMode:
+                                  description: defaultMode are the mode bits used
+                                    to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Directories within the path
+                                    are not affected by this setting. This might be
+                                    in conflict with other options that affect the
+                                    file mode, like fsGroup, and the result can be
+                                    other mode bits set.
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  description: sources is the list of volume projections
+                                  items:
+                                    description: Projection that may be projected
+                                      along with other supported volume types
+                                    properties:
+                                      configMap:
+                                        description: configMap information about the
+                                          configMap data to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced ConfigMap will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the ConfigMap, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                      downwardAPI:
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
+                                        properties:
+                                          items:
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
+                                            items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
+                                              properties:
+                                                fieldRef:
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name and namespace are
+                                                    supported.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                mode:
+                                                  description: 'Optional: mode bits
+                                                    used to set permissions on this
+                                                    file, must be an octal value between
+                                                    0000 and 0777 or a decimal value
+                                                    between 0 and 511. YAML accepts
+                                                    both octal and decimal values,
+                                                    JSON requires decimal values for
+                                                    mode bits. If not specified, the
+                                                    volume defaultMode will be used.
+                                                    This might be in conflict with
+                                                    other options that affect the
+                                                    file mode, like fsGroup, and the
+                                                    result can be other mode bits
+                                                    set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path. Must
+                                                    be utf-8 encoded. The first item
+                                                    of the relative path must not
+                                                    start with ''..'''
+                                                  type: string
+                                                resourceFieldRef:
+                                                  description: 'Selects a resource
+                                                    of the container: only resources
+                                                    limits and requests (limits.cpu,
+                                                    limits.memory, requests.cpu and
+                                                    requests.memory) are currently
+                                                    supported.'
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                              required:
+                                              - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        description: secret information about the
+                                          secret data to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced Secret will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the Secret, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
+                                            type: boolean
+                                        type: object
+                                      serviceAccountToken:
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
+                                        properties:
+                                          audience:
+                                            description: audience is the intended
+                                              audience of the token. A recipient of
+                                              a token must identify itself with an
+                                              identifier specified in the audience
+                                              of the token, and otherwise should reject
+                                              the token. The audience defaults to
+                                              the identifier of the apiserver.
+                                            type: string
+                                          expirationSeconds:
+                                            description: expirationSeconds is the
+                                              requested duration of validity of the
+                                              service account token. As the token
+                                              approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service
+                                              account token. The kubelet will start
+                                              trying to rotate the token if the token
+                                              is older than 80 percent of its time
+                                              to live or if the token is older than
+                                              24 hours.Defaults to 1 hour and must
+                                              be at least 10 minutes.
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            description: path is the path relative
+                                              to the mount point of the file to project
+                                              the token into.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                    type: object
+                                  type: array
                               type: object
                             secret:
                               description: Secret represents a secret that should

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
         - name: sinker
-          image: gcr.io/k8s-prow/sinker:v20230630-9eecc0f38f
+          image: gcr.io/k8s-prow/sinker:v20230801-2352e79673
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20230630-9eecc0f38f
+          image: gcr.io/k8s-prow/status-reconciler:v20230801-2352e79673
           args:
             - --dry-run=false
             - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: gcr.io/k8s-prow/tide:v20230630-9eecc0f38f
+          image: gcr.io/k8s-prow/tide:v20230801-2352e79673
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -79,10 +79,10 @@ plank:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20230630-9eecc0f38f
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20230630-9eecc0f38f
-        initupload: gcr.io/k8s-prow/initupload:v20230630-9eecc0f38f
-        sidecar: gcr.io/k8s-prow/sidecar:v20230630-9eecc0f38f
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20230801-2352e79673
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20230801-2352e79673
+        initupload: gcr.io/k8s-prow/initupload:v20230801-2352e79673
+        sidecar: gcr.io/k8s-prow/sidecar:v20230801-2352e79673
       ssh_key_secrets:
         - bot-ssh-secret
 


### PR DESCRIPTION
The prow infra on the IKS cluster was updated to this version a few days back.

The tag changes were not submitted as I wanted to look into an error message in controller pod Ref: https://ibm-systems.slack.com/archives/G01CH7AC8H1/p1691135647644769?thread_ts=1691127051.299169&cid=G01CH7AC8H1

But this error is not seen now! There are no errors in other components.