### PR TITLE
Knative Eventing Kafka Broker - prow jobs to run upstream testing CI job

### DIFF
--- a/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-main.yaml
+++ b/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-main.yaml
@@ -1,0 +1,181 @@
+periodics:
+  - name: knative-sasl-plain-eventing-kafka-broker-main-periodic
+    labels:
+      preset-knative-powervs: "true"
+    decorate: true
+    cron: "0 8 * * *"
+    extra_refs:
+      - base_ref: main
+        org: ppc64le-cloud
+        repo: knative-tkn-upstream-ci
+        workdir: true
+      - base_ref: main
+        org: knative-extensions
+        repo: eventing-kafka-broker
+    spec:
+      containers:
+        - image: quay.io/powercloud/knative-prow-tests:latest
+          resources:
+            requests:
+              cpu: "1500m"
+            limits:
+              cpu: "1500m"
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+
+              TIMESTAMP=$(date +%Y%m%d%H%M%S%3N)
+              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
+
+              trap 'source cluster-setup.sh delete' EXIT
+
+              source cluster-setup.sh create
+              pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
+              . /tmp/adjust.sh
+              ./test/e2e-tests.sh --run-tests
+              popd
+
+          env:
+            - name: ORG
+              value: knative-extensions
+            - name: KNATIVE_REPO
+              value: eventing-kafka-broker
+            - name: KNATIVE_RELEASE
+              value: main
+            - name: BROKER_CLASS
+              value: Kafka
+            - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+              value: SASL_PLAIN
+            - name: EVENTING_NAMESPACE
+              value: knative-eventing
+            - name: SYSTEM_NAMESPACE
+              value: knative-eventing
+            - name: SCALE_CHAOSDUCK_TO_ZERO
+              value: "1"
+  - name: knative-sasl-ssl-eventing-kafka-broker-main-periodic
+    labels:
+      preset-knative-powervs: "true"
+    decorate: true
+    cron: "0 10 * * *"
+    extra_refs:
+      - base_ref: main
+        org: ppc64le-cloud 
+        repo: knative-tkn-upstream-ci
+        workdir: true
+      - base_ref: main
+        org: knative-extensions
+        repo: eventing-kafka-broker
+    spec:
+      containers:
+        - image: quay.io/powercloud/knative-prow-tests:latest
+          resources:
+            requests:
+              cpu: "1500m"
+            limits:
+              cpu: "1500m"
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+
+              TIMESTAMP=$(date +%Y%m%d%H%M%S%3N)
+              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
+
+              trap 'source cluster-setup.sh delete' EXIT
+
+              source cluster-setup.sh create
+              pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
+              . /tmp/adjust.sh
+              ./test/e2e-tests.sh --run-tests
+              popd
+
+          env:
+            - name: ORG
+              value: knative-extensions
+            - name: KNATIVE_REPO
+              value: eventing-kafka-broker
+            - name: KNATIVE_RELEASE
+              value: main
+            - name: BROKER_CLASS
+              value: Kafka
+            - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+              value: SASL_SSL
+            - name: EVENTING_NAMESPACE
+              value: knative-eventing
+            - name: SYSTEM_NAMESPACE
+              value: knative-eventing
+            - name: SCALE_CHAOSDUCK_TO_ZERO
+              value: "1"
+  - name: knative-ssl-eventing-kafka-broker-main-periodic
+    labels:
+      preset-knative-powervs: "true"
+    decorate: true
+    cron: "0 12 * * *"
+    extra_refs:
+      - base_ref: main
+        org: ppc64le-cloud 
+        repo: knative-tkn-upstream-ci
+        workdir: true
+      - base_ref: main
+        org: knative-extensions
+        repo: eventing-kafka-broker
+    spec:
+      containers:
+        - image: quay.io/powercloud/knative-prow-tests:latest
+          resources:
+            requests:
+              cpu: "1500m"
+            limits:
+              cpu: "1500m"
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+
+              TIMESTAMP=$(date +%Y%m%d%H%M%S%3N)
+              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
+
+              trap 'source cluster-setup.sh delete' EXIT
+
+              source cluster-setup.sh create
+              pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
+              . /tmp/adjust.sh
+              ./test/e2e-tests.sh --run-tests
+              popd
+
+          env:
+            - name: ORG
+              value: knative-extensions
+            - name: KNATIVE_REPO
+              value: eventing-kafka-broker
+            - name: KNATIVE_RELEASE
+              value: main
+            - name: BROKER_CLASS
+              value: Kafka
+            - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+              value: SSL
+            - name: EVENTING_NAMESPACE
+              value: knative-eventing
+            - name: SYSTEM_NAMESPACE
+              value: knative-eventing
+            - name: SCALE_CHAOSDUCK_TO_ZERO
+              value: "1"

--- a/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-main.yaml
+++ b/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-main.yaml
@@ -66,7 +66,7 @@ periodics:
     cron: "0 10 * * *"
     extra_refs:
       - base_ref: main
-        org: ppc64le-cloud 
+        org: ppc64le-cloud
         repo: knative-tkn-upstream-ci
         workdir: true
       - base_ref: main
@@ -126,7 +126,7 @@ periodics:
     cron: "0 12 * * *"
     extra_refs:
       - base_ref: main
-        org: ppc64le-cloud 
+        org: ppc64le-cloud
         repo: knative-tkn-upstream-ci
         workdir: true
       - base_ref: main

--- a/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-release-1.16.yaml
+++ b/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-release-1.16.yaml
@@ -1,0 +1,181 @@
+periodics:
+  - name: knative-sasl-plain-eventing-kafka-broker-release-1.16-periodic
+    labels:
+      preset-knative-powervs: "true"
+    decorate: true
+    cron: "0 9 * * *"
+    extra_refs:
+      - base_ref: main
+        org: ppc64le-cloud
+        repo: knative-tkn-upstream-ci
+        workdir: true
+      - base_ref: release-1.16
+        org: knative-extensions
+        repo: eventing-kafka-broker
+    spec:
+      containers:
+        - image: quay.io/powercloud/knative-prow-tests:latest
+          resources:
+            requests:
+              cpu: "1500m"
+            limits:
+              cpu: "1500m"
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+
+              TIMESTAMP=$(date +%Y%m%d%H%M%S%3N)
+              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
+
+              trap 'source cluster-setup.sh delete' EXIT
+
+              source cluster-setup.sh create
+              pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
+              . /tmp/adjust.sh
+              ./test/e2e-tests.sh --run-tests
+              popd
+
+          env:
+            - name: ORG
+              value: knative-extensions
+            - name: KNATIVE_REPO
+              value: eventing-kafka-broker
+            - name: KNATIVE_RELEASE
+              value: release-1.16
+            - name: BROKER_CLASS
+              value: Kafka
+            - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+              value: SASL_PLAIN
+            - name: EVENTING_NAMESPACE
+              value: knative-eventing
+            - name: SYSTEM_NAMESPACE
+              value: knative-eventing
+            - name: SCALE_CHAOSDUCK_TO_ZERO
+              value: "1"
+  - name: knative-sasl-ssl-eventing-kafka-broker-release-1.16-periodic
+    labels:
+      preset-knative-powervs: "true"
+    decorate: true
+    cron: "0 11 * * *"
+    extra_refs:
+      - base_ref: main
+        org: ppc64le-cloud 
+        repo: knative-tkn-upstream-ci
+        workdir: true
+      - base_ref: release-1.16
+        org: knative-extensions
+        repo: eventing-kafka-broker
+    spec:
+      containers:
+        - image: quay.io/powercloud/knative-prow-tests:latest
+          resources:
+            requests:
+              cpu: "1500m"
+            limits:
+              cpu: "1500m"
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+
+              TIMESTAMP=$(date +%Y%m%d%H%M%S%3N)
+              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
+
+              trap 'source cluster-setup.sh delete' EXIT
+
+              source cluster-setup.sh create
+              pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
+              . /tmp/adjust.sh
+              ./test/e2e-tests.sh --run-tests
+              popd
+
+          env:
+            - name: ORG
+              value: knative-extensions
+            - name: KNATIVE_REPO
+              value: eventing-kafka-broker
+            - name: KNATIVE_RELEASE
+              value: release-1.16
+            - name: BROKER_CLASS
+              value: Kafka
+            - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+              value: SASL_SSL
+            - name: EVENTING_NAMESPACE
+              value: knative-eventing
+            - name: SYSTEM_NAMESPACE
+              value: knative-eventing
+            - name: SCALE_CHAOSDUCK_TO_ZERO
+              value: "1"
+  - name: knative-ssl-eventing-kafka-broker-release-1.16-periodic
+    labels:
+      preset-knative-powervs: "true"
+    decorate: true
+    cron: "0 13 * * *"
+    extra_refs:
+      - base_ref: main
+        org: ppc64le-cloud 
+        repo: knative-tkn-upstream-ci
+        workdir: true
+      - base_ref: release-1.16
+        org: knative-extensions
+        repo: eventing-kafka-broker
+    spec:
+      containers:
+        - image: quay.io/powercloud/knative-prow-tests:latest
+          resources:
+            requests:
+              cpu: "1500m"
+            limits:
+              cpu: "1500m"
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+
+              TIMESTAMP=$(date +%Y%m%d%H%M%S%3N)
+              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
+
+              trap 'source cluster-setup.sh delete' EXIT
+
+              source cluster-setup.sh create
+              pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
+              . /tmp/adjust.sh
+              ./test/e2e-tests.sh --run-tests
+              popd
+
+          env:
+            - name: ORG
+              value: knative-extensions
+            - name: KNATIVE_REPO
+              value: eventing-kafka-broker
+            - name: KNATIVE_RELEASE
+              value: release-1.16
+            - name: BROKER_CLASS
+              value: Kafka
+            - name: EVENTING_KAFKA_BROKER_CHANNEL_AUTH_SCENARIO
+              value: SSL
+            - name: EVENTING_NAMESPACE
+              value: knative-eventing
+            - name: SYSTEM_NAMESPACE
+              value: knative-eventing
+            - name: SCALE_CHAOSDUCK_TO_ZERO
+              value: "1"

--- a/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-release-1.16.yaml
+++ b/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-release-1.16.yaml
@@ -66,7 +66,7 @@ periodics:
     cron: "0 11 * * *"
     extra_refs:
       - base_ref: main
-        org: ppc64le-cloud 
+        org: ppc64le-cloud
         repo: knative-tkn-upstream-ci
         workdir: true
       - base_ref: release-1.16
@@ -126,7 +126,7 @@ periodics:
     cron: "0 13 * * *"
     extra_refs:
       - base_ref: main
-        org: ppc64le-cloud 
+        org: ppc64le-cloud
         repo: knative-tkn-upstream-ci
         workdir: true
       - base_ref: release-1.16


### PR DESCRIPTION
This PR refers dropping-off of Eventing Kafka Broker jobs from: [drop s390x/ppc ci jobs #497](https://github.com/knative/infra/pull/497/files#diff-bc234772807c655163f8f0f1fdaf4c7e055153c4662ff6699484e76caab5380f).
Added updated prow jobs scripts to run Eventing Kafka Broker (main, release-1.16) testing CI jobs.
This PR requires depends on PR: https://github.com/ppc64le-cloud/knative-upstream-ci/pull/17