### PR TITLE
Disable errexit before kubetest2 tf command

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -101,6 +101,7 @@ periodics:
               curl -sSL https://dl.k8s.io/ci/$K8S_BUILD_VERSION/bin/linux/`go env GOARCH`/kubectl > /usr/local/bin/kubectl
               chmod +x /usr/local/bin/kubectl
 
+              set +o errexit
               kubetest2 tf --powervs-dns k8s-tests \
                 --powervs-image-name centos-9-stream-20Gb \
                 --powervs-region syd --powervs-zone syd05 \
@@ -113,7 +114,7 @@ periodics:
                 --up --auto-approve --retry-on-tf-failure 3 \
                 --break-kubetest-on-upfail true \
                 --powervs-memory 32 \
-                --test=ginkgo -- --parallel 10 --test-package-dir ci --test-package-version $K8S_BUILD_VERSION --focus-regex='\[Conformance\]' --skip-regex='\[Serial\]'
+                --test=ginkgo -- --parallel 10 --test-package-dir ci --test-package-version $K8S_BUILD_VERSION --focus-regex='\[Conformance\]' --skip-regex='\[Serial\]'; rc1=$?
               export KUBECONFIG="$(pwd)/config1-$TIMESTAMP/kubeconfig"
               export ARTIFACTS=$ARTIFACTS/serial_tests_artifacts
               #Run Serial Conformance tests
@@ -124,7 +125,15 @@ periodics:
                 --down --auto-approve --ignore-destroy-errors \
                 --test=ginkgo -- \
                 --test-package-dir ci \
-                --test-package-version $K8S_BUILD_VERSION --focus-regex='\[Serial\].*\[Conformance\]'
+                --test-package-version $K8S_BUILD_VERSION --focus-regex='\[Serial\].*\[Conformance\]'; rc2=$?
+              if [ $rc1 != 0 ]; then
+                  echo "ERROR: Non Serial k8s Conformance tests exited with code: $rc1"
+                  exit $rc1
+              elif [ $rc2 != 0 ]; then
+                  echo "ERROR: Serial k8s Conformance tests exited with code: $rc2"
+                  exit $rc2
+              fi
+
   - name: periodic-kubernetes-containerd-e2e-node-tests-ppc64le
     cluster: k8s-ppc64le-cluster
     labels:
@@ -182,6 +191,7 @@ periodics:
               curl -sSL https://dl.k8s.io/ci/$K8S_BUILD_VERSION/bin/linux/`go env GOARCH`/kubectl > /usr/local/bin/kubectl
               chmod +x /usr/local/bin/kubectl
 
+              set +o errexit
               kubetest2 tf --powervs-dns k8s-tests \
                 --powervs-image-name centos-9-stream-20Gb \
                 --powervs-region syd --powervs-zone syd05 \
@@ -194,7 +204,6 @@ periodics:
                 --break-kubetest-on-upfail true --powervs-memory 32 \
                 --playbook k8s-node-remote.yml
               EXTERNAL_IP=`grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $(pwd)/config3-$TIMESTAMP/hosts`
-              set +o errexit
               kubetest2 tf --test=exec -- ssh -i /etc/secret-volume/ssh-privatekey root@$EXTERNAL_IP \
                 "export SKIP='\[Flaky\]|\[Slow\]|\[Serial\]|Containers.Lifecycle.should|Summary.API|should.execute.readiness.probe.while.in.preStop' && /make-test-e2e-node.sh"; \
                 rc=$?; scp -r -i /etc/secret-volume/ssh-privatekey root@$EXTERNAL_IP:/tmp/_artifacts $ARTIFACTS

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -189,6 +189,7 @@ postsubmits:
                 # kubectl needed for the e2e tests
                 wget -qO- $URL/kubernetes-client-linux-ppc64le.tar.gz | tar xz -C /usr/local/bin --strip-components=3
 
+                set +o errexit
                 kubetest2 tf --powervs-dns k8s-tests \
                     --powervs-image-name centos-9-stream-20Gb \
                     --powervs-region syd --powervs-zone syd05 \
@@ -207,7 +208,7 @@ postsubmits:
                     --ginkgo.skip='\[Serial\]' \
                     --ginkgo.flakeAttempts=2 \
                     --report-dir=$ARTIFACTS \
-                    --kubeconfig="$(pwd)/config2-$TIMESTAMP/kubeconfig"
+                    --kubeconfig="$(pwd)/config2-$TIMESTAMP/kubeconfig"; rc1=$?
                 export ARTIFACTS=$ARTIFACTS/serial_tests_artifacts
                 kubetest2 tf --powervs-region syd --powervs-zone syd05 \
                     --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
@@ -218,4 +219,11 @@ postsubmits:
                     -- --ginkgo.focus='\[Serial\].*\[Conformance\]' \
                     --ginkgo.flakeAttempts=2 \
                     --report-dir=$ARTIFACTS \
-                    --kubeconfig="$(pwd)/config2-$TIMESTAMP/kubeconfig"
+                    --kubeconfig="$(pwd)/config2-$TIMESTAMP/kubeconfig"; rc2=$?
+                if [ $rc1 != 0 ]; then
+                    echo "ERROR: Non Serial k8s Conformance tests exited with code: $rc1"
+                    exit $rc1
+                elif [ $rc2 != 0 ]; then
+                    echo "ERROR: Serial k8s Conformance tests exited with code: $rc2"
+                    exit $rc2
+                fi


### PR DESCRIPTION
This change is to make sure the `--down` flag of `kubetest2 tf` runs inspite of failure in the `--up` or `--test` phases.
https://prow.ppc64le-cloud.cis.ibm.net/view/s3/ppc64le-prow-logs/logs/test-postsubmit-master-golang-kubernetes-conformance-test-ppc64le/1793562341929914368 is the test job that was successful with this change.