### PR TITLE
Changes to upgrade prow infra to v20240205-8f023a0da6

### DIFF
--- a/config/prow/cluster/cherrypick_deployment.yaml
+++ b/config/prow/cluster/cherrypick_deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: cherrypick
-        image: gcr.io/k8s-prow/cherrypicker:v20240102-43c89140b5
+        image: gcr.io/k8s-prow/cherrypicker:v20240205-8f023a0da6
         args:
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: gcr.io/k8s-prow/crier:v20240102-43c89140b5
+          image: gcr.io/k8s-prow/crier:v20240205-8f023a0da6
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/crier_github_app_deployment.yaml
+++ b/config/prow/cluster/crier_github_app_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier2
-          image: gcr.io/k8s-prow/crier:v20240102-43c89140b5
+          image: gcr.io/k8s-prow/crier:v20240205-8f023a0da6
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: gcr.io/k8s-prow/deck:v20240102-43c89140b5
+          image: gcr.io/k8s-prow/deck:v20240205-8f023a0da6
           args:
             - --config-path=/etc/config/config.yaml
             - --plugin-config=/etc/plugins/plugins.yaml

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20240102-43c89140b5
+          image: gcr.io/k8s-prow/ghproxy:v20240205-8f023a0da6
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: gcr.io/k8s-prow/hook:v20240102-43c89140b5
+          image: gcr.io/k8s-prow/hook:v20240205-8f023a0da6
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/hook_github_app_deployment.yaml
+++ b/config/prow/cluster/hook_github_app_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook2
-          image: gcr.io/k8s-prow/hook:v20240102-43c89140b5
+          image: gcr.io/k8s-prow/hook:v20240205-8f023a0da6
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: horologium
-          image: gcr.io/k8s-prow/horologium:v20240102-43c89140b5
+          image: gcr.io/k8s-prow/horologium:v20240205-8f023a0da6
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/label_sync_cron_job.yaml
+++ b/config/prow/cluster/label_sync_cron_job.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20240102-43c89140b5
+              image: gcr.io/k8s-prow/label_sync:v20240205-8f023a0da6
               args:
                 - --config=/etc/config/labels.yaml
                 - --confirm=true

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - --github-endpoint=https://api.github.com
             - --enable-controller=plank
             - --job-config-path=/etc/job-config
-          image: gcr.io/k8s-prow/prow-controller-manager:v20240102-43c89140b5
+          image: gcr.io/k8s-prow/prow-controller-manager:v20240205-8f023a0da6
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG

--- a/config/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -92,6 +92,10 @@ spec:
                 description: DecorationConfig holds configuration options for decorating
                   PodSpecs that users provide
                 properties:
+                  blobless_fetch:
+                    description: BloblessFetch tells Prow to avoid fetching objects
+                      when cloning using the --filter=blob:none flag.
+                    type: boolean
                   censor_secrets:
                     description: CensorSecrets enables censoring output logs and artifacts.
                     type: boolean
@@ -484,6 +488,11 @@ spec:
                       type: string
                     base_sha:
                       type: string
+                    blobless_fetch:
+                      description: BloblessFetch tells prow to avoid fetching objects
+                        when cloning using the --filter=blob:none flag. If unspecified,
+                        defaults to DecorationConfig.BloblessFetch.
+                      type: boolean
                     clone_depth:
                       description: CloneDepth is the depth of the clone that will
                         be used. A depth of zero will do a full clone.
@@ -29312,6 +29321,18 @@ spec:
                 description: ProwJobDefault holds configuration options provided as
                   defaults in the Prow config
                 properties:
+                  resultstore_config:
+                    description: ResultStoreConfig specifies parameters for uploading
+                      results to the ResultStore service.
+                    properties:
+                      project_id:
+                        description: ProjectID specifies the ResultStore InvocationAttributes.ProjectID,
+                          used for various quota and GUI access control purposes.
+                          In practice, it is generally the same as the Google Cloud
+                          Project ID or number of the job's GCS storage bucket. Required
+                          to upload results to ResultStore.
+                        type: string
+                    type: object
                   tenant_id:
                     type: string
                 type: object
@@ -29326,6 +29347,11 @@ spec:
                     type: string
                   base_sha:
                     type: string
+                  blobless_fetch:
+                    description: BloblessFetch tells prow to avoid fetching objects
+                      when cloning using the --filter=blob:none flag. If unspecified,
+                      defaults to DecorationConfig.BloblessFetch.
+                    type: boolean
                   clone_depth:
                     description: CloneDepth is the depth of the clone that will be
                       used. A depth of zero will do a full clone.
@@ -29413,18 +29439,6 @@ spec:
               reporter_config:
                 description: ReporterConfig holds reporter-specific configuration
                 properties:
-                  resultstore:
-                    description: 'TODO: This config is used only for alpha testing
-                      and will likely move to ProwJobDefaults for flexibility.'
-                    properties:
-                      project_id:
-                        description: Specifies the ResultStore InvocationAttributes.ProjectId,
-                          used for various quota and GUI access control purposes.
-                          In practice, it is generally the same as the Google Cloud
-                          Project ID or number of the job's GCS storage bucket. Required
-                          to write job results to ResultStore.
-                        type: string
-                    type: object
                   slack:
                     properties:
                       channel:

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
         - name: sinker
-          image: gcr.io/k8s-prow/sinker:v20240102-43c89140b5
+          image: gcr.io/k8s-prow/sinker:v20240205-8f023a0da6
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20240102-43c89140b5
+          image: gcr.io/k8s-prow/status-reconciler:v20240205-8f023a0da6
           args:
             - --dry-run=false
             - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: gcr.io/k8s-prow/tide:v20240102-43c89140b5
+          image: gcr.io/k8s-prow/tide:v20240205-8f023a0da6
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -78,11 +78,12 @@ plank:
         bucket: s3://ppc64le-prow-logs
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+      blobless_fetch: true
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20240102-43c89140b5
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20240102-43c89140b5
-        initupload: gcr.io/k8s-prow/initupload:v20240102-43c89140b5
-        sidecar: gcr.io/k8s-prow/sidecar:v20240102-43c89140b5
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20240205-8f023a0da6
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20240205-8f023a0da6
+        initupload: gcr.io/k8s-prow/initupload:v20240205-8f023a0da6
+        sidecar: gcr.io/k8s-prow/sidecar:v20240205-8f023a0da6
       ssh_key_secrets:
         - bot-ssh-secret
   - cluster: kubeflow-ppc64le-cluster
@@ -100,7 +101,6 @@ tide:
         - lgtm
         - approved
       missingLabels:
-        - needs-rebase
         - do-not-merge/hold
         - do-not-merge/work-in-progress
         - do-not-merge/invalid-owners-file


### PR DESCRIPTION
Commits related to prowjob CRD changes:
https://github.com/kubernetes/test-infra/commit/2eeb019ae1efc6293c439d910fb578270d512b51
https://github.com/kubernetes/test-infra/commit/9fcb8d6fd99684d99f9d095078fe8cc80b825981
https://github.com/kubernetes/test-infra/commit/f21f62fac48ac9fd852d8168af9f6b0071bf4a98
https://github.com/kubernetes/test-infra/commit/8be4218c432e0221372c0d9dbf6845ee7fdac8e6

Removal of `needs-rebase` from config https://github.com/kubernetes/test-infra/commit/6d5a480fca60d61cd3d2658930160d71dd993196
Addition of blobless clone https://github.com/kubernetes/test-infra/commit/e0700c6f5cd97acf68c65171db41b59d6736421b