### PR TITLE
Skip the TestWatchDelay UT based on suggestion from etcd

### DIFF
--- a/config/jobs/periodic/etcd/test-etcd-periodics.yaml
+++ b/config/jobs/periodic/etcd/test-etcd-periodics.yaml
@@ -41,4 +41,4 @@ periodics:
               tar -C /usr/local -xzf go.tgz
               go version
               ./scripts/build.sh
-              GOARCH=`go env GOARCH` make test
+              GOARCH=`go env GOARCH` GO_TEST_FLAGS="-skip=TestWatchDelay" make test

--- a/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
@@ -40,4 +40,4 @@ postsubmits:
                 export KEEP_GOING_SUITE=true
                 go version
                 ./scripts/build.sh
-                GOARCH=`go env GOARCH` make test
+                GOARCH=`go env GOARCH` GO_TEST_FLAGS="-skip=TestWatchDelay" make test


### PR DESCRIPTION
Below UTs have been flaking for many days on both the etcd jobs in our CI - `postsubmit-master-golang-etcd-build-test-ppc64le` and `periodic-etcd-test-ppc64le`

As per the comment here in issue https://github.com/etcd-io/etcd/issues/16319#issuecomment-1961604393, disabling it in our CI seems to be the solution.

Have made sure that this change is really skipping the tests by doing a test-pj.
https://prow.ppc64le-cloud.cis.ibm.net/view/gs/ppc64le-kubernetes/logs/test-periodic-etcd-test-ppc64le/1762434764733681664 is the link where tests from https://github.com/etcd-io/etcd/blob/main/tests/e2e/watch_delay_test.go are not appearing.
