### PR TITLE
To prevent CI jobs from failing due to latest all-in-one:0.6

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
@@ -13,7 +13,7 @@ postsubmits:
           workdir: true
       spec:
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.5
             resources:
             requests:
               cpu: "5000m"

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -13,7 +13,7 @@ postsubmits:
           workdir: true
       spec:
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.5
             resources:
               requests:
                 cpu: "3000m"


### PR DESCRIPTION
`postsubmit-master-golang-kubernetes-conformance-test-ppc64le` started failing with error to fetch `kubelet` version
`postsubmit-master-golang-etcd-build-test-ppc64le` started failing with below error:
```
Test:           TestConnectionMultiplexing/SeparateHTTP/ServerTLS/ClientTLS/curl/default
                    cmux_test.go:132:
                                Error Trace:    /root/etcd/tests/e2e/cmux_test.go:132
                                Error:          Received unexpected error:
                                                failed to close command [curl --cacert /root/fixtures/ca.crt --cert /root/fixtures/server3.crt --key /root/fixtures/server3.key.insecure -L https://localhost:20004/debug/vars -m 5] with error: unexpected exit code [7] after running [/usr/bin/curl --cacert /root/fixtures/ca.crt --cert /root/fixtures/server3.crt --key /root/fixtures/server3.key.insecure -L https://localhost:20004/debug/vars -m 5]
```