### PR TITLE
Commenting openshift-tests dry-run

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
@@ -96,4 +96,5 @@ postsubmits:
                 cp ./openshift-tests /usr/local/bin
                 openshift-tests help
                 openshift-tests images --to-repository=quay.io/powercloud/community-e2e-images
-                openshift-tests run kubernetes/conformance --dry-run
+                # Commenting dry-run until https://github.com/openshift/origin/issues/28681 is addressed
+                # openshift-tests run kubernetes/conformance --dry-run


### PR DESCRIPTION
https://prow.ppc64le-cloud.cis.ibm.net/job-history/s3/ppc64le-prow-logs/logs/postsubmit-os-origin-build-golang-master-ppc64le job has been failing due to https://github.com/openshift/origin/issues/28681

```
+ openshift-tests run kubernetes/conformance --dry-run
Unable to get admin rest config, skipping apigroup check in the dry-run mode: could not load client configuration: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
time="2024-04-09T21:18:35Z" level=info msg="Decoding provider" clusterState="<nil>" discover=true dryRun=true func=DecodeProvider providerType=
  W0409 21:18:35.151420      14 test_context.go:547] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
Unable to get server version through discovery client, skipping apigroup check in the dry-run mode: <nil>
error converting to options: unable to build FeatureGate filter: Get "http://localhost/apis/config.openshift.io/v1/featuregates/cluster": dial tcp [::1]:80: connect: connection refusederror: unable to build FeatureGate filter: Get "http://localhost/apis/config.openshift.io/v1/featuregates/cluster": dial tcp [::1]:80: connect: connection refused
```