### PR TITLE
Upgrade Prow Infra to v20240827-195f38540

### DIFF
--- a/config/prow/cluster/cherrypick_deployment.yaml
+++ b/config/prow/cluster/cherrypick_deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: cherrypick
-        image: gcr.io/k8s-prow/cherrypicker:v20240711-e49eac682
+        image: us-docker.pkg.dev/k8s-infra-prow/images/cherrypicker:v20240827-195f38540
         args:
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: gcr.io/k8s-prow/crier:v20240711-e49eac682
+          image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20240827-195f38540
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/crier_github_app_deployment.yaml
+++ b/config/prow/cluster/crier_github_app_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier2
-          image: gcr.io/k8s-prow/crier:v20240711-e49eac682
+          image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20240827-195f38540
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: gcr.io/k8s-prow/deck:v20240711-e49eac682
+          image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20240827-195f38540
           args:
             - --config-path=/etc/config/config.yaml
             - --plugin-config=/etc/plugins/plugins.yaml

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20240711-e49eac682
+          image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20240827-195f38540
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: gcr.io/k8s-prow/hook:v20240711-e49eac682
+          image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20240827-195f38540
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/hook_github_app_deployment.yaml
+++ b/config/prow/cluster/hook_github_app_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook2
-          image: gcr.io/k8s-prow/hook:v20240711-e49eac682
+          image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20240827-195f38540
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: horologium
-          image: gcr.io/k8s-prow/horologium:v20240711-e49eac682
+          image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:v20240827-195f38540
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - --github-endpoint=https://api.github.com
             - --enable-controller=plank
             - --job-config-path=/etc/job-config
-          image: gcr.io/k8s-prow/prow-controller-manager:v20240711-e49eac682
+          image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20240827-195f38540
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
         - name: sinker
-          image: gcr.io/k8s-prow/sinker:v20240711-e49eac682
+          image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20240827-195f38540
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20240711-e49eac682
+          image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20240827-195f38540
           args:
             - --dry-run=false
             - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: gcr.io/k8s-prow/tide:v20240711-e49eac682
+          image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20240827-195f38540
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -80,10 +80,10 @@ plank:
       s3_credentials_secret: s3-credentials
       blobless_fetch: true
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20240711-e49eac682
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20240711-e49eac682
-        initupload: gcr.io/k8s-prow/initupload:v20240711-e49eac682
-        sidecar: gcr.io/k8s-prow/sidecar:v20240711-e49eac682
+        clonerefs:  us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20240802-66b115076
+        entrypoint: us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20240802-66b115076
+        initupload: us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20240802-66b115076
+        sidecar: us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20240802-66b115076
       ssh_key_secrets:
         - bot-ssh-secret
 


### PR DESCRIPTION
These images are as per the latest changes upstream.
They have started maintaining manifests at new location https://github.com/kubernetes/k8s.io/tree/main/kubernetes/gke-prow/prow.
These have been applied in the IKS cluster and seem to work fine. Have checked the logs and didn't find any errors/failures.
![image](https://github.com/user-attachments/assets/3598f296-e678-4a0a-83af-69e0965a8df1)
