### PR TITLE
Removing Test skip in postsubmit-master-golang-kubernetes-unit-test-ppc64le

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -122,8 +122,7 @@ postsubmits:
                 popd
 
                 export FORCE_HOST_GO=y
-                # Skipping UT TestVerify in typecheck package due to https://github.com/kubernetes/kubernetes/issues/120142
-                make test GOFLAGS=-skip="TestVerify$"
+                make test
                 # Check golang used for binary building
                 go_version_bin=`go version _output/local/go/bin/ncpu | cut -d ' ' -f3`
                 [[ "$go_version_env" == "$go_version_bin" ]] || { echo "The binary was not built with master go version"; exit 1; }


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/issues/120142 is fixed.

```
[root@raji-workspace ~]# git clone https://github.com/kubernetes/kubernetes
Cloning into 'kubernetes'...
remote: Enumerating objects: 1504859, done.
remote: Counting objects: 100% (317/317), done.
remote: Compressing objects: 100% (192/192), done.
remote: Total 1504859 (delta 156), reused 178 (delta 110), pack-reused 1504542
Receiving objects: 100% (1504859/1504859), 1002.05 MiB | 32.16 MiB/s, done.
Resolving deltas: 100% (1101572/1101572), done.
Updating files: 100% (24076/24076), done.
[root@raji-workspace ~]# go version
go version devel go1.23-2a59041420 Tue Feb 13 05:02:46 2024 +0000 linux/ppc64le
[root@raji-workspace ~]# cd kubernetes/test/typecheck/
[root@raji-workspace typecheck]# go test -v -race -run ^TestVerify
=== RUN   TestVerify
--- PASS: TestVerify (5.56s)
PASS
ok      k8s.io/kubernetes/test/typecheck        6.579s
[root@raji-workspace typecheck]#
```