### PR TITLE
Change k8s UT Job name to suit testgrid

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -1,5 +1,5 @@
 periodics:
-  - name: periodic-kubernetes-unit-tests-non-root-ppc64le
+  - name: periodic-kubernetes-unit-test-ppc64le
     labels:
       preset-ssh-bot: "true"
     decorate: true


### PR DESCRIPTION
The last [PR](https://github.com/ppc64le-cloud/test-infra/pull/505) for UT job to running as non-root user has changed the name from [periodic-kubernetes-unit-test-ppc64le](https://prow.k8s.io/job-history/gs/ppc64le-kubernetes/logs/periodic-kubernetes-unit-test-ppc64le) to [periodic-kubernetes-unit-tests-non-root-ppc64le](https://prow.ppc64le-cloud.cis.ibm.net/job-history/gs/ppc64le-kubernetes/logs/periodic-kubernetes-unit-tests-non-root-ppc64le) and [periodic-kubernetes-unit-test-root-ppc64le](https://prow.k8s.io/job-history/gs/ppc64le-kubernetes/logs/periodic-kubernetes-unit-test-root-ppc64le).

The display of UT job testgrid is hindered because of this name change! :disappointed:
https://testgrid.k8s.io/ibm-k8s-unit-tests-ppc64le#periodic-k8s-unit-tests-ppc64le
