### PR TITLE
Include "stats Summary API" e2e-node test to job

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -205,7 +205,7 @@ periodics:
                 --playbook k8s-node-remote.yml
               EXTERNAL_IP=`grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $(pwd)/config3-$TIMESTAMP/hosts`
               kubetest2 tf --test=exec -- ssh -i /etc/secret-volume/ssh-privatekey root@$EXTERNAL_IP \
-                "export SKIP='\[Flaky\]|\[Slow\]|\[Serial\]|Containers.Lifecycle.should|Summary.API|should.execute.readiness.probe.while.in.preStop' && /make-test-e2e-node.sh"; \
+                "export SKIP='\[Flaky\]|\[Slow\]|\[Serial\]|Containers.Lifecycle.should|should.execute.readiness.probe.while.in.preStop' && /make-test-e2e-node.sh"; \
                 rc=$?; scp -r -i /etc/secret-volume/ssh-privatekey root@$EXTERNAL_IP:/tmp/_artifacts $ARTIFACTS
               kubetest2 tf --powervs-region syd --powervs-zone syd05 \
                 --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \


### PR DESCRIPTION
Include `E2eNode Suite: [It] [sig-node] Summary API [NodeConformance] when querying /stats/summary should report resource usage through the stats api` testcase in job [periodic-kubernetes-containerd-e2e-node-tests-ppc64le](https://prow.ppc64le-cloud.cis.ibm.net/job-history/gs/ppc64le-kubernetes/logs/periodic-kubernetes-containerd-e2e-node-tests-ppc64le)

https://github.com/ppc64le-cloud/k8s-ansible/pull/72 allowed to add this.

Test run: https://prow.ppc64le-cloud.cis.ibm.net/view/gs/ppc64le-kubernetes/logs/test-periodic-kubernetes-containerd-e2e-node-tests-ppc64le/1842164160318672896