### PR TITLE
Move postsubmit-master-golang-kubernetes-unit-test-ppc64le job logs to GCS from IBM S3

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -65,6 +65,11 @@ postsubmits:
     - name: postsubmit-master-golang-kubernetes-unit-test-ppc64le
       cluster: k8s-ppc64le-cluster
       decorate: true
+      decoration_config:
+        gcs_configuration:
+          bucket: ppc64le-kubernetes
+          path_strategy: explicit
+        gcs_credentials_secret: gcs-credentials
       branches:
         - master
       run_if_changed: '^golang/master/'


### PR DESCRIPTION
The change is to have prow job logs of `postsubmit-master-golang-kubernetes-unit-test-ppc64le` in GCS bucket than the current IBM S3.