### PR TITLE
Remove ocp4-extra repo from mergeable plugin list

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -266,8 +266,3 @@ external_plugins:
     events:
       - issue_comment
       - pull_request
-  ocp-power-automation/ocp4-extras:
-  - name: mergable
-    events:
-      - issue_comment
-      - pull_request


### PR DESCRIPTION
The ocp-power-automation/ocp4-extras repo does not require +2 hence removing the mergeable plugin from the config.