### PR TITLE
Skip failing UT in postsubmit-master-golang-kubernetes-unit-test-ppc64le

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -122,7 +122,8 @@ postsubmits:
                 popd
 
                 export FORCE_HOST_GO=y
-                make test
+                # Skipping UT TestVerify in typecheck package due to https://github.com/kubernetes/kubernetes/issues/120142
+                make test GOFLAGS=-skip="TestVerify$"
                 # Check golang used for binary building
                 go_version_bin=`go version _output/local/go/bin/ncpu | cut -d ' ' -f3`
                 [[ "$go_version_env" == "$go_version_bin" ]] || { echo "The binary was not built with master go version"; exit 1; }


### PR DESCRIPTION
Have passed the failing test pattern `TestVerify` as GOFLAG to the make command in the job.

Reference test job that Passed by skipping the failing test:
https://prow.ppc64le-cloud.cis.ibm.net/view/gs/ppc64le-kubernetes/logs/test-postsubmit-master-golang-kubernetes-unit-test-ppc64le/1717062420242894848