### PR TITLE
Change image of containerd-conformance and e2e-node jobs to kubekins-e2e

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -47,7 +47,6 @@ periodics:
               tar -C /usr/local -xzf go.tgz
               make test KUBE_RACE=-race
   - name: periodic-kubernetes-containerd-conformance-test-ppc64le
-    cluster: k8s-ppc64le-cluster
     labels:
       preset-ssh-bot: "true"
     decorate: true
@@ -61,18 +60,15 @@ periodics:
       - base_ref: master
         org: ppc64le-cloud
         repo: kubetest2-plugins
-      - base_ref: master
-        org: kubernetes-sigs
-        repo: kubetest2
         workdir: true
     spec:
       containers:
-        - image: quay.io/powercloud/all-in-one:0.7
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.31
           resources:
             requests:
-              cpu: "4000m"
+              cpu: "1500m"
             limits:
-              cpu: "4000m"
+              cpu: "1500m"
           command:
             - /bin/bash
           args:
@@ -86,12 +82,17 @@ periodics:
               export PATH=$GOPATH/bin:$PATH
               export GO111MODULE=on
 
-              make install
-              make install-tester-ginkgo
 
-              pushd ../../ppc64le-cloud/kubetest2-plugins
               make install-deployer-tf
-              popd
+              TF_LATEST="v1.9.8"
+
+              curl -fsSL https://releases.hashicorp.com/terraform/${TF_LATEST:1}/terraform_${TF_LATEST:1}_linux_amd64.zip -o ./terraform.zip
+              unzip -o ./terraform.zip  >/dev/null 2>&1
+              rm -f ./terraform.zip
+              TF="$PWD/terraform"
+              export PATH=$PWD:$PATH
+
+              apt-get update && apt-get install -y ansible
 
               TIMESTAMP=$(date +%s)
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
@@ -135,7 +136,6 @@ periodics:
               fi
 
   - name: periodic-kubernetes-containerd-e2e-node-tests-ppc64le
-    cluster: k8s-ppc64le-cluster
     labels:
       preset-golang-build: "true"
       preset-ssh-bot: "true"
@@ -151,18 +151,15 @@ periodics:
       - base_ref: master
         org: ppc64le-cloud
         repo: kubetest2-plugins
-      - base_ref: master
-        org: kubernetes-sigs
-        repo: kubetest2
         workdir: true
     spec:
       containers:
-        - image: quay.io/powercloud/all-in-one:0.7
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.31
           resources:
             requests:
-              cpu: "4000m"
+              cpu: "1500m"
             limits:
-              cpu: "4000m"
+              cpu: "1500m"
           command:
             - /bin/bash
           args:
@@ -176,12 +173,18 @@ periodics:
               export PATH=$GOPATH/bin:$PATH
               export GO111MODULE=on
 
-              make install
-              make install-tester-exec
 
-              pushd ../../ppc64le-cloud/kubetest2-plugins
               make install-deployer-tf
-              popd
+
+              TF_LATEST="v1.9.8"
+
+              curl -fsSL https://releases.hashicorp.com/terraform/${TF_LATEST:1}/terraform_${TF_LATEST:1}_linux_amd64.zip -o ./terraform.zip
+              unzip -o ./terraform.zip  >/dev/null 2>&1
+              rm -f ./terraform.zip
+              TF="$PWD/terraform"
+              export PATH=$PWD:$PATH
+
+              apt-get update && apt-get install -y ansible
 
               TIMESTAMP=$(date +%s)
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)


### PR DESCRIPTION
Modify `periodic-kubernetes-containerd-conformance-test-ppc64le` and `periodic-kubernetes-containerd-e2e-node-tests-ppc64le` jobs to use kubekins-e2e image and run on x86 cluster.

https://prow.ppc64le-cloud.cis.ibm.net/view/gs/ppc64le-kubernetes/logs/test-periodic-kubernetes-containerd-conformance-test-ppc64le/1848668882760372224 and 
https://prow.ppc64le-cloud.cis.ibm.net/view/gs/ppc64le-kubernetes/logs/test-periodic-kubernetes-containerd-e2e-node-tests-ppc64le/1848668489179467776 jobs ran successfully with this change.