### PR TITLE
Add manifest for build-img token secret

### DIFF
--- a/config/prow/buildfarms/build-img_rbac.yaml
+++ b/config/prow/buildfarms/build-img_rbac.yaml
@@ -80,3 +80,12 @@ subjects:
   - kind: ServiceAccount
     name: "build-img"
     namespace: test-pods
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: build-img-secret
+  namespace: test-pods
+  annotations:
+    kubernetes.io/service-account.name: build-img
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-long-lived-api-token-for-a-serviceaccount
Moving to `token` and `ca.crt` fetching from ServiceAccount Token secret rather than,
the earlier mechanism of capturing from pod using ServiceAccount has been 