### PR TITLE
Change OS image of k8s cluster in conformance job

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -174,7 +174,7 @@ periodics:
 
               set -o xtrace
               kubetest2 tf --powervs-dns k8s-tests \
-                --powervs-image-name centos-9-stream-20Gb \
+                --powervs-image-name CentOS-Stream-9 \
                 --powervs-region ${BOSKOS_REGION} --powervs-zone ${BOSKOS_ZONE} \
                 --powervs-service-id ${BOSKOS_RESOURCE_ID} \
                 --powervs-ssh-key powercloud-bot-key \


### PR DESCRIPTION
Job `periodic-kubernetes-containerd-conformance-test-ppc64le` will use `CentOS-Stream-9` IBMCloud PowerVS's stock catalog image instead of the currently used custom image.