### PR TITLE
Update ibmcloud commands

### DIFF
--- a/config/jobs/periodic/containerd/test-containerd-powervs-periodic.yaml
+++ b/config/jobs/periodic/containerd/test-containerd-powervs-periodic.yaml
@@ -20,7 +20,7 @@ periodics:
               # Connect to IBMCloud
               echo "" | ibmcloud login
               ibmcloud target -r eu-gb -g runtimes-dev-resource-group
-              ibmcloud pi service-target crn:v1:bluemix:public:power-iaas:syd05:a/65b64c1f1c29460e8c2e4bbfbd893c2c:c3b44a6c-bc0c-4bc3-802c-b78ff68be862::
+              ibmcloud pi workspace target crn:v1:bluemix:public:power-iaas:syd05:a/65b64c1f1c29460e8c2e4bbfbd893c2c:c3b44a6c-bc0c-4bc3-802c-b78ff68be862::
 
               wget https://raw.githubusercontent.com/ppc64le-cloud/docker-ce-build/main/test-containerd/instantiate_vm_and_test.sh
               chmod +x instantiate_vm_and_test.sh
@@ -56,7 +56,7 @@ periodics:
               # Connect to IBMCloud
               echo "" | ibmcloud login
               ibmcloud target -r eu-gb -g runtimes-dev-resource-group
-              ibmcloud pi service-target crn:v1:bluemix:public:power-iaas:syd05:a/65b64c1f1c29460e8c2e4bbfbd893c2c:c3b44a6c-bc0c-4bc3-802c-b78ff68be862::
+              ibmcloud pi workspace target crn:v1:bluemix:public:power-iaas:syd05:a/65b64c1f1c29460e8c2e4bbfbd893c2c:c3b44a6c-bc0c-4bc3-802c-b78ff68be862::
 
               wget https://raw.githubusercontent.com/ppc64le-cloud/docker-ce-build/main/test-containerd/instantiate_vm_and_test.sh
               chmod +x instantiate_vm_and_test.sh


### PR DESCRIPTION
Update ibmcloud commands to match the new `ibmcloud pi` plugin version.