### PR TITLE
Update the DinD image used to the one tagged 0.8-ppc64le

### DIFF
--- a/config/jobs/periodic/docker/periodic-ci-docker.yaml
+++ b/config/jobs/periodic/docker/periodic-ci-docker.yaml
@@ -13,7 +13,7 @@ periodics:
             report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
+        - image: quay.io/powercloud/docker-ce-build@sha256:2231f00d1b1af02c018ea8f2f2ee2a890174d0bb0ce7067d128519e442776cbc
           resources:
             requests:
               cpu: "8000m"
@@ -57,7 +57,7 @@ periodics:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
+        - image: quay.io/powercloud/docker-ce-build@sha256:2231f00d1b1af02c018ea8f2f2ee2a890174d0bb0ce7067d128519e442776cbc
           resources:
             requests:
               cpu: "8000m"
@@ -94,7 +94,7 @@ periodics:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
+        - image: quay.io/powercloud/docker-ce-build@sha256:2231f00d1b1af02c018ea8f2f2ee2a890174d0bb0ce7067d128519e442776cbc
           resources:
             requests:
               cpu: "8000m"
@@ -133,7 +133,7 @@ periodics:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
+        - image: quay.io/powercloud/docker-ce-build@sha256:2231f00d1b1af02c018ea8f2f2ee2a890174d0bb0ce7067d128519e442776cbc
           resources:
             requests:
               cpu: "8000m"

--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-build-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-build-docker.yaml
@@ -16,7 +16,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
+        - image: quay.io/powercloud/docker-ce-build@sha256:2231f00d1b1af02c018ea8f2f2ee2a890174d0bb0ce7067d128519e442776cbc
           resources:
             requests:
               cpu: "8000m"
@@ -76,7 +76,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
+        - image: quay.io/powercloud/docker-ce-build@sha256:2231f00d1b1af02c018ea8f2f2ee2a890174d0bb0ce7067d128519e442776cbc
           resources:
             requests:
               cpu: "8000m"

--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
@@ -18,7 +18,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
+        - image: quay.io/powercloud/docker-ce-build@sha256:2231f00d1b1af02c018ea8f2f2ee2a890174d0bb0ce7067d128519e442776cbc
           resources:
             requests:
               cpu: "8000m"
@@ -70,7 +70,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:20890c8770ff57f91eb9f16fbb9f9e979958cd02b2a3c03795d2587e7b58a9db
+        - image: quay.io/powercloud/docker-ce-build@sha256:2231f00d1b1af02c018ea8f2f2ee2a890174d0bb0ce7067d128519e442776cbc
           resources:
             requests:
               cpu: "8000m"


### PR DESCRIPTION
[0.8-ppc64le Docker-in-Docker image](https://quay.io/repository/powercloud/docker-ce-build/manifest/sha256:2231f00d1b1af02c018ea8f2f2ee2a890174d0bb0ce7067d128519e442776cbc) has been released. Update the jobs to use it. This updates the packages in it. The updated packages address vulnerability issues in their older versions.