### PR TITLE
Change k8s UT Job to run as non-root user on powervs

### DIFF
--- a/config/jobs/CLUSTERCONFIGS.md
+++ b/config/jobs/CLUSTERCONFIGS.md
@@ -5,3 +5,4 @@
 | config1-\<Timestamp\> | periodic-kubernetes-containerd-conformance-test-ppc64le      | latest nightly build from upstream                                 | containerd | To run conformance tests from e2e suite        |
 | config2-\<Timestamp\> | postsubmit-master-golang-kubernetes-conformance-test-ppc64le | k8s built by job postsubmit-kubernetes-build-golang-master-ppc64le | containerd     | To run conformance tests from e2e suite         |
 | config3-\<Timestamp\> | periodic-kubernetes-containerd-e2e-node-tests-ppc64le | latest nightly build from upstream | containerd | To run NodeConformace tests from e2e-node suite |
+| config4-\<Timestamp\> | periodic-kubernetes-unit-tests-non-root-ppc64le | k8s upstream master | N/A | To run Unit Tests using make test |

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -1,5 +1,77 @@
 periodics:
-  - name: periodic-kubernetes-unit-test-ppc64le
+  - name: periodic-kubernetes-unit-tests-non-root-ppc64le
+    labels:
+      preset-ssh-bot: "true"
+    decorate: true
+    decoration_config:
+      gcs_configuration:
+        bucket: ppc64le-kubernetes
+        path_strategy: explicit
+      gcs_credentials_secret: gcs-credentials
+    cron: "0 1/3 * * *"
+    extra_refs:
+      - base_ref: master
+        org: ppc64le-cloud
+        repo: kubetest2-plugins
+        workdir: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20241021-d3a4913879-1.31
+          resources:
+            requests:
+              cpu: "1500m"
+            limits:
+              cpu: "1500m"
+          command:
+            - /bin/bash
+          args:
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+
+              export PATH=$GOPATH/bin:$PATH
+              export GO111MODULE=on
+
+
+              make install-deployer-tf
+
+              TF_LATEST="v1.9.8"
+
+              curl -fsSL https://releases.hashicorp.com/terraform/${TF_LATEST:1}/terraform_${TF_LATEST:1}_linux_amd64.zip -o ./terraform.zip
+              unzip -o ./terraform.zip  >/dev/null 2>&1
+              rm -f ./terraform.zip
+              TF="$PWD/terraform"
+              export PATH=$PWD:$PATH
+
+              apt-get update && apt-get install -y ansible
+
+              TIMESTAMP=$(date +%s)
+
+              set +o errexit
+              kubetest2 tf --powervs-image-name CentOS-Stream-9 \
+                --powervs-region syd --powervs-zone syd05 \
+                --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
+                --powervs-ssh-key powercloud-bot-key \
+                --ssh-private-key /etc/secret-volume/ssh-privatekey \
+                --cluster-name config4-$TIMESTAMP \
+                --up --set-kubeconfig=false --auto-approve \
+                --retry-on-tf-failure 3 \
+                --break-kubetest-on-upfail true --powervs-memory 32 \
+                --playbook k8s-ut-remote.yml
+              EXTERNAL_IP=`grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $(pwd)/config4-$TIMESTAMP/hosts`
+              kubetest2 tf --test=exec -- ssh -i /etc/secret-volume/ssh-privatekey root@$EXTERNAL_IP \
+                "/make-test.sh"; \
+                rc=$?; scp -r -i /etc/secret-volume/ssh-privatekey root@$EXTERNAL_IP:/home/nonroot/artifacts $ARTIFACTS
+              kubetest2 tf --powervs-region syd --powervs-zone syd05 \
+                --powervs-service-id c3f5354a-517e-4927-8523-890c4bf3d6c5 \
+                --ignore-cluster-dir true \
+                --cluster-name config4-$TIMESTAMP \
+                --down --auto-approve --ignore-destroy-errors
+              [ $rc != 0 ] && echo "ERROR: Unit Test suite exited with code:$rc"; exit $rc
+  - name: periodic-kubernetes-unit-test-root-ppc64le
     cluster: k8s-ppc64le-cluster
     labels:
       preset-golang-build: "true"
@@ -9,7 +81,7 @@ periodics:
         bucket: ppc64le-kubernetes
         path_strategy: explicit
       gcs_credentials_secret: gcs-credentials
-    cron: "0 1/3 * * *"
+    cron: "0 0 * * 1,4"
     extra_refs:
       - base_ref: master
         org: kubernetes
@@ -36,15 +108,6 @@ periodics:
               export KUBE_TIMEOUT='--timeout=600s'
               export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
               export LOG_LEVEL=4
-              wget -q -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_ppc64le
-              chmod +x /usr/local/bin/yq
-              pushd ./build/
-              GOLANG_VERSION=`yq read dependencies.yaml 'dependencies(name==golang: upstream*).version'`
-              popd
-              url="https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-ppc64le.tar.gz"
-              wget -O go.tgz "$url" --progress=dot:giga
-              rm -rf /usr/local/go
-              tar -C /usr/local -xzf go.tgz
               make test KUBE_RACE=-race
   - name: periodic-kubernetes-containerd-conformance-test-ppc64le
     labels:


### PR DESCRIPTION
This is to change the way k8s UT job is running.
- Will make the existing job that runs as root user(on test-pod in ppc64le build cluster) to run only twice a week.
- Adding a new job that runs UT in a VM in Power VS created using `kubetest2 tf` pointing to play book added by https://github.com/ppc64le-cloud/k8s-ansible/pull/79