### PR TITLE
Correct the indentation typo with resource requests

### DIFF
--- a/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
+++ b/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
@@ -19,10 +19,10 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-1.28
           resources:
-          limits:
-           cpu: "3000m"
-          requests:
-           cpu: "3000m"
+            limits:
+              cpu: "3000m"
+            requests:
+              cpu: "3000m"
           env:
             - name: "E2E_FLAVOR"
               value: "powervs-md-remediation"
@@ -53,10 +53,10 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.28
           resources:
-          limits:
-           cpu: "3000m"
-          requests:
-           cpu: "3000m"
+            limits:
+              cpu: "3000m"
+            requests:
+              cpu: "3000m"
           env:
             - name: "E2E_FLAVOR"
               value: "powervs-md-remediation"

--- a/config/jobs/periodic/etcd/test-etcd-periodics.yaml
+++ b/config/jobs/periodic/etcd/test-etcd-periodics.yaml
@@ -17,10 +17,12 @@ periodics:
       containers:
         - image: quay.io/powercloud/all-in-one:0.6
           resources:
-          requests:
-            cpu: "5000m"
-          limits:
-            cpu: "5000m"
+            requests:
+              cpu: "5000m"
+              memory: "8Gi"
+            limits:
+              cpu: "5000m"
+              memory: "8Gi"
           command:
             - /bin/bash
           args:

--- a/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
@@ -15,10 +15,12 @@ postsubmits:
         containers:
           - image: quay.io/powercloud/all-in-one:0.6
             resources:
-            requests:
-              cpu: "5000m"
-            limits:
-              cpu: "5000m"
+              requests:
+                cpu: "5000m"
+                memory: "8Gi"
+              limits:
+                cpu: "5000m"
+                memory: "8Gi"
             command:
               - /bin/bash
             args:


### PR DESCRIPTION
The indentation was wrong for resources metadata in jobs `test-e2e-capi-ibmcloud-periodics.yaml`, `test-etcd-periodics.yaml` and `etcd-postsubmit.yaml`, and hence no proper resources were allocated to the jobs.
I see the `TestWatchDelay` related flakiness improve to a major extent after proper resource allotment.