### PR TITLE
Rename repo name to knative-tkn-upstream-ci for Knative jobs

### DIFF
--- a/config/jobs/periodic/knative/client/client-main.yaml
+++ b/config/jobs/periodic/knative/client/client-main.yaml
@@ -7,7 +7,7 @@ periodics:
     extra_refs:
       - base_ref: main
         org: ppc64le-cloud
-        repo: knative-upstream-ci
+        repo: knative-tkn-upstream-ci
         workdir: true
       - base_ref: main
         org: knative

--- a/config/jobs/periodic/knative/client/client-release-1.16.yaml
+++ b/config/jobs/periodic/knative/client/client-release-1.16.yaml
@@ -7,7 +7,7 @@ periodics:
     extra_refs:
       - base_ref: main
         org: ppc64le-cloud
-        repo: knative-upstream-ci
+        repo: knative-tkn-upstream-ci
         workdir: true
       - base_ref: release-1.16
         org: knative

--- a/config/jobs/periodic/knative/eventing/eventing-main.yaml
+++ b/config/jobs/periodic/knative/eventing/eventing-main.yaml
@@ -7,7 +7,7 @@ periodics:
     extra_refs:
       - base_ref: main
         org: ppc64le-cloud
-        repo: knative-upstream-ci
+        repo: knative-tkn-upstream-ci
         workdir: true
       - base_ref: main
         org: knative

--- a/config/jobs/periodic/knative/eventing/eventing-release-1.16.yaml
+++ b/config/jobs/periodic/knative/eventing/eventing-release-1.16.yaml
@@ -7,7 +7,7 @@ periodics:
     extra_refs:
       - base_ref: main
         org: ppc64le-cloud
-        repo: knative-upstream-ci
+        repo: knative-tkn-upstream-ci
         workdir: true
       - base_ref: release-1.16
         org: knative

--- a/config/jobs/periodic/knative/operator/operator-main.yaml
+++ b/config/jobs/periodic/knative/operator/operator-main.yaml
@@ -7,7 +7,7 @@ periodics:
     extra_refs:
       - base_ref: main
         org: ppc64le-cloud
-        repo: knative-upstream-ci
+        repo: knative-tkn-upstream-ci
         workdir: true
       - base_ref: main
         org: knative

--- a/config/jobs/periodic/knative/operator/operator-release-1.16.yaml
+++ b/config/jobs/periodic/knative/operator/operator-release-1.16.yaml
@@ -7,7 +7,7 @@ periodics:
     extra_refs:
       - base_ref: main
         org: ppc64le-cloud
-        repo: knative-upstream-ci
+        repo: knative-tkn-upstream-ci
         workdir: true
       - base_ref: release-1.16
         org: knative


### PR DESCRIPTION
Renamed the repo from `knative-upstream-ci` to `knative-tkn-upstream-ci` to include scripts for Tekton as well. This ensures a single repository serves both Knative and Tekton components,