### PR TITLE
Modify RegEx to prevent deletion of resources created in local HyperShift clusters

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-hypershift-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-hypershift-periodics.yaml
@@ -27,6 +27,6 @@ periodics:
               # cleanup all the vms created in rh-upstream-hypershift-powervs-e2e-ci-pvs workspace before 24hrs
               pvsadm purge vms --instance-id 577df9a3-84b7-4de7-9ab7-c86a6180cabb --before 24h --ignore-errors --no-prompt
               # cleanup all the vms created in rh-upstream-hypershift-agent-ci workspace before 24hrs
-              pvsadm purge vms --instance-id d04e2b0c-58aa-4e64-85c1-ecb5ab00d03d --before 24h --regexp '[^bastion]' --ignore-errors --no-prompt
+              pvsadm purge vms --instance-id d04e2b0c-58aa-4e64-85c1-ecb5ab00d03d --before 24h --regexp '[^bastion\w]' --ignore-errors --no-prompt
               # cleanup all the vms created in rh-upstream-hypershift-agent-heterogeneous-ci workspace before 24hrs
-              pvsadm purge vms --instance-id d4309c6b-e13f-45cd-b0d1-360d476cd9e6 --before 24h --regexp '[^bastion]' --ignore-errors --no-prompt
+              pvsadm purge vms --instance-id d4309c6b-e13f-45cd-b0d1-360d476cd9e6 --before 24h --regexp '[^bastion\w]' --ignore-errors --no-prompt


### PR DESCRIPTION
**Why we need this PR?**
In agent based HyperShift, we use local clusters to further debug CI errors due to the time, permission and resource constraint. To achieve this, we are planning to reuse existing CI setups for our local deployments from now on.(resource reusability)
**Issue**: The current regex is strictly character matching against the word `bastion` and so any other worker node created there is getting cleaned up automatically.
**What this PR does**
This PR updates the regex to not delete any VM which is either bastion or is created locally(contains words without special characters).
All CI VMs are of the pattern `power-clustername-worker` and so they will be cleaned up.
**Testing**
Tested locally
```
macbookpro:~ nehayadav$ pvsadm purge vms --instance-id d4309c6b-e13f-45cd-b0d1-360d476cd9e6  --regexp '[^bastion\w]' --ignore-errors --no-prompt
I0203 16:20:28.761205   82044 root.go:50] Using an API key from IBMCLOUD_API_KEY environment variable
+------+--------------+-------+------+-----+--------+---------------+
| NAME | IP ADDRESSES | IMAGE | CPUS | RAM | STATUS | CREATION DATE |
+------+--------------+-------+------+-----+--------+---------------+
+------+--------------+-------+------+-----+--------+---------------+

macbookpro:~ nehayadav$ pvsadm purge vms --instance-id d4309c6b-e13f-45cd-b0d1-360d476cd9e6  --regexp '[^bastion\w]' --ignore-errors --no-prompt
I0203 16:47:46.140997   85919 root.go:50] Using an API key from IBMCLOUD_API_KEY environment variable
+----------------------+--------------------------+--------------------------------------+------+-----+-----------------+--------------------------+
|         NAME         |       IP ADDRESSES       |                IMAGE                 | CPUS | RAM |     STATUS      |      CREATION DATE       |
+----------------------+--------------------------+--------------------------------------+------+-----+-----------------+--------------------------+
| power-Bastion-Worker | External:  Private:      | e09beff5-3c87-4811-80a3-3bd67c8c737c |  0.5 |  16 | Status: ACTIVE  | 2025-02-03T10:51:17.000Z |
|                      | 192.168.140.116          |                                      |      |     | Health: WARNING |                          |
+----------------------+--------------------------+--------------------------------------+------+-----+-----------------+--------------------------+
I0203 16:48:01.991817   85919 vms.go:79] Deleting the power-Bastio
```n-Worker, and ID: b34ad718-d2db-40d7-a981-8c6b8846a2ad

