### PR TITLE
Update all-in-one image to 0.6 for etcd job

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
@@ -13,7 +13,7 @@ postsubmits:
           workdir: true
       spec:
         containers:
-          - image: quay.io/powercloud/all-in-one:0.5
+          - image: quay.io/powercloud/all-in-one:0.6
             resources:
             requests:
               cpu: "5000m"


### PR DESCRIPTION
The Job `postsubmit-master-golang-etcd-build-test-ppc64le` earlier would fail `TestConnectionMultiplexing` related tests for `http` version 1.0 in test case. Ref: https://ibm-systems-power.slack.com/archives/C01DPA12NHJ/p1692156783447299

After the change https://github.com/etcd-io/etcd/pull/16516, this version of `http` is removed from test and hence no failure.
Test job that passed with `all-in-one:0.6` - https://prow.ppc64le-cloud.cis.ibm.net/view/s3/ppc64le-prow-logs/logs/test-postsubmit-master-golang-etcd-build-test-ppc64le/1698731224345874432