### PR TITLE
Add postsubmit job to periodic-gcs-logs-cleanup config

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-gcs-logs-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-gcs-logs-periodics.yaml
@@ -30,5 +30,7 @@ periodics:
                 daysLimit: 7
               - dir: logs/periodic-kubernetes-containerd-conformance-test-ppc64le
                 daysLimit: 7
+              - dir: logs/postsubmit-master-golang-kubernetes-unit-test-ppc64le
+                daysLimit: 30
               EOL
               $(go env GOPATH)/bin/gcs-cleaner


### PR DESCRIPTION
Adding `postsubmit-master-golang-kubernetes-unit-test-ppc64le` job to the config of  `periodic-gcs-logs-cleanup`.

Have mentioned the 30-day duration for this content cleanup, as sometimes flaky test failures need comparisons as old as a month.