### PR TITLE
Install only required testers for corresponding jobs

### DIFF
--- a/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
@@ -45,7 +45,7 @@ periodics:
         export PATH=$GOPATH/bin:$PATH
         export GO111MODULE=on
 
-        make install-all
+        make install install-tester-clusterloader2
 
         pushd ../../ppc64le-cloud/kubetest2-plugins
         make install-deployer-tf
@@ -126,7 +126,7 @@ periodics:
         export PATH=$GOPATH/bin:$PATH
         export GO111MODULE=on
 
-        make install-all
+        make install install-tester-exec
 
         pushd ../../ppc64le-cloud/kubetest2-plugins
         make install-deployer-tf


### PR DESCRIPTION
This PR aims at installing only the required deployers and testers for the corresponding jobs.
Some stats from a 4vCPU/8GB test-machine, with the modcache being cleared before every installation for a fair comparison. 

```
make install-all
...
install -d /usr/local/go/bin
install -d /usr/local/go/bin
install /root/kubetest2/bin/kubetest2-tester-ginkgo /usr/local/go/bin/kubetest2-tester-ginkgo
install /root/kubetest2/bin/kubetest2-kind /usr/local/go/bin/kubetest2-kind
install -d /usr/local/go/bin
install /root/kubetest2/bin/kubetest2-gke /usr/local/go/bin/kubetest2-gke
install -d /usr/local/go/bin
install /root/kubetest2/bin/kubetest2-gce /usr/local/go/bin/kubetest2-gce
make[1]: Leaving directory '/root/kubetest2'

real	5m2.571s         <------
user	16m7.339s
sys	2m25.694s


Installing just the required components (Kubetest2 - testers: clusterloader and exec)
--------------
[root@kubetest21 kubetest2]# time make install
warning: GOPATH set to GOROOT (/usr/local/go) has no effect
go build -v -trimpath -ldflags="-buildid= -X=sigs.k8s.io/kubetest2/pkg/app/shim.GitTag=v20241202-4294dbe" -o /root/kubetest2/bin/kubetest2 .
go: downloading github.com/spf13/pflag v1.0.5
go: downloading github.com/spf13/cobra v1.8.0
install -d /usr/local/go/bin
install /root/kubetest2/bin/kubetest2 /usr/local/go/bin/kubetest2

real	0m1.068s
user	0m0.461s
sys	0m0.211s


[root@kubetest21 kubetest2]# time make install-tester-clusterloader2
......
install -d /usr/local/go/bin
install /root/kubetest2/bin/kubetest2-tester-clusterloader2 /usr/local/go/bin/kubetest2-tester-clusterloader2

real	0m1.114s
user	0m0.457s
sys	0m0.236s

[root@kubetest21 kubetest2]#  time make install-tester-exec
.....
install -d /usr/local/go/bin
install /root/kubetest2/bin/kubetest2-tester-exec /usr/local/go/bin/kubetest2-tester-exec

real	0m1.196s
user	0m0.441s
sys	0m0.213s
```


The only required testers and deployers required as as follows:
```
[root@kubetest21 kubetest2-plugins]# kubetest2
kubetest2 is a tool for kubernetes end to end testing.

It orchestrates creating clusters, building kubernetes, deleting clusters, running tests, etc.

kubetest2 should be called with a deployer like: 'kubetest2 kind --help'

For more information see: https://github.com/kubernetes-sigs/kubetest2

Usage:
  kubetest2 [deployer] [flags]

Detected Deployers:
  tf

Detected Testers:
  clusterloader2
  exec
  ```
  
  Tests were successfully executed with the above testers.