### PR TITLE
Bump all-in-one image to 0.7

### DIFF
--- a/config/jobs/etcd-io/etcd/etcd-presubmit.yaml
+++ b/config/jobs/etcd-io/etcd/etcd-presubmit.yaml
@@ -6,7 +6,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-        - image: quay.io/powercloud/all-in-one:0.6
+        - image: quay.io/powercloud/all-in-one:0.7
           command:
             - /bin/bash
           args:

--- a/config/jobs/ocp-automation/ocp-powervm-faq/ocp-powervm-faq-postsubmit.yaml
+++ b/config/jobs/ocp-automation/ocp-powervm-faq/ocp-powervm-faq-postsubmit.yaml
@@ -9,7 +9,7 @@ postsubmits:
         - ^master$
       spec:
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             command:
               - sh
             args:

--- a/config/jobs/ocp-automation/ocp4-upi-kvm/ocp4-upi-kvm-postsubmit.yaml
+++ b/config/jobs/ocp-automation/ocp4-upi-kvm/ocp4-upi-kvm-postsubmit.yaml
@@ -9,7 +9,7 @@ postsubmits:
         - ^master$
       spec:
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             command:
               - sh
             args:

--- a/config/jobs/ocp-automation/ocp4-upi-powervm/ocp4-upi-powervm-postsubmit.yaml
+++ b/config/jobs/ocp-automation/ocp4-upi-powervm/ocp4-upi-powervm-postsubmit.yaml
@@ -9,7 +9,7 @@ postsubmits:
         - ^master$
       spec:
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             command:
               - sh
             args:

--- a/config/jobs/ocp-automation/ocp4-upi-powervs/ocp4-upi-powervs-postsubmit.yaml
+++ b/config/jobs/ocp-automation/ocp4-upi-powervs/ocp4-upi-powervs-postsubmit.yaml
@@ -9,7 +9,7 @@ postsubmits:
         - ^master$
       spec:
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             command:
               - sh
             args:

--- a/config/jobs/ocp-automation/openshift-install-power/openshift-install-power-images.yaml
+++ b/config/jobs/ocp-automation/openshift-install-power/openshift-install-power-images.yaml
@@ -15,7 +15,7 @@ postsubmits:
       spec:
         serviceAccountName: build-img
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             command:
               - /bin/bash
             args:

--- a/config/jobs/ocp-automation/openshift-install-power/openshift-install-power-postsubmit.yaml
+++ b/config/jobs/ocp-automation/openshift-install-power/openshift-install-power-postsubmit.yaml
@@ -9,7 +9,7 @@ postsubmits:
         - ^main$
       spec:
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             command:
               - sh
             args:

--- a/config/jobs/periodic/containerd/test-containerd-powervs-periodic.yaml
+++ b/config/jobs/periodic/containerd/test-containerd-powervs-periodic.yaml
@@ -7,7 +7,7 @@ periodics:
     interval: 24h
     spec:
       containers:
-        - image: quay.io/powercloud/all-in-one:0.6
+        - image: quay.io/powercloud/all-in-one:0.7
           command:
             - /bin/bash
             - -c
@@ -43,7 +43,7 @@ periodics:
     interval: 24h
     spec:
       containers:
-        - image: quay.io/powercloud/all-in-one:0.6
+        - image: quay.io/powercloud/all-in-one:0.7
           command:
             - /bin/bash
             - -c

--- a/config/jobs/periodic/etcd/test-etcd-periodics.yaml
+++ b/config/jobs/periodic/etcd/test-etcd-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
         workdir: true
     spec:
       containers:
-        - image: quay.io/powercloud/all-in-one:0.6
+        - image: quay.io/powercloud/all-in-one:0.7
           resources:
             requests:
               cpu: "5000m"

--- a/config/jobs/periodic/housekeeping/cleanup-gcs-logs-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-gcs-logs-periodics.yaml
@@ -8,7 +8,7 @@ periodics:
           secret:
             secretName: gcs-credentials
       containers:
-        - image: quay.io/powercloud/all-in-one:0.6
+        - image: quay.io/powercloud/all-in-one:0.7
           command:
             - /bin/bash
           volumeMounts:

--- a/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
@@ -26,7 +26,7 @@ periodics:
     repo: perf-tests
   spec:
     containers:
-    - image: quay.io/powercloud/all-in-one:0.6
+    - image: quay.io/powercloud/all-in-one:0.7
       resources:
         requests:
           cpu: "3000m"
@@ -107,7 +107,7 @@ periodics:
     repo: perf-tests
   spec:
     containers:
-    - image: quay.io/powercloud/all-in-one:0.6
+    - image: quay.io/powercloud/all-in-one:0.7
       resources:
         requests:
           cpu: "3000m"

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
         workdir: true
     spec:
       containers:
-        - image: quay.io/powercloud/all-in-one:0.6
+        - image: quay.io/powercloud/all-in-one:0.7
           resources:
             requests:
               cpu: "5000m"
@@ -67,7 +67,7 @@ periodics:
         workdir: true
     spec:
       containers:
-        - image: quay.io/powercloud/all-in-one:0.6
+        - image: quay.io/powercloud/all-in-one:0.7
           resources:
             requests:
               cpu: "4000m"
@@ -157,7 +157,7 @@ periodics:
         workdir: true
     spec:
       containers:
-        - image: quay.io/powercloud/all-in-one:0.6
+        - image: quay.io/powercloud/all-in-one:0.7
           resources:
             requests:
               cpu: "4000m"

--- a/config/jobs/ppc64le-cloud/all-in-one/allinone-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/all-in-one/allinone-postsubmit.yaml
@@ -14,7 +14,7 @@ postsubmits:
       spec:
         serviceAccountName: build-img
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             command:
               - /bin/bash
             args:

--- a/config/jobs/ppc64le-cloud/bazel/bazel-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/bazel/bazel-postsubmit.yaml
@@ -13,7 +13,7 @@ postsubmits:
           repo: buildkit-cli-for-kubectl
       spec:
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             command:
               - /bin/bash
             args:

--- a/config/jobs/ppc64le-cloud/build-bot/buildbot-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/build-bot/buildbot-postsubmit.yaml
@@ -11,7 +11,7 @@ postsubmits:
       spec:
         serviceAccountName: build-img
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             env:
               - name: DOCKER_CONFIG
                 valueFrom:

--- a/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/etcd-postsubmit.yaml
@@ -15,7 +15,7 @@ postsubmits:
           workdir: true
       spec:
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             resources:
               requests:
                 cpu: "5000m"

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -15,7 +15,7 @@ postsubmits:
           workdir: true
       spec:
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             resources:
               requests:
                 cpu: "3000m"
@@ -83,7 +83,7 @@ postsubmits:
           workdir: true
       spec:
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             resources:
               requests:
                 cpu: "5000m"
@@ -146,7 +146,7 @@ postsubmits:
           workdir: true
       spec:
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             resources:
               requests:
                 cpu: "4000m"

--- a/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
@@ -15,7 +15,7 @@ postsubmits:
           workdir: true
       spec:
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             resources:
               requests:
                 cpu: "3000m"
@@ -70,7 +70,7 @@ postsubmits:
           workdir: true
       spec:
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             resources:
               requests:
                 cpu: "2500m"

--- a/config/jobs/ppc64le-cloud/ibm-cloud/ibmcloud-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/ibm-cloud/ibmcloud-postsubmit.yaml
@@ -12,7 +12,7 @@ postsubmits:
       spec:
         serviceAccountName: build-img
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             command:
               - /bin/bash
             args:

--- a/config/jobs/ppc64le-cloud/mkdocs/mkdocs-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/mkdocs/mkdocs-postsubmit.yaml
@@ -12,7 +12,7 @@ postsubmits:
       spec:
         serviceAccountName: build-img
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             command:
               - /bin/bash
             args:

--- a/config/jobs/ppc64le-cloud/pod-utilities/podutilities-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/pod-utilities/podutilities-postsubmit.yaml
@@ -16,7 +16,7 @@ postsubmits:
       spec:
         serviceAccountName: build-img
         containers:
-          - image: quay.io/powercloud/all-in-one:0.6
+          - image: quay.io/powercloud/all-in-one:0.7
             command:
               - /bin/bash
             args:

--- a/config/jobs/trigger-prow/test-trigger/test-prow-trigger.yaml
+++ b/config/jobs/trigger-prow/test-trigger/test-prow-trigger.yaml
@@ -6,7 +6,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-        - image: quay.io/powercloud/all-in-one:0.6
+        - image: quay.io/powercloud/all-in-one:0.7
           command:
             - /bin/bash
           args:


### PR DESCRIPTION
Postsubmit-allinone-job has passed for all-in-one:0.7 with the image pushed to powercloud/all-in-one:0.7

Job link: https://prow.ppc64le-cloud.cis.ibm.net/view/s3/ppc64le-prow-logs/logs/postsubmit-allinone-job/1805093811626446848