### PR TITLE
Update hypershift-powervs-cleanup job to clean new infra

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-hypershift-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-hypershift-periodics.yaml
@@ -22,7 +22,9 @@ periodics:
               wget -q -O /usr/local/bin/pvsadm https://github.com/ppc64le-cloud/pvsadm/releases/download/v0.1.1-alpha.7/pvsadm-linux-ppc64le
               chmod +x /usr/local/bin/pvsadm
 
-              # delete all the vms created before 24hrs
-              pvsadm purge vms --instance-id 5ac28aa5-47b2-46b8-958f-d9c2284aab04 --before 24h --ignore-errors --no-prompt
-              pvsadm purge vms --instance-id 3358be60-dd61-41af-ab07-79139e149142 --before 24h --ignore-errors --no-prompt
+              # cleanup all the vms created in rh-upstream-hypershift-clusterbot-pvs workspace before 24hrs
+              pvsadm purge vms --instance-id 3fd2eae4-f67b-4a2d-a2fb-438bd6355eb4 --before 24h --ignore-errors --no-prompt
+              # cleanup all the vms created in rh-upstream-hypershift-powervs-e2e-ci-pvs workspace before 24hrs
+              pvsadm purge vms --instance-id bcfa4456-4be5-422a-b742-181f0cbe17d8 --before 24h --ignore-errors --no-prompt
+              # cleanup all the vms created in rh-upstream-hypershift-agent-ci workspace before 24hrs
               pvsadm purge vms --instance-id d04e2b0c-58aa-4e64-85c1-ecb5ab00d03d --before 24h --regexp '[^bastion]' --ignore-errors --no-prompt


### PR DESCRIPTION
The PowerVS Workspace for Clusterbot `(rh-upstream-hypershift-clusterbot-pvs)` and Powervs-e2e-ci `(rh-upstream-hypershift-powervs-e2e-ci-pvs)` are updated to accommodate `transit-gateway `related changes.
So, this PR updates `hypershift-powervs-cleanup` job's purge command with new instance-ids.

Testing:
The purge command was tested manually with both new service-ids.