### PR TITLE
Correct the image tag of label_sync CronJob

### DIFF
--- a/config/prow/cluster/label_sync_cron_job.yaml
+++ b/config/prow/cluster/label_sync_cron_job.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20240410-4be743f3e
+              image: gcr.io/k8s-prow/label_sync:v20240409-13cd3acf7e
               args:
                 - --config=/etc/config/labels.yaml
                 - --confirm=true


### PR DESCRIPTION
The manifest of label_sync has an invalid image tag.
