### PR TITLE
Upload content under _artifacts(cluster logs) to GCS

### DIFF
--- a/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
@@ -61,7 +61,7 @@ periodics:
 
         echo POD_STARTUP_LATENCY_THRESHOLD: 10s >> $GOPATH/src/github.com/kubernetes/perf-tests/clusterloader2/testing/overrides/node_containerd.yaml
 
-        kubetest2 tf --powervs-dns k8s-tests \
+        kubetest2 tf --rundir-in-artifacts --powervs-dns k8s-tests \
           --powervs-image-name centos-9-stream-20Gb \
           --powervs-region syd --powervs-zone syd05 \
           --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
@@ -140,7 +140,7 @@ periodics:
         curl -sSL https://dl.k8s.io/ci/$K8S_BUILD_VERSION/bin/linux/`go env GOARCH`/kubectl > /usr/local/bin/kubectl
         chmod +x /usr/local/bin/kubectl
 
-        kubetest2 tf --powervs-dns k8s-tests \
+        kubetest2 tf --rundir-in-artifacts --powervs-dns k8s-tests \
           --powervs-image-name centos-9-stream-20Gb \
           --powervs-region syd --powervs-zone syd05 \
           --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -254,7 +254,7 @@ periodics:
               chmod +x /usr/local/bin/kubectl
 
               set +o errexit
-              kubetest2 tf --powervs-dns k8s-tests \
+              kubetest2 tf --rundir-in-artifacts --powervs-dns k8s-tests \
                 --powervs-image-name centos-9-stream-20Gb \
                 --powervs-region syd --powervs-zone syd05 \
                 --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -190,7 +190,7 @@ postsubmits:
                 wget -qO- $URL/kubernetes-client-linux-ppc64le.tar.gz | tar xz -C /usr/local/bin --strip-components=3
 
                 set +o errexit
-                kubetest2 tf --powervs-dns k8s-tests \
+                kubetest2 tf --rundir-in-artifacts --powervs-dns k8s-tests \
                     --powervs-image-name centos-9-stream-20Gb \
                     --powervs-region syd --powervs-zone syd05 \
                     --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \


### PR DESCRIPTION
Adding changes to support uploading of cluster logs which is available under the _rundir directory to be uploaded to the bucket.

Ref: https://github.com/kubernetes-sigs/kubetest2/blob/4799c63b607af619efc614d976272c70b6bd27cc/pkg/app/cmd.go#L213