### PR TITLE
Add networks purge command to cleanup job

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-k8s-periodics.yaml
@@ -24,3 +24,4 @@ periodics:
 
               # delete all the vms created before 4hrs
               pvsadm purge vms --instance-id c3f5354a-517e-4927-8523-890c4bf3d6c5 --before 4h --ignore-errors --no-prompt
+              pvsadm purge networks --instance-id c3f5354a-517e-4927-8523-890c4bf3d6c5 --before 4h --ignore-errors --no-prompt


### PR DESCRIPTION
Stale networks are sometimes left behind in the workspace.
Adding this would make sure the networks are also cleaned up thoroughly.

Also, about to create an IBM support ticket for networks that are throwing Internal server errors while deletion.
