### PR TITLE
Upgrade Prow Infra to v20240304-a80e95c002

### DIFF
--- a/config/prow/cluster/cherrypick_deployment.yaml
+++ b/config/prow/cluster/cherrypick_deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: cherrypick
-        image: gcr.io/k8s-prow/cherrypicker:v20240205-8f023a0da6
+        image: gcr.io/k8s-prow/cherrypicker:v20240304-a80e95c002
         args:
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: gcr.io/k8s-prow/crier:v20240205-8f023a0da6
+          image: gcr.io/k8s-prow/crier:v20240304-a80e95c002
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/crier_github_app_deployment.yaml
+++ b/config/prow/cluster/crier_github_app_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier2
-          image: gcr.io/k8s-prow/crier:v20240205-8f023a0da6
+          image: gcr.io/k8s-prow/crier:v20240304-a80e95c002
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: gcr.io/k8s-prow/deck:v20240205-8f023a0da6
+          image: gcr.io/k8s-prow/deck:v20240304-a80e95c002
           args:
             - --config-path=/etc/config/config.yaml
             - --plugin-config=/etc/plugins/plugins.yaml

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20240205-8f023a0da6
+          image: gcr.io/k8s-prow/ghproxy:v20240304-a80e95c002
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: gcr.io/k8s-prow/hook:v20240205-8f023a0da6
+          image: gcr.io/k8s-prow/hook:v20240304-a80e95c002
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/hook_github_app_deployment.yaml
+++ b/config/prow/cluster/hook_github_app_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook2
-          image: gcr.io/k8s-prow/hook:v20240205-8f023a0da6
+          image: gcr.io/k8s-prow/hook:v20240304-a80e95c002
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: horologium
-          image: gcr.io/k8s-prow/horologium:v20240205-8f023a0da6
+          image: gcr.io/k8s-prow/horologium:v20240304-a80e95c002
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/label_sync_cron_job.yaml
+++ b/config/prow/cluster/label_sync_cron_job.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20240205-8f023a0da6
+              image: gcr.io/k8s-prow/label_sync:v20240304-a80e95c002
               args:
                 - --config=/etc/config/labels.yaml
                 - --confirm=true

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - --github-endpoint=https://api.github.com
             - --enable-controller=plank
             - --job-config-path=/etc/job-config
-          image: gcr.io/k8s-prow/prow-controller-manager:v20240205-8f023a0da6
+          image: gcr.io/k8s-prow/prow-controller-manager:v20240304-a80e95c002
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG

--- a/config/prow/cluster/prow-controller-manager_rbac.yaml
+++ b/config/prow/cluster/prow-controller-manager_rbac.yaml
@@ -64,11 +64,11 @@ rules:
     resources:
       - pods
     verbs:
+      - create
       - delete
-      - get
       - list
       - watch
-      - create
+      - get
       - patch
 ---
 kind: RoleBinding

--- a/config/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -182,6 +182,16 @@ spec:
                           discouraged to use Bucket without prefix please add the
                           gs:// prefix)'
                         type: string
+                      compress_file_types:
+                        description: 'CompressFileTypes specify file types that should
+                          be gzipped prior to upload. Matching files will be compressed
+                          prior to upload, and the content-encoding on these files
+                          will be set to gzip. GCS will transcode these gzipped files
+                          transparently when viewing. See: https://cloud.google.com/storage/docs/transcoding
+                          Example: "txt", "json" Use "*" for all'
+                        items:
+                          type: string
+                        type: array
                       default_org:
                         description: DefaultOrg is omitted from GCS paths when using
                           the legacy or simple strategy

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
         - name: sinker
-          image: gcr.io/k8s-prow/sinker:v20240205-8f023a0da6
+          image: gcr.io/k8s-prow/sinker:v20240304-a80e95c002
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20240205-8f023a0da6
+          image: gcr.io/k8s-prow/status-reconciler:v20240304-a80e95c002
           args:
             - --dry-run=false
             - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: gcr.io/k8s-prow/tide:v20240205-8f023a0da6
+          image: gcr.io/k8s-prow/tide:v20240304-a80e95c002
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -80,10 +80,10 @@ plank:
       s3_credentials_secret: s3-credentials
       blobless_fetch: true
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20240205-8f023a0da6
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20240205-8f023a0da6
-        initupload: gcr.io/k8s-prow/initupload:v20240205-8f023a0da6
-        sidecar: gcr.io/k8s-prow/sidecar:v20240205-8f023a0da6
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20240304-a80e95c002
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20240304-a80e95c002
+        initupload: gcr.io/k8s-prow/initupload:v20240304-a80e95c002
+        sidecar: gcr.io/k8s-prow/sidecar:v20240304-a80e95c002
       ssh_key_secrets:
         - bot-ssh-secret
   - cluster: kubeflow-ppc64le-cluster


### PR DESCRIPTION
Upgrades the image tags to `v20240304-a80e95c002`
Also includes changes:
- https://github.com/kubernetes/test-infra/pull/32071
- https://github.com/kubernetes/test-infra/pull/32027