### PR TITLE
Reduce cpu request/limit for capi jobs

### DIFF
--- a/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
+++ b/config/jobs/periodic/cluster-api-provider-ibmcloud/test-e2e-capi-ibmcloud-periodics.yaml
@@ -20,9 +20,9 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-1.28
           resources:
             limits:
-              cpu: "3000m"
+              cpu: "1000m"
             requests:
-              cpu: "3000m"
+              cpu: "1000m"
           env:
             - name: "E2E_FLAVOR"
               value: "powervs-md-remediation"
@@ -54,9 +54,9 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.28
           resources:
             limits:
-              cpu: "3000m"
+              cpu: "1000m"
             requests:
-              cpu: "3000m"
+              cpu: "1000m"
           env:
             - name: "E2E_FLAVOR"
               value: "powervs-md-remediation"
@@ -88,9 +88,9 @@ periodics:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.27
           resources:
           limits:
-           cpu: "3000m"
+           cpu: "1000m"
           requests:
-           cpu: "3000m"
+           cpu: "1000m"
           env:
             - name: "E2E_FLAVOR"
               value: "powervs-md-remediation"
@@ -121,9 +121,9 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-1.28
           limits:
-           cpu: "3000m"
+           cpu: "1000m"
           requests:
-           cpu: "3000m"
+           cpu: "1000m"
           env:
             - name: "E2E_FLAVOR"
               value: "vpc"
@@ -154,9 +154,9 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.28
           limits:
-           cpu: "3000m"
+           cpu: "1000m"
           requests:
-           cpu: "3000m"
+           cpu: "1000m"
           env:
             - name: "E2E_FLAVOR"
               value: "vpc"
@@ -187,9 +187,9 @@ periodics:
       containers:
         - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231208-8b9fd88e88-1.27
           limits:
-           cpu: "3000m"
+           cpu: "1000m"
           requests:
-           cpu: "3000m"
+           cpu: "1000m"
           env:
             - name: "E2E_FLAVOR"
               value: "vpc-load-balancer"


### PR DESCRIPTION
Reducing the resource request and limit values from `3000m` to `1000m` to avoid job failures due to resource unavailability.

Ref: https://ibm-cloudplatform.slack.com/archives/G01CH7AC8H1/p1709276740613729

A couple of test runs: https://prow.ppc64le-cloud.cis.ibm.net/view/gs/ppc64le-kubernetes/logs/periodic-capi-provider-ibmcloud-e2e-powervs/1763525894820859904
https://prow.ppc64le-cloud.cis.ibm.net/view/gs/ppc64le-kubernetes/logs/periodic-capi-provider-ibmcloud-e2e-powervs/1763490552956850176

![image](https://github.com/ppc64le-cloud/test-infra/assets/63038004/c7892f57-0bb7-4d84-8b62-b318d633c136)
