### PR TITLE
8 vCPU limit

### DIFF
--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-build-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-build-docker.yaml
@@ -24,6 +24,11 @@ postsubmits:
           effect: "NoSchedule"
         containers:
         - image: quay.io/powercloud/docker-ce-build
+          resources:
+            requests:
+              cpu: "8000m"
+            limits:
+              cpu: "8000m"
           command:
           - /bin/bash
           args:
@@ -86,6 +91,11 @@ postsubmits:
           effect: "NoSchedule"
         containers:
         - image: quay.io/powercloud/docker-ce-build
+          resources:
+            requests:
+              cpu: "8000m"
+            limits:
+              cpu: "8000m"
           command:
           - /bin/bash
           args:

--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
@@ -26,6 +26,11 @@ postsubmits:
           effect: "NoSchedule"
         containers:
         - image: quay.io/powercloud/docker-ce-build
+          resources:
+            requests:
+              cpu: "8000m"
+            limits:
+              cpu: "8000m"
           command:
           - /bin/bash
           args:
@@ -80,6 +85,11 @@ postsubmits:
           effect: "NoSchedule"
         containers:
         - image: quay.io/powercloud/docker-ce-build
+          resources:
+            requests:
+              cpu: "8000m"
+            limits:
+              cpu: "8000m"
           command:
           - /bin/bash
           args:


### PR DESCRIPTION
Capping vCPUs used by postsubmit jobs to allow strict resource planning.