### PR TITLE
Change checkconfig command in pull-test-infra-prow-checkconfig job

### DIFF
--- a/config/jobs/ppc64le-cloud/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/ppc64le-cloud/test-infra/test-infra-presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-prow/checkconfig:v20240205-8f023a0da6
         command:
-        - /checkconfig
+        - checkconfig
         args:
         - --config-path=config/prow/config.yaml
         - --job-config-path=config/jobs


### PR DESCRIPTION
The presubmit job for https://github.com/ppc64le-cloud/test-infra/pull/444 still fails with below error:
```
could not start the process: fork/exec /checkconfig: no such file or directory
```
This change is required after the image tag upgrade.

Have verified this manually by creating a container and also had a look at the upstream job https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml#L75

```
[root@maxwells1 ~]# kubectl describe pod checkconfig2 | grep image
  Normal  Pulling    8m23s  kubelet            Pulling image "gcr.io/k8s-prow/checkconfig:v20240205-8f023a0da6"
  Normal  Pulled     8m22s  kubelet            Successfully pulled image "gcr.io/k8s-prow/checkconfig:v20240205-8f023a0da6" in 1.834609537s (1.834623899s including waiting)
[root@maxwells1 ~]# kubectl exec -it checkconfig2 -- /bin/sh
/ # /checkconfig version
/bin/sh: /checkconfig: not found
/ # checkconfig version
{"component":"checkconfig","file":"k8s.io/test-infra/prow/cmd/checkconfig/main.go:240","func":"main.main","level":"fatal","msg":"Error parsing options - invalid options: --config-path is mandatory","severity":"fatal","time":"2024-02-08T07:57:09Z"}
/ #
```