### PR TITLE
Add kubeflow kubeconfig and patch config

### DIFF
--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -38,7 +38,7 @@ spec:
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG
-              value: "/etc/kubeconfig/config"
+              value: "/etc/kubeconfig/config:/etc/kubeflow-kubeconfig/config"
           volumeMounts:
             - name: config
               mountPath: /etc/config
@@ -51,6 +51,9 @@ spec:
               readOnly: true
             - name: kubeconfig
               mountPath: /etc/kubeconfig
+              readOnly: true
+            - name: kubeflow-kubeconfig
+              mountPath: /etc/kubeflow-kubeconfig
               readOnly: true
             - name: s3-credentials
               mountPath: /etc/s3-credentials
@@ -75,6 +78,10 @@ spec:
           secret:
             defaultMode: 0644
             secretName: kubeconfig
+        - name: kubeflow-kubeconfig
+          secret:
+            defaultMode: 0644
+            secretName: kubeflow-kubeconfig
         - name: s3-credentials
           secret:
             secretName: s3-credentials

--- a/config/prow/cluster/crier_github_app_deployment.yaml
+++ b/config/prow/cluster/crier_github_app_deployment.yaml
@@ -37,7 +37,7 @@ spec:
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG
-              value: "/etc/kubeconfig/config"
+              value: "/etc/kubeconfig/config:/etc/kubeflow-kubeconfig/config"
           volumeMounts:
             - name: config
               mountPath: /etc/config
@@ -50,6 +50,9 @@ spec:
               readOnly: true
             - name: kubeconfig
               mountPath: /etc/kubeconfig
+              readOnly: true
+            - name: kubeflow-kubeconfig
+              mountPath: /etc/kubeflow-kubeconfig
               readOnly: true
             - name: s3-credentials
               mountPath: /etc/s3-credentials
@@ -71,6 +74,10 @@ spec:
           secret:
             defaultMode: 0644
             secretName: kubeconfig
+        - name: kubeflow-kubeconfig
+          secret:
+            defaultMode: 0644
+            secretName: kubeflow-kubeconfig
         - name: s3-credentials
           secret:
             secretName: s3-credentials

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -43,7 +43,7 @@ spec:
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG
-              value: "/etc/kubeconfig/config"
+              value: "/etc/kubeconfig/config:/etc/kubeflow-kubeconfig/config"
           ports:
             - name: http
               containerPort: 8080
@@ -62,6 +62,9 @@ spec:
               readOnly: true
             - name: kubeconfig
               mountPath: /etc/kubeconfig
+              readOnly: true
+            - name: kubeflow-kubeconfig
+              mountPath: /etc/kubeflow-kubeconfig
               readOnly: true
             - name: s3-credentials
               mountPath: /etc/s3-credentials
@@ -93,6 +96,10 @@ spec:
           secret:
             defaultMode: 0644
             secretName: kubeconfig
+        - name: kubeflow-kubeconfig
+          secret:
+            defaultMode: 0644
+            secretName: kubeflow-kubeconfig
         - name: plugins
           configMap:
             name: plugins

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -38,7 +38,7 @@ spec:
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG
-              value: "/etc/kubeconfig/config"
+              value: "/etc/kubeconfig/config:/etc/kubeflow-kubeconfig/config"
           volumeMounts:
             - name: github-token
               mountPath: /etc/github
@@ -51,6 +51,9 @@ spec:
               readOnly: true
             - name: kubeconfig
               mountPath: /etc/kubeconfig
+              readOnly: true
+            - name: kubeflow-kubeconfig
+              mountPath: /etc/kubeflow-kubeconfig
               readOnly: true
           livenessProbe: # Pod is killed if this fails 3 times.
             httpGet:
@@ -78,3 +81,7 @@ spec:
           secret:
             defaultMode: 0644
             secretName: kubeconfig
+        - name: kubeflow-kubeconfig
+          secret:
+            defaultMode: 0644
+            secretName: kubeflow-kubeconfig

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -27,7 +27,7 @@ spec:
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG
-              value: "/etc/kubeconfig/config"
+              value: "/etc/kubeconfig/config:/etc/kubeflow-kubeconfig/config"
           volumeMounts:
             - name: config
               mountPath: /etc/config
@@ -37,6 +37,9 @@ spec:
               readOnly: true
             - name: kubeconfig
               mountPath: /etc/kubeconfig
+              readOnly: true
+            - name: kubeflow-kubeconfig
+              mountPath: /etc/kubeflow-kubeconfig
               readOnly: true
       volumes:
         - name: config
@@ -49,3 +52,7 @@ spec:
           secret:
             defaultMode: 0644
             secretName: kubeconfig
+        - name: kubeflow-kubeconfig
+          secret:
+            defaultMode: 0644
+            secretName: kubeflow-kubeconfig

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -87,8 +87,7 @@ plank:
         - bot-ssh-secret
   - cluster: kubeflow-ppc64le-cluster
     config:
-      ssh_key_secrets:
-        - ""
+      ssh_key_secrets: null
 
 tide:
   sync_period: 2m


### PR DESCRIPTION
Adding `kubeconfig` details to `crier`, `deck`, `prow-controller`, `sinker` manifests that are required to include new kubeflow build cluster.
Also patch the config to correct the error with `ssh_key_secrets` decoration config.

@mkumatag I shall include the new kubeconfig details to secret repo too.