### PR TITLE
Add GOPPC64 env avriable to go building jobs

### DIFF
--- a/config/jobs/periodic/etcd/test-etcd-periodics.yaml
+++ b/config/jobs/periodic/etcd/test-etcd-periodics.yaml
@@ -1,6 +1,8 @@
 periodics:
   - name: periodic-etcd-test-ppc64le
     cluster: k8s-ppc64le-cluster
+    labels:
+      preset-golang-build: "true"
     decorate: true
     decoration_config:
       gcs_configuration:
@@ -33,7 +35,6 @@ periodics:
               set -o pipefail
               set -o xtrace
 
-              export PATH=$GOPATH/bin:$PATH
               export KEEP_GOING_MODULE=true
               export KEEP_GOING_SUITE=true
               GOLANG_VERSION=`cat .go-version`

--- a/config/jobs/periodic/golang/build-golang-periodics.yaml
+++ b/config/jobs/periodic/golang/build-golang-periodics.yaml
@@ -1,6 +1,8 @@
 periodics:
   - name: periodic-golang-master-build-ppc64le
     cluster: k8s-ppc64le-cluster
+    labels:
+      preset-golang-build: "true"
     decorate: true
     cron: "50 1/1 * * *"
     spec:

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -1,6 +1,8 @@
 periodics:
   - name: periodic-kubernetes-unit-test-ppc64le
     cluster: k8s-ppc64le-cluster
+    labels:
+      preset-golang-build: "true"
     decorate: true
     decoration_config:
       gcs_configuration:
@@ -126,6 +128,7 @@ periodics:
   - name: periodic-kubernetes-containerd-e2e-node-tests-ppc64le
     cluster: k8s-ppc64le-cluster
     labels:
+      preset-golang-build: "true"
       preset-ssh-bot: "true"
     decorate: true
     decoration_config:

--- a/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
@@ -2,6 +2,8 @@ postsubmits:
   ppc64le-cloud/builds:
     - name: postsubmit-master-golang-etcd-build-test-ppc64le
       cluster: k8s-ppc64le-cluster
+      labels:
+        preset-golang-build: "true"
       decorate: true
       branches:
         - master
@@ -36,8 +38,6 @@ postsubmits:
                 curl -X GET http://build-bot.prow:8090/build\?project\=$build_project\&commit\=$build_commit -o /tmp/golang.tar.gz
                 rm -rf /usr/local/go
                 tar -C /usr/local -xzf /tmp/golang.tar.gz
-                export PATH=/usr/local/go/bin:$PATH
-                export PATH=$GOPATH/bin:$PATH
                 export KEEP_GOING_MODULE=true
                 export KEEP_GOING_SUITE=true
                 go version

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -2,6 +2,8 @@ postsubmits:
   ppc64le-cloud/builds:
     - name: postsubmit-kubernetes-build-golang-master-ppc64le
       cluster: k8s-ppc64le-cluster
+      labels:
+        preset-golang-build: "true"
       decorate: true
       branches:
         - master
@@ -34,7 +36,6 @@ postsubmits:
                 curl -X GET http://build-bot.prow:8090/build\?project\=$build_project\&commit\=$build_commit -o /tmp/golang.tar.gz
                 rm -rf /usr/local/go
                 tar -C /usr/local -xzf /tmp/golang.tar.gz
-                export PATH=/usr/local/go/bin:$PATH
                 # Storing go version of environment
                 go_version_env=`go version | cut -d ' ' -f4`
                 # go version of development master go will be of the kind "go version devel go1.21-39c5070712 Thu Jul 6 23:23:41 2023 +0000 linux/ppc64le"
@@ -64,6 +65,8 @@ postsubmits:
                 curl -v -X POST http://build-bot.prow:8090/build -H 'Content-Type: multipart/form-data' -F file1=@kubernetes-test-linux-`go env GOARCH`.tar.gz -F file2=@kubernetes-client-linux-`go env GOARCH`.tar.gz -F file3=@kubernetes-server-linux-`go env GOARCH`.tar.gz -F source=github.com/kubernetes/kubernetes.git -F commit=$GITCOMMIT -F project=kubernetes/master/golang/master
     - name: postsubmit-master-golang-kubernetes-unit-test-ppc64le
       cluster: k8s-ppc64le-cluster
+      labels:
+        preset-golang-build: "true"
       decorate: true
       decoration_config:
         gcs_configuration:
@@ -106,14 +109,12 @@ postsubmits:
                 curl -X GET http://build-bot.prow:8090/build\?project\=$build_project\&commit\=$build_commit -o /tmp/golang.tar.gz
                 rm -rf /usr/local/go
                 tar -C /usr/local -xzf /tmp/golang.tar.gz
-                export PATH=/usr/local/go/bin:$PATH
                 # Storing go version of environment
                 go_version_env=`go version | cut -d ' ' -f4`
                 # go version of development master go will be of the kind "go version devel go1.21-39c5070712 Thu Jul 6 23:23:41 2023 +0000 linux/ppc64le"
                 # hence the cut at f4 will store go1.21-39c5070712 to go_version_env variable
                 echo "The Go version of environment is $go_version_env"
 
-                export PATH=$GOPATH/bin:$PATH
                 go version
                 go env
 

--- a/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
@@ -2,6 +2,8 @@ postsubmits:
   ppc64le-cloud/builds:
     - name: postsubmit-os-kubernetes-build-golang-master-ppc64le
       cluster: k8s-ppc64le-cluster
+      labels:
+        preset-golang-build: "true"
       decorate: true
       branches:
         - master
@@ -34,7 +36,6 @@ postsubmits:
                 curl -X GET http://build-bot.prow:8090/build\?project\=$build_project\&commit\=$build_commit -o /tmp/golang.tar.gz
                 rm -rf /usr/local/go
                 tar -C /usr/local -xzf /tmp/golang.tar.gz
-                export PATH=/usr/local/go/bin:$PATH
                 # Storing go version of environment
                 go_version_env=`go version | cut -d ' ' -f4`
                 # go version of development master go will be of the kind "go version devel go1.21-39c5070712 Thu Jul 6 23:23:41 2023 +0000 linux/ppc64le"
@@ -56,6 +57,8 @@ postsubmits:
                 done
     - name: postsubmit-os-origin-build-golang-master-ppc64le
       cluster: k8s-ppc64le-cluster
+      labels:
+        preset-golang-build: "true"
       decorate: true
       branches:
         - master
@@ -88,7 +91,6 @@ postsubmits:
                 curl -X GET http://build-bot.prow:8090/build\?project\=$build_project\&commit\=$build_commit -o /tmp/golang.tar.gz
                 rm -rf /usr/local/go
                 tar -C /usr/local -xzf /tmp/golang.tar.gz
-                export PATH=/usr/local/go/bin:$PATH
                 export OPENSHIFT_SKIP_EXTERNAL_TESTS=true
                 make GO_REQUIRED_MIN_VERSION:= WHAT=cmd/openshift-tests
                 cp ./openshift-tests /usr/local/bin

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -223,3 +223,9 @@ presets:
       secret:
         defaultMode: 256
         secretName: bot-ssh-secret
+# Building Golang binaries
+- labels:
+    preset-golang-build: "true"
+  env:
+    - name: GOPPC64
+      value: power9


### PR DESCRIPTION
- Have added a preset label to enable the environment variable `GOPPC64=power9` for all the go binary building jobs.

  1. periodic-golang-master-build-ppc64le
  2. postsubmit-kubernetes-build-golang-master-ppc64le
  3. postsubmit-master-golang-kubernetes-unit-test-ppc64le
  4. postsubmit-os-kubernetes-build-golang-master-ppc64le
  5. postsubmit-os-origin-build-golang-master-ppc64le
  6. postsubmit-master-golang-etcd-build-test-ppc64le
  7. periodic-etcd-test-ppc64le
  8. periodic-kubernetes-unit-test-ppc64le
  9. periodic-kubernetes-containerd-e2e-node-tests-ppc64le

- Also have removed the export of the PATH variable to add `/usr/local/go/bin` and `$GOPATH/bin` to the PATH value. As the `all-in-one:0.6` image has these values already added to PATH.
    - https://github.com/ppc64le-cloud/test-infra/blob/master/images/all-in-one/Dockerfile#L47
    - https://github.com/ppc64le-cloud/test-infra/blob/master/images/all-in-one/Dockerfile#L113

@mkumatag I have verified if the value is being picked up while binary building by running a few jobs by doing `strings <binary_name> | grep GOPPC`

Also have checked in a couple of runs if the removal of PATH export is not creating any failure. Any idea why we had to include these PATH exports inspite of having these values set in `all-in-one` image from the beginning?