### PR TITLE
Update capi-ibmcloud jobs with new release v0.7.0

### DIFF
--- a/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
+++ b/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
@@ -17,7 +17,41 @@ periodics:
         workdir: true
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.28
+          resources:
+          limits:
+           cpu: "3000m"
+          requests:
+           cpu: "3000m"
+          env:
+            - name: "E2E_FLAVOR"
+              value: "powervs-md-remediation"
+            - name: "BOSKOS_HOST"
+              value: "boskos.test-pods.svc.cluster.local"
+          command:
+            - "runner.sh"
+            - "./scripts/ci-e2e.sh"
+          securityContext:
+            privileged: true
+  - name: periodic-capi-provider-ibmcloud-e2e-powervs-release-0.7
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    decoration_config:
+      gcs_configuration:
+        bucket: ppc64le-kubernetes
+        path_strategy: explicit
+      gcs_credentials_secret: gcs-credentials
+    cron: "0 6 * * 6"
+    extra_refs:
+      - base_ref: release-0.7
+        org: kubernetes-sigs
+        repo: cluster-api-provider-ibmcloud
+        workdir: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.28
           resources:
           limits:
            cpu: "3000m"
@@ -43,7 +77,7 @@ periodics:
         bucket: ppc64le-kubernetes
         path_strategy: explicit
       gcs_credentials_secret: gcs-credentials
-    cron: "0 6 * * 6"
+    cron: "0 8 * * 0"
     extra_refs:
       - base_ref: release-0.6
         org: kubernetes-sigs
@@ -51,41 +85,7 @@ periodics:
         workdir: true
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
-          resources:
-          limits:
-           cpu: "3000m"
-          requests:
-           cpu: "3000m"
-          env:
-            - name: "E2E_FLAVOR"
-              value: "powervs-md-remediation"
-            - name: "BOSKOS_HOST"
-              value: "boskos.test-pods.svc.cluster.local"
-          command:
-            - "runner.sh"
-            - "./scripts/ci-e2e.sh"
-          securityContext:
-            privileged: true
-  - name: periodic-capi-provider-ibmcloud-e2e-powervs-release-0.5
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: ppc64le-kubernetes
-        path_strategy: explicit
-      gcs_credentials_secret: gcs-credentials
-    cron: "0 8 * * 0"
-    extra_refs:
-      - base_ref: release-0.5
-        org: kubernetes-sigs
-        repo: cluster-api-provider-ibmcloud
-        workdir: true
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.27
           resources:
           limits:
            cpu: "3000m"
@@ -119,7 +119,7 @@ periodics:
         workdir: true
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.28
           limits:
            cpu: "3000m"
           requests:
@@ -127,6 +127,39 @@ periodics:
           env:
             - name: "E2E_FLAVOR"
               value: "vpc"
+            - name: "BOSKOS_HOST"
+              value: "boskos.test-pods.svc.cluster.local"
+          command:
+            - "runner.sh"
+            - "./scripts/ci-e2e.sh"
+          securityContext:
+            privileged: true
+  - name: periodic-capi-provider-ibmcloud-e2e-vpc-release-0.7
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    decoration_config:
+      gcs_configuration:
+        bucket: ppc64le-kubernetes
+        path_strategy: explicit
+      gcs_credentials_secret: gcs-credentials
+    cron: "0 2 * * 6"
+    extra_refs:
+      - base_ref: release-0.7
+        org: kubernetes-sigs
+        repo: cluster-api-provider-ibmcloud
+        workdir: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.28
+          limits:
+           cpu: "3000m"
+          requests:
+           cpu: "3000m"
+          env:
+            - name: "E2E_FLAVOR"
+              value: "vpc-load-balancer"
             - name: "BOSKOS_HOST"
               value: "boskos.test-pods.svc.cluster.local"
           command:
@@ -144,7 +177,7 @@ periodics:
         bucket: ppc64le-kubernetes
         path_strategy: explicit
       gcs_credentials_secret: gcs-credentials
-    cron: "0 2 * * 6"
+    cron: "0 4 * * 0"
     extra_refs:
       - base_ref: release-0.6
         org: kubernetes-sigs
@@ -152,40 +185,7 @@ periodics:
         workdir: true
     spec:
       containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
-          limits:
-           cpu: "3000m"
-          requests:
-           cpu: "3000m"
-          env:
-            - name: "E2E_FLAVOR"
-              value: "vpc-load-balancer"
-            - name: "BOSKOS_HOST"
-              value: "boskos.test-pods.svc.cluster.local"
-          command:
-            - "runner.sh"
-            - "./scripts/ci-e2e.sh"
-          securityContext:
-            privileged: true
-  - name: periodic-capi-provider-ibmcloud-e2e-vpc-release-0.5
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    decorate: true
-    decoration_config:
-      gcs_configuration:
-        bucket: ppc64le-kubernetes
-        path_strategy: explicit
-      gcs_credentials_secret: gcs-credentials
-    cron: "0 4 * * 0"
-    extra_refs:
-      - base_ref: release-0.5
-        org: kubernetes-sigs
-        repo: cluster-api-provider-ibmcloud
-        workdir: true
-    spec:
-      containers:
-        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230703-e6ae5b372a-1.27
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.27
           limits:
            cpu: "3000m"
           requests:


### PR DESCRIPTION
This PR updates capi-ibmcloud jobs with new release v0.7.0 and updates the kubekins-e2e image versions accordingly.