### PR TITLE
Upgrade Prow Infra to v20241224-8e8a5cfe7

### DIFF
--- a/config/prow/cluster/cherrypick_deployment.yaml
+++ b/config/prow/cluster/cherrypick_deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: cherrypick
-        image: us-docker.pkg.dev/k8s-infra-prow/images/cherrypicker:v20240827-195f38540
+        image: us-docker.pkg.dev/k8s-infra-prow/images/cherrypicker:v20241224-8e8a5cfe7
         args:
         - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20240827-195f38540
+          image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20241224-8e8a5cfe7
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/crier_github_app_deployment.yaml
+++ b/config/prow/cluster/crier_github_app_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier2
-          image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20240827-195f38540
+          image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20241224-8e8a5cfe7
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20240827-195f38540
+          image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20241224-8e8a5cfe7
           args:
             - --config-path=/etc/config/config.yaml
             - --plugin-config=/etc/plugins/plugins.yaml

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20240827-195f38540
+          image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20241224-8e8a5cfe7
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20240827-195f38540
+          image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20241224-8e8a5cfe7
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/hook_github_app_deployment.yaml
+++ b/config/prow/cluster/hook_github_app_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook2
-          image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20240827-195f38540
+          image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20241224-8e8a5cfe7
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: horologium
-          image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:v20240827-195f38540
+          image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:v20241224-8e8a5cfe7
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - --github-endpoint=https://api.github.com
             - --enable-controller=plank
             - --job-config-path=/etc/job-config
-          image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20240827-195f38540
+          image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20241224-8e8a5cfe7
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
         - name: sinker
-          image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20240827-195f38540
+          image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20241224-8e8a5cfe7
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20240827-195f38540
+          image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20241224-8e8a5cfe7
           args:
             - --dry-run=false
             - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20240827-195f38540
+          image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20241224-8e8a5cfe7
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml


### PR DESCRIPTION
Have deployed these in IKS cluster and are running fine without errors.
Also need this change in s3 credential secret https://github.ibm.com/powercloud-secrets/secrets/pull/42

The upstream are not upgrading the pod utility image tags these days.. I have posted a question in k8c channel asking why..
Ref: https://kubernetes.slack.com/archives/CDECRSC5U/p1738064361257469?thread_ts=1737176000.439429&cid=CDECRSC5U