### PR TITLE
Enable Docker CI

### DIFF
--- a/config/jobs/periodic/docker/periodic-ci-docker.yaml
+++ b/config/jobs/periodic/docker/periodic-ci-docker.yaml
@@ -1,0 +1,108 @@
+periodics:
+    - name: periodic-config-docker
+      cluster: k8s-ppc64le-cluster
+      labels:
+        preset-build-docker: "true"
+      cron: 0 0 * * *
+      decorate: true
+      extra_refs:
+        - base_ref: main
+          org: ppc64le-cloud
+          repo: docker-ce-build
+      reporter_config:
+        slack:
+          channel: 'prow-job-notifications'
+          job_states_to_report:
+           - failure
+           - error
+          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
+      spec:
+        containers:
+        - image: quay.io/powercloud/docker-ce-build@sha256:b1e2679b9a5aabe15a94ae3130f5b02ce67441cf361fda7dc7a41929bb50ba87
+          resources:
+            requests:
+              cpu: "4000m"
+            limits:
+              cpu: "4000m"
+          command:
+          - /bin/bash
+          args:
+          - -c
+          - |
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+            set -o xtrace
+
+            # Set the SSH key for git from the secret 'git-ssh-docker-ce-build'
+            echo "* Set up the ssh key for git *"
+            mkdir -p ~/.ssh
+            cp /etc/ssh-key/ssh-privatekey  ~/.ssh/id_rsa
+            chmod 600 ~/.ssh/id_rsa
+            ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+
+            echo "* Start prow-info-docker *"
+            chmod ug+x $PWD/upstream-master-ci/prow-info-docker.sh
+            $PWD/upstream-master-ci/prow-info-docker.sh
+            rc=$?
+            [ $rc != 0 ] && echo "ERROR: prow-info-docker exited with code:$rc"
+            exit $rc
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: boot
+            mountPath: /boot
+          - name: ssh-key
+            readOnly: true
+            mountPath: /etc/ssh-key
+        volumes:
+        - name: boot
+          hostpath:
+            path: /boot/
+            volumes:
+        - name: ssh-key
+          secret:
+           secretName: git-ssh-docker-ce-build
+
+    - name: periodic-build-dev-image-docker
+      cluster: k8s-ppc64le-cluster
+      labels:
+        preset-build-docker: "true"
+      cron: 10 0 * * *
+      decorate: true
+      extra_refs:
+        - base_ref: main
+          org: ppc64le-cloud
+          repo: docker-ce-build
+      reporter_config:
+        slack:
+          channel: 'prow-job-notifications'
+          job_states_to_report:
+           - failure
+           - error
+          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
+      spec:
+        containers:
+        - image: quay.io/powercloud/docker-ce-build@sha256:b1e2679b9a5aabe15a94ae3130f5b02ce67441cf361fda7dc7a41929bb50ba87
+          resources:
+            requests:
+              cpu: "4000m"
+            limits:
+              cpu: "4000m"
+          command:
+          - /bin/bash
+          args:
+          - -c
+          - |
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+            set -o xtrace
+            echo "* Start prow-build-dev-image *"
+            chmod ug+x $PWD/upstream-master-ci/prow-build-dev-image.sh
+            $PWD/upstream-master-ci/prow-build-dev-image.sh
+            rc=$?
+            [ $rc != 0 ] && echo "ERROR: prow-build-dev-image exited with code:$rc"
+            exit $rc
+          securityContext:
+            privileged: true

--- a/config/jobs/periodic/docker/periodic-ci-docker.yaml
+++ b/config/jobs/periodic/docker/periodic-ci-docker.yaml
@@ -9,13 +9,6 @@ periodics:
         - base_ref: main
           org: ppc64le-cloud
           repo: docker-ce-build
-      reporter_config:
-        slack:
-          channel: 'prow-job-notifications'
-          job_states_to_report:
-           - failure
-           - error
-          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
         - image: quay.io/powercloud/docker-ce-build@sha256:b1e2679b9a5aabe15a94ae3130f5b02ce67441cf361fda7dc7a41929bb50ba87
@@ -74,13 +67,6 @@ periodics:
         - base_ref: main
           org: ppc64le-cloud
           repo: docker-ce-build
-      reporter_config:
-        slack:
-          channel: 'prow-job-notifications'
-          job_states_to_report:
-           - failure
-           - error
-          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
         - image: quay.io/powercloud/docker-ce-build@sha256:b1e2679b9a5aabe15a94ae3130f5b02ce67441cf361fda7dc7a41929bb50ba87

--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-ci-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-ci-docker.yaml
@@ -1,0 +1,161 @@
+postsubmits:
+ ppc64le-cloud/docker-ce-build:
+    - name: postsubmit-unit-test-docker
+      cluster: k8s-ppc64le-cluster
+      labels:
+        preset-build-docker: "true"
+      decorate: true
+      decoration_config:
+        timeout: 2h
+      run_if_changed: 'job/periodic-config-docker'
+      reporter_config:
+        slack:
+          channel: 'prow-job-notifications'
+          job_states_to_report:
+           - failure
+           - error
+          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
+      branches:
+        - prow-job-tracking
+      spec:
+        containers:
+        - image: quay.io/powercloud/docker-ce-build@sha256:b1e2679b9a5aabe15a94ae3130f5b02ce67441cf361fda7dc7a41929bb50ba87
+          resources:
+            requests:
+              cpu: "4000m"
+            limits:
+              cpu: "4000m"
+          command:
+          - /bin/bash
+          args:
+          - -c
+          - |
+            ##
+            # This job is populated with the files from the 'prow-job-tracking' branch.
+            # We switch to the 'main' branch, as it contains the scripts used by this job.
+            ###
+
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+            set -o xtrace
+
+            #Set this to your dev branch for testing
+            WORK_BRANCH=main
+            git fetch https://github.com/${REPO_OWNER}/${REPO_NAME} ${WORK_BRANCH}
+            git checkout ${WORK_BRANCH}
+            echo "* Start prow-unit-test-docker *"
+            chmod ug+x $PWD/upstream-master-ci/prow-unit-test-docker.sh
+            $PWD/upstream-master-ci/prow-unit-test-docker.sh
+            rc=$?
+            [ $rc != 0 ] && echo "ERROR: prow-unit-test-docker exited with code:$rc"
+            exit $rc
+
+          securityContext:
+            privileged: true
+    - name: postsubmit-integration-cli-docker
+      cluster: k8s-ppc64le-cluster
+      labels:
+        preset-build-docker: "true"
+      decorate: true
+      decoration_config:
+        timeout: 2h
+      run_if_changed: 'job/periodic-config-docker'
+      reporter_config:
+        slack:
+          channel: 'prow-job-notifications'
+          job_states_to_report:
+           - failure
+           - error
+          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
+      branches:
+        - prow-job-tracking
+      spec:
+        containers:
+        - image: quay.io/powercloud/docker-ce-build@sha256:b1e2679b9a5aabe15a94ae3130f5b02ce67441cf361fda7dc7a41929bb50ba87
+          resources:
+            requests:
+              cpu: "4000m"
+            limits:
+              cpu: "4000m"
+          command:
+          - /bin/bash
+          args:
+          - -c
+          - |
+            ##
+            # This job is populated with the files from the 'prow-job-tracking' branch.
+            # We switch to the 'main' branch, as it contains the scripts used by this job.
+            ###
+
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+            set -o xtrace
+
+            #Set this to your dev branch for testing
+            WORK_BRANCH=main
+            git fetch https://github.com/${REPO_OWNER}/${REPO_NAME} ${WORK_BRANCH}
+            git checkout ${WORK_BRANCH}
+            echo "* Start prow-integration-cli-docker *"
+            chmod ug+x $PWD/upstream-master-ci/prow-integration-cli.sh
+            $PWD/upstream-master-ci/prow-integration-cli.sh
+            rc=$?
+            [ $rc != 0 ] && echo "ERROR: prow-integration-cli-docker exited with code:$rc"
+            exit $rc
+
+          securityContext:
+            privileged: true
+    - name: postsubmit-integration-test-docker
+      cluster: k8s-ppc64le-cluster
+      labels:
+        preset-build-docker: "true"
+      decorate: true
+      decoration_config:
+        timeout: 2h
+      run_if_changed: 'job/periodic-config-docker'
+      reporter_config:
+        slack:
+          channel: 'prow-job-notifications'
+          job_states_to_report:
+           - failure
+           - error
+          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
+      branches:
+        - prow-job-tracking
+      spec:
+        containers:
+        - image: quay.io/powercloud/docker-ce-build@sha256:b1e2679b9a5aabe15a94ae3130f5b02ce67441cf361fda7dc7a41929bb50ba87
+          resources:
+            requests:
+              cpu: "4000m"
+            limits:
+              cpu: "4000m"
+          command:
+          - /bin/bash
+          args:
+          - -c
+          - |
+            ##
+            # This job is populated with the files from the 'prow-job-tracking' branch.
+            # We switch to the 'main' branch, as it contains the scripts used by this job.
+            ###
+
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+            set -o xtrace
+
+            #Set this to your dev branch for testing
+            WORK_BRANCH=main
+            git fetch https://github.com/${REPO_OWNER}/${REPO_NAME} ${WORK_BRANCH}
+            git checkout ${WORK_BRANCH}
+            echo "* Start prow-integration-test-docker *"
+            chmod ug+x $PWD/upstream-master-ci/prow-integration-tests.sh
+            $PWD/upstream-master-ci/prow-integration-tests.sh
+            rc=$?
+            [ $rc != 0 ] && echo "ERROR: prow-integration-test-docker exited with code:$rc"
+            exit $rc
+
+          securityContext:
+            privileged: true

--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-ci-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-ci-docker.yaml
@@ -8,13 +8,6 @@ postsubmits:
       decoration_config:
         timeout: 2h
       run_if_changed: 'job/periodic-config-docker'
-      reporter_config:
-        slack:
-          channel: 'prow-job-notifications'
-          job_states_to_report:
-           - failure
-           - error
-          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       branches:
         - prow-job-tracking
       spec:
@@ -61,13 +54,6 @@ postsubmits:
       decoration_config:
         timeout: 2h
       run_if_changed: 'job/periodic-config-docker'
-      reporter_config:
-        slack:
-          channel: 'prow-job-notifications'
-          job_states_to_report:
-           - failure
-           - error
-          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       branches:
         - prow-job-tracking
       spec:
@@ -114,13 +100,6 @@ postsubmits:
       decoration_config:
         timeout: 2h
       run_if_changed: 'job/periodic-config-docker'
-      reporter_config:
-        slack:
-          channel: 'prow-job-notifications'
-          job_states_to_report:
-           - failure
-           - error
-          report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       branches:
         - prow-job-tracking
       spec:

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -13,6 +13,15 @@ slack_reporter_configs:
       - error
     channel: prow-job-notifications
     report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S01E9J0G3EU> <{{.Status.URL}}|View logs>'
+  ppc64le-cloud/docker-ce-build:
+    job_types_to_report:
+      - postsubmit
+      - periodic
+    job_states_to_report:
+      - failure
+      - error
+    channel: prow-job-notifications
+    report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
 
 in_repo_config:
   enabled:


### PR DESCRIPTION
The purpose of each job:

1. periodic-config-docker: Check the configuration of the kernel for suitability to run Docker.
2. periodic-build-dev-image-docker: Build a minimal Docker development image.
3. postsubmit-unit-test-docker: Run unit tests against https://github.com/moby/moby
4. postsubmit-integration-test-docker: Run integration tests against https://github.com/moby/moby
5. postsubmit-integration-cli-docker: Run the end-to-end test suite from https://github.com/docker/cli