### PR TITLE
Update containerd periodic job to use 0.11-ppc64le DinD image

### DIFF
--- a/config/jobs/periodic/containerd/test-containerd-periodics.yaml
+++ b/config/jobs/periodic/containerd/test-containerd-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
         workdir: true
     spec:
       containers:
-      - image: quay.io/powercloud/docker-ce-build@sha256:f93b6d36ad414d30f584c6555d8c2116de58bd56601da36f4e13d4b5b624114a
+      - image: quay.io/powercloud/docker-ce-build@sha256:b89afc315f96f5cfd43de82b3b02f9221983592b893f838d816db5954088c9fc
         command:
           - /bin/bash
         args:


### PR DESCRIPTION
Follow up of https://github.com/ppc64le-cloud/test-infra/pull/516 to update the containerd job to use the same image.