### PR TITLE
Knative operator job added for ppc64le 

### DIFF
--- a/config/jobs/periodic/knative/operator/main/operator-main.gen.yaml
+++ b/config/jobs/periodic/knative/operator/main/operator-main.gen.yaml
@@ -1,0 +1,65 @@
+periodics:
+  - name: knative-operator-main-periodic
+    labels:
+      preset-knative-powervs: "true"
+    decorate: true
+    cron: "20 0 * * *"
+    extra_refs:
+      - base_ref: main
+        org: ppc64le-cloud
+        repo: knative-upstream-ci
+        workdir: true
+      - base_ref: main
+        org: knative
+        repo: operator
+    spec:
+      containers:
+        - image: quay.io/powercloud/knative-prow-tests:latest
+          resources:
+            requests:
+              cpu: "1500m"
+            limits:
+              cpu: "1500m"
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+
+              TIMESTAMP=$(date +%s)
+              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
+
+              kubetest2 tf --powervs-image-name CentOS9-Stream\
+                --powervs-region syd --powervs-zone syd05 \
+                --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
+                --powervs-ssh-key knative-ssh-key \
+                --ssh-private-key ~/.ssh/ssh-key \
+                --build-version $K8S_BUILD_VERSION \
+                --cluster-name knative-$TIMESTAMP \
+                --workers-count 2 \
+                --up --auto-approve --retry-on-tf-failure 5 \
+                --break-kubetest-on-upfail true \
+                --powervs-memory 32
+
+              export KUBECONFIG="$(pwd)/knative-$TIMESTAMP/kubeconfig"
+              grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $(pwd)/knative-$TIMESTAMP/hosts > HOSTS_IP
+              source setup-environment.sh HOSTS_IP
+
+              pushd $GOPATH/src/github.com/knative/operator
+              . /tmp/adjust.sh
+              ./test/e2e-tests.sh --run-tests
+              popd
+
+              kubetest2 tf --powervs-region syd --powervs-zone syd05 \
+                --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
+                --ignore-cluster-dir true \
+                --cluster-name knative-$TIMESTAMP \
+                --down --auto-approve --ignore-destroy-errors
+          env:
+          - name: CI_JOB
+            value: operator-main

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -226,6 +226,43 @@ presets:
   env:
     - name: GOPPC64
       value: power9
+# knative powervs preset
+- labels:
+    preset-knative-powervs: "true"
+  env:
+    - name: TF_VAR_powervs_api_key
+      valueFrom:
+        secretKeyRef:
+          name: knative-apikey
+          key: apikey
+    - name: KO_FLAGS
+      value: --platform=linux/ppc64le
+    - name: PLATFORM
+      value: linux/ppc64le
+    - name: INGRESS_CLASS
+      value: contour.ingress.networking.knative.dev
+    - name: KO_DOCKER_REPO
+      value: icr.io/upstream-k8s-registry/knative
+    - name: DOCKER_CONFIG
+      value: /root/.docker
+
+  volumeMounts:
+    - name: ssh-key
+      mountPath: /root/.ssh/
+      readOnly: true
+    - name: config-json
+      mountPath: /root/.docker/
+      readOnly: true
+
+  volumes:
+    - name: ssh-key
+      secret:
+        secretName: ssh-key-secret
+        defaultMode: 384 
+    - name: config-json
+      secret:
+        secretName: config-json-secret
+        defaultMode: 420
 # credentials for pushing to IBM COS
 - labels:
     preset-s3-stage-cred: "true"


### PR DESCRIPTION
With the Knative community's recent decision to disable jobs for P & Z architectures in the upstream Prow CI ([knative/infra#497](https://github.com/knative/infra/pull/497)), we are migrating the Knative CI jobs to a local Prow server to ensure continued support for Power architecture.

Here's the Slack thread for discussions & planning for this migration ([discussion thread](https://ibm-cloudplatform.slack.com/archives/G01CH7AC8H1/p1723184215935419)) to align with the community's needs while addressing the specific requirements for Power .

This PR marks the first step in a broader effort to ensure that Knative's CI infrastructure remains robust and inclusive for power arch. 

**Key Actions:**
]Initiated the migration process to our local Prow CI setup to maintain CI coverage for Power architecture, starting with the knative/operator tests, which are relatively straightforward to implement.

Further migrations will follow as we continue
