### PR TITLE
Start using centos-9-stream image for CI jobs

### DIFF
--- a/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
@@ -62,7 +62,7 @@ periodics:
         echo POD_STARTUP_LATENCY_THRESHOLD: 10s >> $GOPATH/src/github.com/kubernetes/perf-tests/clusterloader2/testing/overrides/node_containerd.yaml
 
         kubetest2 tf --powervs-dns k8s-tests \
-          --powervs-image-name centos-stream-8 \
+          --powervs-image-name centos-9-stream-20Gb \
           --powervs-region syd --powervs-zone syd05 \
           --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
           --powervs-ssh-key powercloud-bot-key \
@@ -141,7 +141,7 @@ periodics:
         chmod +x /usr/local/bin/kubectl
 
         kubetest2 tf --powervs-dns k8s-tests \
-          --powervs-image-name centos-stream-8 \
+          --powervs-image-name centos-9-stream-20Gb \
           --powervs-region syd --powervs-zone syd05 \
           --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
           --powervs-ssh-key powercloud-bot-key \

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -102,7 +102,7 @@ periodics:
               chmod +x /usr/local/bin/kubectl
 
               kubetest2 tf --powervs-dns k8s-tests \
-                --powervs-image-name centos-stream-8 \
+                --powervs-image-name centos-9-stream-20Gb \
                 --powervs-region syd --powervs-zone syd05 \
                 --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
                 --powervs-ssh-key powercloud-bot-key \
@@ -183,7 +183,7 @@ periodics:
               chmod +x /usr/local/bin/kubectl
 
               kubetest2 tf --powervs-dns k8s-tests \
-                --powervs-image-name centos-stream-8 \
+                --powervs-image-name centos-9-stream-20Gb \
                 --powervs-region syd --powervs-zone syd05 \
                 --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
                 --powervs-ssh-key powercloud-bot-key \

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -190,7 +190,7 @@ postsubmits:
                 wget -qO- $URL/kubernetes-client-linux-ppc64le.tar.gz | tar xz -C /usr/local/bin --strip-components=3
 
                 kubetest2 tf --powervs-dns k8s-tests \
-                    --powervs-image-name centos-stream-8 \
+                    --powervs-image-name centos-9-stream-20Gb \
                     --powervs-region syd --powervs-zone syd05 \
                     --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
                     --powervs-ssh-key powercloud-bot-key \


### PR DESCRIPTION
This change is to make prow jobs use Centos-9-stream images instead of existing Centos-8-stream images.

https://prow.ppc64le-cloud.cis.ibm.net/view/gs/ppc64le-kubernetes/logs/test-periodic-kubernetes-containerd-conformance-test-ppc64le/1791388352495226880 is the test job that PASSED using this image.