### PR TITLE
Knative Eventing - prow jobs to run upstream testing CI job

### DIFF
--- a/config/jobs/periodic/knative/eventing/eventing-main.yaml
+++ b/config/jobs/periodic/knative/eventing/eventing-main.yaml
@@ -1,0 +1,76 @@
+periodics:
+  - name: knative-eventing-main-periodic
+    labels:
+      preset-knative-powervs: "true"
+    decorate: true
+    cron: "0 2 * * *"
+    extra_refs:
+      - base_ref: main
+        org: ppc64le-cloud
+        repo: knative-upstream-ci
+        workdir: true
+      - base_ref: main
+        org: knative
+        repo: eventing
+    spec:
+      containers:
+        - image: quay.io/powercloud/knative-prow-tests:latest
+          resources:
+            requests:
+              cpu: "1500m"
+            limits:
+              cpu: "1500m"
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+
+              TIMESTAMP=$(date +%Y%m%d%H%M%S%3N)
+              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
+
+              cleanup() {
+                pushd $GOPATH/src/github.com/ppc64le-cloud/knative-upstream-ci
+                kubetest2 tf --powervs-region syd --powervs-zone syd05 \
+                  --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
+                  --ignore-cluster-dir true \
+                  --cluster-name knative-$TIMESTAMP \
+                  --down --auto-approve --ignore-destroy-errors
+                popd
+              }
+
+              trap cleanup EXIT
+
+              kubetest2 tf --powervs-image-name CentOS9-Stream\
+                --powervs-region syd --powervs-zone syd05 \
+                --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
+                --powervs-ssh-key knative-ssh-key \
+                --ssh-private-key ~/.ssh/ssh-key \
+                --build-version $K8S_BUILD_VERSION \
+                --cluster-name knative-$TIMESTAMP \
+                --workers-count 2 \
+                --up --auto-approve --retry-on-tf-failure 5 \
+                --break-kubetest-on-upfail true \
+                --powervs-memory 32
+
+              export KUBECONFIG="$(pwd)/knative-$TIMESTAMP/kubeconfig"
+              grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $(pwd)/knative-$TIMESTAMP/hosts > HOSTS_IP
+              source setup-environment.sh HOSTS_IP
+
+              pushd $GOPATH/src/github.com/knative/eventing
+              . /tmp/adjust.sh
+              ./test/e2e-tests.sh --run-tests
+              popd
+
+          env:
+            - name: CI_JOB
+              value: eventing-main
+            - name: SYSTEM_NAMESPACE
+              value: knative-eventing
+            - name: SCALE_CHAOSDUCK_TO_ZERO
+              value: "1"

--- a/config/jobs/periodic/knative/eventing/eventing-release-1.16.yaml
+++ b/config/jobs/periodic/knative/eventing/eventing-release-1.16.yaml
@@ -1,0 +1,76 @@
+periodics:
+  - name: knative-eventing-release-1.16-periodic
+    labels:
+      preset-knative-powervs: "true"
+    decorate: true
+    cron: "0 8 * * *"
+    extra_refs:
+      - base_ref: main
+        org: ppc64le-cloud
+        repo: knative-upstream-ci
+        workdir: true
+      - base_ref: release-1.16
+        org: knative
+        repo: eventing
+    spec:
+      containers:
+        - image: quay.io/powercloud/knative-prow-tests:latest
+          resources:
+            requests:
+              cpu: "1500m"
+            limits:
+              cpu: "1500m"
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+
+              TIMESTAMP=$(date +%Y%m%d%H%M%S%3N)
+              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
+
+              cleanup() {
+                pushd $GOPATH/src/github.com/ppc64le-cloud/knative-upstream-ci
+                kubetest2 tf --powervs-region syd --powervs-zone syd05 \
+                  --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
+                  --ignore-cluster-dir true \
+                  --cluster-name knative-$TIMESTAMP \
+                  --down --auto-approve --ignore-destroy-errors
+                popd
+              }
+
+              trap cleanup EXIT
+
+              kubetest2 tf --powervs-image-name CentOS9-Stream\
+                --powervs-region syd --powervs-zone syd05 \
+                --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
+                --powervs-ssh-key knative-ssh-key \
+                --ssh-private-key ~/.ssh/ssh-key \
+                --build-version $K8S_BUILD_VERSION \
+                --cluster-name knative-$TIMESTAMP \
+                --workers-count 2 \
+                --up --auto-approve --retry-on-tf-failure 5 \
+                --break-kubetest-on-upfail true \
+                --powervs-memory 32
+
+              export KUBECONFIG="$(pwd)/knative-$TIMESTAMP/kubeconfig"
+              grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $(pwd)/knative-$TIMESTAMP/hosts > HOSTS_IP
+              source setup-environment.sh HOSTS_IP
+
+              pushd $GOPATH/src/github.com/knative/eventing
+              . /tmp/adjust.sh
+              ./test/e2e-tests.sh --run-tests
+              popd
+
+          env:
+            - name: CI_JOB
+              value: eventing-release-1.16
+            - name: SYSTEM_NAMESPACE
+              value: knative-eventing
+            - name: SCALE_CHAOSDUCK_TO_ZERO
+              value: "1"


### PR DESCRIPTION
This PR refers dropping off of Knative Eventing jobs: https://github.com/knative/infra/pull/497/files#diff-8de52f6a751c3e2c071ef708fdae694043a7cf4b9d173bb7e2e2e6b51c0483e4.
Added updated prow jobs scripts to run Knative Eventing (main, release-1.15 & release-1.16) testing CI jobs.
This PR requires merging of PR: https://github.com/ppc64le-cloud/knative-upstream-ci/pull/14
