### PR TITLE
Correct the gcs_configuration for etcd periodic job

### DIFF
--- a/config/jobs/periodic/etcd/test-etcd-periodics.yaml
+++ b/config/jobs/periodic/etcd/test-etcd-periodics.yaml
@@ -3,7 +3,7 @@ periodics:
     cluster: k8s-ppc64le-cluster
     decorate: true
     decoration_config:
-      decoration_config:
+      gcs_configuration:
         bucket: ppc64le-kubernetes
         path_strategy: explicit
       gcs_credentials_secret: gcs-credentials


### PR DESCRIPTION
Correcting the `decoration_configuration` for the periodic job added `periodic-etcd-test-ppc64le`.
These logs need to be in GCS bucket for them to appear in k8s testgrid.