### PR TITLE
cleanup - remove raksh repository

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -89,18 +89,6 @@ plank:
 tide:
   sync_period: 2m
   queries:
-    - repos:
-        - IBM/raksh
-      labels:
-        - lgtm
-        - approved
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/blocked-paths
-        - do-not-merge/hold
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-        - needs-rebase
     - orgs:
         - ppc64le-cloud
         - ocp-power-automation

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -1,9 +1,6 @@
 ---
 triggers:
   - repos:
-      - IBM/raksh
-    join_org_url: https://github.com/IBM/raksh/blob/master/CONTRIBUTING.md
-  - repos:
       - ppc64le-cloud
     join_org_url: https://github.com/ppc64le-cloud/test-infra/blob/master/README.md
     only_org_members: true
@@ -23,9 +20,6 @@ triggers:
     join_org_url: https://github.com/Rajalakshmi-Girish/etcd/blob/main/README.md#contributing
 
 approve:
-  - repos:
-      - IBM/raksh
-    require_self_approval: false
   - repos:
       - ppc64le-cloud/test-infra
       - ppc64le-cloud/kubetest2-plugins
@@ -58,18 +52,7 @@ config_updater:
       name: job-config
       gzip: true
 
-welcome:
-  - repos:
-      - IBM/raksh
-    message_template: "Welcome @{{.AuthorLogin}}! <br><br>It looks like this is your first PR to <a href='https://github.com/{{.Org}}/{{.Repo}}'>{{.Org}}/{{.Repo}}</a> 🎉. Please refer to our [pull request process documentation](https://github.com/IBM/raksh/blob/master/CONTRIBUTING.md#pull-requests) to help your PR have a smooth ride to approval. <br><br>You will be prompted by a bot to use commands during the review process. Do not be afraid to follow the prompts! It is okay to experiment. [Here is the bot commands documentation](https://go.k8s.io/bot-commands). <br><br>You can also check if {{.Org}}/{{.Repo}} has [its own contribution guidelines](https://github.com/{{.Org}}/{{.Repo}}/tree/master/CONTRIBUTING.md). <br><br>Thank you, and welcome to Project Raksh. :smiley:"
-
 require_matching_label:
-  - missing_label: needs-kind
-    org: IBM
-    repo: raksh
-    issues: true
-    prs: true
-    regexp: ^kind/
   - missing_label: needs-kind
     org: ppc64le-cloud
     repo: test-infra
@@ -93,35 +76,6 @@ retitle:
   allow_closed_issues: true
 
 plugins:
-  IBM/raksh:
-    plugins:
-      - approve
-      - assign
-      - blunderbuss
-      - cat
-      - dog
-      - golint
-      - goose
-      - heart
-      - help
-      - hold
-      - invalidcommitmsg
-      - label
-      - lgtm
-      - lifecycle
-      - mergecommitblocker
-      - owners-label
-      - pony
-      - retitle
-      - shrug
-      - size
-      - skip
-      - trigger
-      - verify-owners
-      - welcome
-      - wip
-      - yuks
-
   ppc64le-cloud:
     plugins:
       - approve


### PR DESCRIPTION
https://github.com/ibm/raksh is been archived and no activities happening in the repository, hence removing all the references.