### PR TITLE
Replace wget with cURL

### DIFF
--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
@@ -40,7 +40,7 @@ postsubmits:
             FILE_URL="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/prow-job-tracking/job/${TIMESTAMP_FILE}"
 
             echo "* Retrieve the timestamp file from the tracking branch: ${FILE_URL} *"
-            wget -O env/date.list ${FILE_URL}
+            curl -o env/date.list ${FILE_URL}
             cat env/date.list
 
             echo "* Start prow-test-docker.sh *"
@@ -92,7 +92,7 @@ postsubmits:
             FILE_URL="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/prow-job-tracking/job/${TIMESTAMP_FILE}"
 
             echo "* Retrieve the timestamp file from the tracking branch: ${FILE_URL} *"
-            wget -O env/date.list ${FILE_URL}
+            curl -o env/date.list ${FILE_URL}
             cat env/date.list
 
             echo "* Start prow-test-docker.sh *"


### PR DESCRIPTION
We have replaced all instances of wget with cURL in [0.7-ppc64le](https://quay.io/repository/powercloud/docker-ce-build/manifest/sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db)
to resolve an old CVE with wget. Doing so also enables us to track and fix vulnerabilities with cURL alone rather than both.