### PR TITLE
Upgrade prow infra to v20231004-f64f17f7bb

### DIFF
--- a/config/prow/cluster/cherrypick_deployment.yaml
+++ b/config/prow/cluster/cherrypick_deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: cherrypick
-        image: gcr.io/k8s-prow/cherrypicker:v20230901-e9e5d470a5
+        image: gcr.io/k8s-prow/cherrypicker:v20231004-f64f17f7bb
         args:
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: gcr.io/k8s-prow/crier:v20230901-e9e5d470a5
+          image: gcr.io/k8s-prow/crier:v20231004-f64f17f7bb
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/crier_github_app_deployment.yaml
+++ b/config/prow/cluster/crier_github_app_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier2
-          image: gcr.io/k8s-prow/crier:v20230901-e9e5d470a5
+          image: gcr.io/k8s-prow/crier:v20231004-f64f17f7bb
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: gcr.io/k8s-prow/deck:v20230901-e9e5d470a5
+          image: gcr.io/k8s-prow/deck:v20231004-f64f17f7bb
           args:
             - --config-path=/etc/config/config.yaml
             - --plugin-config=/etc/plugins/plugins.yaml

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20230901-e9e5d470a5
+          image: gcr.io/k8s-prow/ghproxy:v20231004-f64f17f7bb
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: gcr.io/k8s-prow/hook:v20230901-e9e5d470a5
+          image: gcr.io/k8s-prow/hook:v20231004-f64f17f7bb
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/hook_github_app_deployment.yaml
+++ b/config/prow/cluster/hook_github_app_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook2
-          image: gcr.io/k8s-prow/hook:v20230901-e9e5d470a5
+          image: gcr.io/k8s-prow/hook:v20231004-f64f17f7bb
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: horologium
-          image: gcr.io/k8s-prow/horologium:v20230901-e9e5d470a5
+          image: gcr.io/k8s-prow/horologium:v20231004-f64f17f7bb
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/label_sync_cron_job.yaml
+++ b/config/prow/cluster/label_sync_cron_job.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20230901-e9e5d470a5
+              image: gcr.io/k8s-prow/label_sync:v20231004-f64f17f7bb
               args:
                 - --config=/etc/config/labels.yaml
                 - --confirm=true

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - --github-endpoint=https://api.github.com
             - --enable-controller=plank
             - --job-config-path=/etc/job-config
-          image: gcr.io/k8s-prow/prow-controller-manager:v20230901-e9e5d470a5
+          image: gcr.io/k8s-prow/prow-controller-manager:v20231004-f64f17f7bb
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
         - name: sinker
-          image: gcr.io/k8s-prow/sinker:v20230901-e9e5d470a5
+          image: gcr.io/k8s-prow/sinker:v20231004-f64f17f7bb
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20230901-e9e5d470a5
+          image: gcr.io/k8s-prow/status-reconciler:v20231004-f64f17f7bb
           args:
             - --dry-run=false
             - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: gcr.io/k8s-prow/tide:v20230901-e9e5d470a5
+          image: gcr.io/k8s-prow/tide:v20231004-f64f17f7bb
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -79,10 +79,10 @@ plank:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20230901-e9e5d470a5
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20230901-e9e5d470a5
-        initupload: gcr.io/k8s-prow/initupload:v20230901-e9e5d470a5
-        sidecar: gcr.io/k8s-prow/sidecar:v20230901-e9e5d470a5
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20231004-f64f17f7bb
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20231004-f64f17f7bb
+        initupload: gcr.io/k8s-prow/initupload:v20231004-f64f17f7bb
+        sidecar: gcr.io/k8s-prow/sidecar:v20231004-f64f17f7bb
       ssh_key_secrets:
         - bot-ssh-secret
 


### PR DESCRIPTION
There were no changes found other than the image tag change.

Have applied these on infra and found it working fine.

Sample ob that ran after upgrade: https://prow.ppc64le-cloud.cis.ibm.net/view/s3/ppc64le-prow-logs/logs/periodic-golang-master-build-ppc64le/1710155437690589184

![image](https://github.com/ppc64le-cloud/test-infra/assets/63038004/ca4b6f0e-2dd9-43a1-aa40-bb6bc4cf9b63)
