### PR TITLE
Upgrade Golang to 1.23.0 to fix master golang build failure

### DIFF
--- a/config/jobs/periodic/golang/build-golang-periodics.yaml
+++ b/config/jobs/periodic/golang/build-golang-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
     cron: "50 1/1 * * *"
     spec:
       containers:
-        - image: golang:1.20.6
+        - image: golang:1.23.0
           resources:
             requests:
               cpu: "2000m"


### PR DESCRIPTION
Job `periodic-golang-master-build-ppc64le` has been failing with below error since https://github.com/golang/go/commit/a4cb37d4afd4b6b386ed7b51466c8c57c6045f9c
```
+ ./make.bash
Building Go cmd/dist using /usr/local/go. (go1.20.6 linux/ppc64le)
found packages main (build.go) and building_Go_requires_Go_1_22_6_or_later (notgo122.go) in /root/go/src/cmd/dist
```

Golang build is successful when I tried with version 1.23.0
```
[root@raji-ws ~]#  rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.0.linux-ppc64le.tar.gz
[root@raji-ws ~]# go version
go version go1.23.0 linux/ppc64le
[root@raji-ws ~]# cd go_src/go/
[root@raji-ws go]# cd src/
[root@raji-ws src]# ./make.bash
Building Go cmd/dist using /usr/local/go. (go1.23.0 linux/ppc64le)
Building Go toolchain1 using /usr/local/go.
Building Go bootstrap cmd/go (go_bootstrap) using Go toolchain1.
Building Go toolchain2 using go_bootstrap and Go toolchain1.
Building Go toolchain3 using go_bootstrap and Go toolchain2.
Building packages and commands for linux/ppc64le.
---
Installed Go for linux/ppc64le in /root/go_src/go
Installed commands in /root/go_src/go/bin
*** You need to add /root/go_src/go/bin to your PATH.
[root@raji-ws src]#
```