### PR TITLE
Modify k8s conformance job to use new Secrest from SM

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -111,9 +111,8 @@ periodics:
               make test KUBE_RACE=-race
   - name: periodic-kubernetes-containerd-conformance-test-ppc64le
     labels:
-      preset-ssh-bot: "true"
       preset-dind-enabled: "true"
-      preset-s3-stage-cred: "true"
+      preset-ibmcloud-cred: "true"
     decorate: true
     decoration_config:
       gcs_configuration:
@@ -179,13 +178,13 @@ periodics:
               apt-get update && apt-get install -y ansible
 
               # Details of IBM S3 storage
-              S3_SERVER=s3.us-south.cloud-object-storage.appdomain.cloud
-              BUCKET=ppc64le-ci-builds
+              S3_SERVER=s3.us.cloud-object-storage.appdomain.cloud
+              BUCKET=k8s-infra-cos-bucket
               DIRECTORY=ci
 
               # Build and push artifacts to IBM COS
               REPOROOT=../../kubernetes/kubernetes
-              kubetest2 tf --build --repo-root $REPOROOT --stage cos://us-south/$BUCKET/$DIRECTORY
+              kubetest2 tf --build --repo-root $REPOROOT --stage cos://us/$BUCKET/$DIRECTORY --cos-cred-type cos_hmac
               K8S_BUILD_VERSION=`cat $REPOROOT/_output/release-stage/server/linux-ppc64le/kubernetes/version`
 
               TIMESTAMP=$(date +%s)
@@ -234,11 +233,10 @@ periodics:
               fi
 
               set -o xtrace
-              kubetest2 tf --powervs-dns k8s-tests \
-                --powervs-image-name CentOS-Stream-9 \
+              kubetest2 tf --powervs-image-name CentOS-Stream-9 \
                 --powervs-region ${BOSKOS_REGION} --powervs-zone ${BOSKOS_ZONE} \
                 --powervs-service-id ${BOSKOS_RESOURCE_ID} \
-                --powervs-ssh-key powercloud-bot-key \
+                --powervs-ssh-key k8s-infra-sshkey \
                 --ssh-private-key /etc/secret-volume/ssh-privatekey \
                 --s3-server $S3_SERVER --bucket $BUCKET  --directory $DIRECTORY \
                 --extra-vars=k8s_tar_bundles:kubernetes-server-linux-ppc64le.tar.gz \

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -263,15 +263,27 @@ presets:
       secret:
         secretName: config-json-secret
         defaultMode: 420
-# credentials for pushing to IBM COS
 - labels:
-    preset-s3-stage-cred: "true"
+    preset-ibmcloud-cred: "true"
   volumeMounts:
-    - mountPath: /root/.aws
-      name: s3-stage-credentials
+    - mountPath: /etc/secret-volume
+      name: k8s-infra-ssh-key
       readOnly: true
+    - mountPath: /root/.ibmcloud
+      name: s3-hmac-credentials
+      readOnly: true
+  env:
+    - name: TF_VAR_powervs_api_key
+      valueFrom:
+        secretKeyRef:
+          name: ibmcloud-iam
+          key: key
   volumes:
-    - name: s3-stage-credentials
+    - name: k8s-infra-ssh-key
       secret:
         defaultMode: 256
-        secretName: s3-stage-credentials
+        secretName: k8s-infra-ssh-key
+    - name: s3-hmac-credentials
+      secret:
+        defaultMode: 256
+        secretName: s3-hmac-credentials

--- a/config/prow/external-secrets/cos-service-creds.yaml
+++ b/config/prow/external-secrets/cos-service-creds.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: s3-hmac-credentials
+  namespace: test-pods
+spec:
+  refreshInterval: 60m
+  secretStoreRef:
+    name: secretstore-ibm-k8s-infra
+    kind: ClusterSecretStore
+  target:
+    name: s3-hmac-credentials
+    creationPolicy: Owner
+  data:
+  - secretKey: hmac_credentials
+    remoteRef:
+      key: service_credentials/c1286cb2-95f2-1814-e501-17fa8013548f

--- a/config/prow/external-secrets/iam-cred.yaml
+++ b/config/prow/external-secrets/iam-cred.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ibmcloud-iam
+  namespace: test-pods
+spec:
+  refreshInterval: 60m
+  secretStoreRef:
+    name: secretstore-ibm-k8s-infra
+    kind: ClusterSecretStore
+  target:
+    name: ibmcloud-iam
+    creationPolicy: Owner
+  data: 
+  - secretKey: key
+    remoteRef:
+      key: iam_credentials/bfdb638a-3d0e-3b1b-0b30-6dd97b899559

--- a/config/prow/external-secrets/secretstore-ibm-k8s-infra.yaml
+++ b/config/prow/external-secrets/secretstore-ibm-k8s-infra.yaml
@@ -1,0 +1,14 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: secretstore-ibm-k8s-infra
+spec:
+  provider:
+    ibm:
+      serviceUrl: "https://5fb5cabf-7ab9-4ba8-9f58-85bf1b8c470e.us-south.secrets-manager.appdomain.cloud"
+      auth:
+        secretRef:
+          secretApiKeySecretRef:
+            name: admin-ibm-cloud
+            key: ADMIN_API_KEY
+            namespace: test-pods

--- a/config/prow/external-secrets/ssh-private-key.yaml
+++ b/config/prow/external-secrets/ssh-private-key.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: k8s-infra-ssh-key
+  namespace: test-pods
+spec:
+  refreshInterval: 60m
+  secretStoreRef:
+    name: secretstore-ibm-k8s-infra
+    kind: ClusterSecretStore
+  target:
+    name: k8s-infra-ssh-key
+    creationPolicy: Owner
+  data: 
+  - secretKey: ssh-privatekey
+    remoteRef:
+      key: df7624a8-d6c0-59ba-27e2-b560e21b8f48


### PR DESCRIPTION
Change the conformance job to use the new secrets from Secrets Manager.

https://prow.ppc64le-cloud.cis.ibm.net/view/gs/ppc64le-kubernetes/logs/test-periodic-kubernetes-containerd-conformance-test-ppc64le/1859851409806069760 worked fine with this change.