### PR TITLE
Correct K8s Version path for 1-30 release job

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-1.30-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-1.30-periodics.yaml
@@ -148,7 +148,7 @@ periodics:
               # Build and push artifacts to IBM COS
               REPOROOT=../../kubernetes/kubernetes
               kubetest2 tf --build --repo-root $REPOROOT --stage cos://us/$BUCKET/$DIRECTORY --cos-cred-type cos_hmac
-              K8S_BUILD_VERSION=`cat $REPOROOT/_output/release-stage/server/linux-ppc64le/kubernetes/version`
+              K8S_BUILD_VERSION=`cat $REPOROOT/_output/release-stage/full/kubernetes/version`
 
               TIMESTAMP=$(date +%s)
               jq --arg key0 'k8s-build-version' --arg value0 $K8S_BUILD_VERSION '. | .[$key0]=$value0' <<<'{}' > $ARTIFACTS/metadata.json


### PR DESCRIPTION
For `release-1.30` the version path was different. Hence the job failure https://prow.ppc64le-cloud.cis.ibm.net/view/gs/ppc64le-kubernetes/logs/periodic-kubernetes-containerd-conformance-test-ppc64le-1-30/1864550409314504704

Ref: https://github.com/kubernetes/kubernetes/pull/125076