### PR TITLE
Run periodic jobs against github.com/moby/moby

### DIFF
--- a/config/jobs/periodic/docker/periodic-ci-docker.yaml
+++ b/config/jobs/periodic/docker/periodic-ci-docker.yaml
@@ -1,0 +1,158 @@
+periodics:
+    - name: periodic-config-docker
+      cluster: k8s-ppc64le-cluster
+      cron: 0 0 * * *
+      decorate: true
+      extra_refs:
+        - base_ref: main
+          org: ppc64le-cloud
+          repo: docker-ce-build
+      reporter_config:
+          slack:
+            channel: 'prow-job-notifications'
+            report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
+      spec:
+        containers:
+        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
+          resources:
+            requests:
+              cpu: "8000m"
+            limits:
+              cpu: "8000m"
+          command:
+          - /bin/bash
+          args:
+          - -c
+          - |
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+            set -o xtrace
+            echo "* Start prow-info-docker *"
+            chmod ug+x $PWD/upstream-master-ci/prow-info-docker.sh
+            $PWD/upstream-master-ci/prow-info-docker.sh
+            rc=$?
+            [ $rc != 0 ] && echo "ERROR: prow-info-docker exited with code:$rc"
+            exit $rc
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: boot
+            mountPath: /boot
+        volumes:
+        - name: boot
+          hostpath:
+            path: /boot/
+    - name: periodic-build-dev-image-docker
+      cluster: k8s-ppc64le-cluster
+      cron: 0 3 * * *
+      decorate: true
+      extra_refs:
+        - base_ref: main
+          org: ppc64le-cloud
+          repo: docker-ce-build
+      reporter_config:
+        slack:
+          channel: 'prow-job-notifications'
+          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
+      spec:
+        containers:
+        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
+          resources:
+            requests:
+              cpu: "8000m"
+            limits:
+              cpu: "8000m"
+          command:
+          - /bin/bash
+          args:
+          - -c
+          - |
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+            set -o xtrace
+            echo "* Start prow-build-dev-image *"
+            chmod ug+x $PWD/upstream-master-ci/prow-build-dev-image.sh
+            $PWD/upstream-master-ci/prow-build-dev-image.sh
+            rc=$?
+            [ $rc != 0 ] && echo "ERROR: prow-build-dev-image exited with code:$rc"
+            exit $rc
+          securityContext:
+            privileged: true
+    - name: periodic-unit-test-docker
+      cluster: k8s-ppc64le-cluster
+      cron: 0 9 * * *
+      decorate: true
+      extra_refs:
+        - base_ref: main
+          org: ppc64le-cloud
+          repo: docker-ce-build
+      reporter_config:
+        slack:
+          channel: 'prow-job-notifications'
+          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
+      spec:
+        containers:
+        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
+          resources:
+            requests:
+              cpu: "8000m"
+            limits:
+              cpu: "8000m"
+          command:
+          - /bin/bash
+          args:
+          - -c
+          - |
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+            set -o xtrace
+            echo "* Start prow-unit-test-docker *"
+            chmod ug+x $PWD/upstream-master-ci/prow-unit-test-docker.sh
+            $PWD/upstream-master-ci/prow-unit-test-docker.sh
+            rc=$?
+            [ $rc != 0 ] && echo "ERROR: prow-unit-test-docker exited with code:$rc"
+            exit $rc
+          securityContext:
+            privileged: true
+    - name: periodic-integration-test-docker
+      cluster: k8s-ppc64le-cluster
+      cron: 0 14 * * *
+      decorate: true
+      decoration_config:
+        timeout: 3h
+      extra_refs:
+        - base_ref: main
+          org: ppc64le-cloud
+          repo: docker-ce-build
+      reporter_config:
+        slack:
+          channel: 'prow-job-notifications'
+          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
+      spec:
+        containers:
+        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
+          resources:
+            requests:
+              cpu: "8000m"
+            limits:
+              cpu: "8000m"
+          command:
+          - /bin/bash
+          args:
+          - -c
+          - |
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+            set -o xtrace
+            echo "* Start prow-integration-tests *"
+            chmod ug+x $PWD/upstream-master-ci/prow-integration-tests.sh
+            $PWD/upstream-master-ci/prow-integration-tests.sh
+            rc=$?
+            [ $rc != 0 ] && echo "ERROR: prow-integration-tests exited with code:$rc"
+            exit $rc
+          securityContext:
+            privileged: true


### PR DESCRIPTION
Docker no longer runs periodic test jobs on moby/moby for ppc64le. Instead, we plan to run these on our production cluster.
There are 4 jobs:
1. Check configuration
2. Build the dev image
3. Run unit tests
4. Run integration tests
Please refer https://github.com/ppc64le-cloud/docker-ce-build/pull/182 for scripts.