### PR TITLE
Code restructured

### DIFF
--- a/config/jobs/periodic/knative/client/client-main.yaml
+++ b/config/jobs/periodic/knative/client/client-main.yaml
@@ -34,42 +34,20 @@ periodics:
               TIMESTAMP=$(date +%s)
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
 
-              cleanup() {
-                pushd $GOPATH/src/github.com/ppc64le-cloud/knative-upstream-ci
-                kubetest2 tf --powervs-region syd --powervs-zone syd05 \
-                  --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
-                  --ignore-cluster-dir true \
-                  --cluster-name knative-$TIMESTAMP \
-                  --down --auto-approve --ignore-destroy-errors
-                popd
-              }
+              trap 'source cluster-setup.sh delete' EXIT
 
-              trap cleanup EXIT
-
-              kubetest2 tf --powervs-image-name CentOS9-Stream\
-                --powervs-region syd --powervs-zone syd05 \
-                --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
-                --powervs-ssh-key knative-ssh-key \
-                --ssh-private-key ~/.ssh/ssh-key \
-                --build-version $K8S_BUILD_VERSION \
-                --cluster-name knative-$TIMESTAMP \
-                --workers-count 2 \
-                --playbook install-k8s-kn-tkn.yml \
-                --up --auto-approve --retry-on-tf-failure 5 \
-                --break-kubetest-on-upfail true \
-                --powervs-memory 32
-
-              export KUBECONFIG="$(pwd)/knative-$TIMESTAMP/kubeconfig"
-              grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $(pwd)/knative-$TIMESTAMP/hosts > HOSTS_IP
-              source setup-environment.sh HOSTS_IP
-
-              pushd $GOPATH/src/github.com/knative/client
+              source cluster-setup.sh create
+              pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
               . /tmp/adjust.sh
               ./test/e2e-tests.sh --run-tests
               popd
 
           env:
-            - name: CI_JOB
-              value: client-main
+            - name: ORG
+              value: knative
+            - name: KNATIVE_REPO
+              value: client
+            - name: KNATIVE_RELEASE
+              value: main
             - name: SSL_CERT_FILE
               value: /etc/ssl/certs/ca-certificates.crt

--- a/config/jobs/periodic/knative/client/client-release-1.16.yaml
+++ b/config/jobs/periodic/knative/client/client-release-1.16.yaml
@@ -34,42 +34,20 @@ periodics:
               TIMESTAMP=$(date +%s)
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
 
-              cleanup() {
-                pushd $GOPATH/src/github.com/ppc64le-cloud/knative-upstream-ci
-                kubetest2 tf --powervs-region syd --powervs-zone syd05 \
-                  --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
-                  --ignore-cluster-dir true \
-                  --cluster-name knative-$TIMESTAMP \
-                  --down --auto-approve --ignore-destroy-errors
-                popd
-              }
+              trap 'source cluster-setup.sh delete' EXIT
 
-              trap cleanup EXIT
-
-              kubetest2 tf --powervs-image-name CentOS9-Stream\
-                --powervs-region syd --powervs-zone syd05 \
-                --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
-                --powervs-ssh-key knative-ssh-key \
-                --ssh-private-key ~/.ssh/ssh-key \
-                --build-version $K8S_BUILD_VERSION \
-                --cluster-name knative-$TIMESTAMP \
-                --workers-count 2 \
-                --playbook install-k8s-kn-tkn.yml \
-                --up --auto-approve --retry-on-tf-failure 5 \
-                --break-kubetest-on-upfail true \
-                --powervs-memory 32
-
-              export KUBECONFIG="$(pwd)/knative-$TIMESTAMP/kubeconfig"
-              grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $(pwd)/knative-$TIMESTAMP/hosts > HOSTS_IP
-              source setup-environment.sh HOSTS_IP
-
-              pushd $GOPATH/src/github.com/knative/client
+              source cluster-setup.sh create
+              pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
               . /tmp/adjust.sh
               ./test/e2e-tests.sh --run-tests
               popd
 
           env:
-            - name: CI_JOB
-              value: client-release-1.16
+            - name: ORG
+              value: knative
+            - name: KNATIVE_REPO
+              value: client
+            - name: KNATIVE_RELEASE
+              value: release-1.16
             - name: SSL_CERT_FILE
               value: /etc/ssl/certs/ca-certificates.crt

--- a/config/jobs/periodic/knative/eventing/eventing-main.yaml
+++ b/config/jobs/periodic/knative/eventing/eventing-main.yaml
@@ -31,45 +31,25 @@ periodics:
               set -o pipefail
               set -o xtrace
 
-              TIMESTAMP=$(date +%Y%m%d%H%M%S%3N)
+              TIMESTAMP=$(date +%s)
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
 
-              cleanup() {
-                pushd $GOPATH/src/github.com/ppc64le-cloud/knative-upstream-ci
-                kubetest2 tf --powervs-region syd --powervs-zone syd05 \
-                  --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
-                  --ignore-cluster-dir true \
-                  --cluster-name knative-$TIMESTAMP \
-                  --down --auto-approve --ignore-destroy-errors
-                popd
-              }
+              trap 'source cluster-setup.sh delete' EXIT
 
-              trap cleanup EXIT
+              source cluster-setup.sh create
+              pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
 
-              kubetest2 tf --powervs-image-name CentOS9-Stream\
-                --powervs-region syd --powervs-zone syd05 \
-                --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
-                --powervs-ssh-key knative-ssh-key \
-                --ssh-private-key ~/.ssh/ssh-key \
-                --build-version $K8S_BUILD_VERSION \
-                --cluster-name knative-$TIMESTAMP \
-                --workers-count 2 \
-                --up --auto-approve --retry-on-tf-failure 5 \
-                --break-kubetest-on-upfail true \
-                --powervs-memory 32
-
-              export KUBECONFIG="$(pwd)/knative-$TIMESTAMP/kubeconfig"
-              grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $(pwd)/knative-$TIMESTAMP/hosts > HOSTS_IP
-              source setup-environment.sh HOSTS_IP
-
-              pushd $GOPATH/src/github.com/knative/eventing
               . /tmp/adjust.sh
               ./test/e2e-tests.sh --run-tests
               popd
 
           env:
-            - name: CI_JOB
-              value: eventing-main
+            - name: ORG
+              value: knative
+            - name: KNATIVE_REPO
+              value: eventing
+            - name: KNATIVE_RELEASE
+              value: main
             - name: SYSTEM_NAMESPACE
               value: knative-eventing
             - name: SCALE_CHAOSDUCK_TO_ZERO

--- a/config/jobs/periodic/knative/eventing/eventing-release-1.16.yaml
+++ b/config/jobs/periodic/knative/eventing/eventing-release-1.16.yaml
@@ -31,45 +31,24 @@ periodics:
               set -o pipefail
               set -o xtrace
 
-              TIMESTAMP=$(date +%Y%m%d%H%M%S%3N)
+              TIMESTAMP=$(date +%s)
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
 
-              cleanup() {
-                pushd $GOPATH/src/github.com/ppc64le-cloud/knative-upstream-ci
-                kubetest2 tf --powervs-region syd --powervs-zone syd05 \
-                  --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
-                  --ignore-cluster-dir true \
-                  --cluster-name knative-$TIMESTAMP \
-                  --down --auto-approve --ignore-destroy-errors
-                popd
-              }
+              trap 'source cluster-setup.sh delete' EXIT
 
-              trap cleanup EXIT
-
-              kubetest2 tf --powervs-image-name CentOS9-Stream\
-                --powervs-region syd --powervs-zone syd05 \
-                --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
-                --powervs-ssh-key knative-ssh-key \
-                --ssh-private-key ~/.ssh/ssh-key \
-                --build-version $K8S_BUILD_VERSION \
-                --cluster-name knative-$TIMESTAMP \
-                --workers-count 2 \
-                --up --auto-approve --retry-on-tf-failure 5 \
-                --break-kubetest-on-upfail true \
-                --powervs-memory 32
-
-              export KUBECONFIG="$(pwd)/knative-$TIMESTAMP/kubeconfig"
-              grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $(pwd)/knative-$TIMESTAMP/hosts > HOSTS_IP
-              source setup-environment.sh HOSTS_IP
-
-              pushd $GOPATH/src/github.com/knative/eventing
+              source cluster-setup.sh create
+              pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
               . /tmp/adjust.sh
               ./test/e2e-tests.sh --run-tests
               popd
 
           env:
-            - name: CI_JOB
-              value: eventing-release-1.16
+            - name: ORG
+              value: knative
+            - name: KNATIVE_REPO
+              value: eventing
+            - name: KNATIVE_RELEASE
+              value: release-1.16
             - name: SYSTEM_NAMESPACE
               value: knative-eventing
             - name: SCALE_CHAOSDUCK_TO_ZERO

--- a/config/jobs/periodic/knative/operator/operator-main.yaml
+++ b/config/jobs/periodic/knative/operator/operator-main.yaml
@@ -34,39 +34,18 @@ periodics:
               TIMESTAMP=$(date +%s)
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
 
-              cleanup() {
-                pushd $GOPATH/src/github.com/ppc64le-cloud/knative-upstream-ci
-                kubetest2 tf --powervs-region syd --powervs-zone syd05 \
-                  --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
-                  --ignore-cluster-dir true \
-                  --cluster-name knative-$TIMESTAMP \
-                  --down --auto-approve --ignore-destroy-errors
-                popd
-              }
+              trap 'source cluster-setup.sh delete' EXIT
 
-              trap cleanup EXIT
-
-              kubetest2 tf --powervs-image-name CentOS9-Stream\
-                --powervs-region syd --powervs-zone syd05 \
-                --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
-                --powervs-ssh-key knative-ssh-key \
-                --ssh-private-key ~/.ssh/ssh-key \
-                --build-version $K8S_BUILD_VERSION \
-                --cluster-name knative-$TIMESTAMP \
-                --workers-count 2 \
-                --up --auto-approve --retry-on-tf-failure 5 \
-                --break-kubetest-on-upfail true \
-                --powervs-memory 32
-
-              export KUBECONFIG="$(pwd)/knative-$TIMESTAMP/kubeconfig"
-              grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $(pwd)/knative-$TIMESTAMP/hosts > HOSTS_IP
-              source setup-environment.sh HOSTS_IP
-
-              pushd $GOPATH/src/github.com/knative/operator
+              source cluster-setup.sh create
+              pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
               . /tmp/adjust.sh
               ./test/e2e-tests.sh --run-tests
               popd
 
           env:
-            - name: CI_JOB
-              value: operator-main
+            - name: ORG
+              value: knative
+            - name: KNATIVE_REPO
+              value: operator
+            - name: KNATIVE_RELEASE
+              value: main

--- a/config/jobs/periodic/knative/operator/operator-release-1.16.yaml
+++ b/config/jobs/periodic/knative/operator/operator-release-1.16.yaml
@@ -34,39 +34,18 @@ periodics:
               TIMESTAMP=$(date +%s)
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
 
-              cleanup() {
-                pushd $GOPATH/src/github.com/ppc64le-cloud/knative-upstream-ci
-                kubetest2 tf --powervs-region syd --powervs-zone syd05 \
-                  --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
-                  --ignore-cluster-dir true \
-                  --cluster-name knative-$TIMESTAMP \
-                  --down --auto-approve --ignore-destroy-errors
-                popd
-              }
+              trap 'source cluster-setup.sh delete' EXIT
 
-              trap cleanup EXIT
-
-              kubetest2 tf --powervs-image-name CentOS9-Stream\
-                --powervs-region syd --powervs-zone syd05 \
-                --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
-                --powervs-ssh-key knative-ssh-key \
-                --ssh-private-key ~/.ssh/ssh-key \
-                --build-version $K8S_BUILD_VERSION \
-                --cluster-name knative-$TIMESTAMP \
-                --workers-count 2 \
-                --up --auto-approve --retry-on-tf-failure 5 \
-                --break-kubetest-on-upfail true \
-                --powervs-memory 32
-
-              export KUBECONFIG="$(pwd)/knative-$TIMESTAMP/kubeconfig"
-              grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' $(pwd)/knative-$TIMESTAMP/hosts > HOSTS_IP
-              source setup-environment.sh HOSTS_IP
-
-              pushd $GOPATH/src/github.com/knative/operator
+              source cluster-setup.sh create
+              pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
               . /tmp/adjust.sh
               ./test/e2e-tests.sh --run-tests
               popd
 
           env:
-            - name: CI_JOB
-              value: operator-release-1.16
+            - name: ORG
+              value: knative
+            - name: KNATIVE_REPO
+              value: operator
+            - name: KNATIVE_RELEASE
+              value: release-1.16


### PR DESCRIPTION
This PR restructures the code to reduce duplication in Knative CI jobs. These jobs had repeated lines for bringing up the cluster, running tests & cleaning up the resources. These common steps have now been moved to [knative-upstream-ci ](https://github.com/ppc64le-cloud/knative-upstream-ci) repo.

This change simplifies the job definitions and ensures consistency across all the Knative CI jobs