### PR TITLE
Upgrade prow infra to v20231101-86c2fe4d89

### DIFF
--- a/config/prow/cluster/cherrypick_deployment.yaml
+++ b/config/prow/cluster/cherrypick_deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: cherrypick
-        image: gcr.io/k8s-prow/cherrypicker:v20231004-f64f17f7bb
+        image: gcr.io/k8s-prow/cherrypicker:v20231101-86c2fe4d89
         args:
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: gcr.io/k8s-prow/crier:v20231004-f64f17f7bb
+          image: gcr.io/k8s-prow/crier:v20231101-86c2fe4d89
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/crier_github_app_deployment.yaml
+++ b/config/prow/cluster/crier_github_app_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier2
-          image: gcr.io/k8s-prow/crier:v20231004-f64f17f7bb
+          image: gcr.io/k8s-prow/crier:v20231101-86c2fe4d89
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: gcr.io/k8s-prow/deck:v20231004-f64f17f7bb
+          image: gcr.io/k8s-prow/deck:v20231101-86c2fe4d89
           args:
             - --config-path=/etc/config/config.yaml
             - --plugin-config=/etc/plugins/plugins.yaml

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20231004-f64f17f7bb
+          image: gcr.io/k8s-prow/ghproxy:v20231101-86c2fe4d89
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: gcr.io/k8s-prow/hook:v20231004-f64f17f7bb
+          image: gcr.io/k8s-prow/hook:v20231101-86c2fe4d89
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/hook_github_app_deployment.yaml
+++ b/config/prow/cluster/hook_github_app_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook2
-          image: gcr.io/k8s-prow/hook:v20231004-f64f17f7bb
+          image: gcr.io/k8s-prow/hook:v20231101-86c2fe4d89
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: horologium
-          image: gcr.io/k8s-prow/horologium:v20231004-f64f17f7bb
+          image: gcr.io/k8s-prow/horologium:v20231101-86c2fe4d89
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/label_sync_cron_job.yaml
+++ b/config/prow/cluster/label_sync_cron_job.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: label-sync
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20231004-f64f17f7bb
+              image: gcr.io/k8s-prow/label_sync:v20231101-86c2fe4d89
               args:
                 - --config=/etc/config/labels.yaml
                 - --confirm=true

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - --github-endpoint=https://api.github.com
             - --enable-controller=plank
             - --job-config-path=/etc/job-config
-          image: gcr.io/k8s-prow/prow-controller-manager:v20231004-f64f17f7bb
+          image: gcr.io/k8s-prow/prow-controller-manager:v20231101-86c2fe4d89
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
         - name: sinker
-          image: gcr.io/k8s-prow/sinker:v20231004-f64f17f7bb
+          image: gcr.io/k8s-prow/sinker:v20231101-86c2fe4d89
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20231004-f64f17f7bb
+          image: gcr.io/k8s-prow/status-reconciler:v20231101-86c2fe4d89
           args:
             - --dry-run=false
             - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: gcr.io/k8s-prow/tide:v20231004-f64f17f7bb
+          image: gcr.io/k8s-prow/tide:v20231101-86c2fe4d89
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -79,10 +79,10 @@ plank:
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20231004-f64f17f7bb
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20231004-f64f17f7bb
-        initupload: gcr.io/k8s-prow/initupload:v20231004-f64f17f7bb
-        sidecar: gcr.io/k8s-prow/sidecar:v20231004-f64f17f7bb
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20231101-86c2fe4d89
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20231101-86c2fe4d89
+        initupload: gcr.io/k8s-prow/initupload:v20231101-86c2fe4d89
+        sidecar: gcr.io/k8s-prow/sidecar:v20231101-86c2fe4d89
       ssh_key_secrets:
         - bot-ssh-secret
 


### PR DESCRIPTION
Change the image tag and apiVersion of `CronJob` batch resource in label_sync cronjob from v1beta to v1.
Applied these changes on IKS cluster. No errors or failures were observed in the logs.
Successful job after upgrade: https://prow.ppc64le-cloud.cis.ibm.net/view/s3/ppc64le-prow-logs/logs/periodic-golang-master-build-ppc64le/1719970225685794816