### PR TITLE
Use image SHA along with name as a good practice

### DIFF
--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-build-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-build-docker.yaml
@@ -16,7 +16,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build
+        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
           resources:
             requests:
               cpu: "8000m"
@@ -76,7 +76,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build
+        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
           resources:
             requests:
               cpu: "8000m"

--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
@@ -18,7 +18,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build
+        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
           resources:
             requests:
               cpu: "8000m"
@@ -70,7 +70,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build
+        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
           resources:
             requests:
               cpu: "8000m"


### PR DESCRIPTION
For the Docker postsubmit jobs, we currently only specify the image name, which defaults to the image tagged "latest". Specifying the hash is a safer practice. The hash specified corresponds to the newly built and locally tested 0.7-ppc64le image available here: https://quay.io/repository/powercloud/docker-ce-build