### PR TITLE
Restrict INGRESS_CLASS env variable to required Knative jobs  

### DIFF
--- a/config/jobs/periodic/knative/client/client-main.yaml
+++ b/config/jobs/periodic/knative/client/client-main.yaml
@@ -50,5 +50,7 @@ periodics:
               value: client
             - name: KNATIVE_RELEASE
               value: main
+            - name: INGRESS_CLASS
+              value: contour.ingress.networking.knative.dev
             - name: SSL_CERT_FILE
               value: /etc/ssl/certs/ca-certificates.crt

--- a/config/jobs/periodic/knative/client/client-release-1.16.yaml
+++ b/config/jobs/periodic/knative/client/client-release-1.16.yaml
@@ -50,5 +50,7 @@ periodics:
               value: client
             - name: KNATIVE_RELEASE
               value: release-1.16
+            - name: INGRESS_CLASS
+              value: contour.ingress.networking.knative.dev
             - name: SSL_CERT_FILE
               value: /etc/ssl/certs/ca-certificates.crt

--- a/config/jobs/periodic/knative/operator/operator-main.yaml
+++ b/config/jobs/periodic/knative/operator/operator-main.yaml
@@ -50,3 +50,5 @@ periodics:
               value: operator
             - name: KNATIVE_RELEASE
               value: main
+            - name: INGRESS_CLASS
+              value: contour.ingress.networking.knative.dev

--- a/config/jobs/periodic/knative/operator/operator-release-1.16.yaml
+++ b/config/jobs/periodic/knative/operator/operator-release-1.16.yaml
@@ -50,3 +50,5 @@ periodics:
               value: operator
             - name: KNATIVE_RELEASE
               value: release-1.16
+            - name: INGRESS_CLASS
+              value: contour.ingress.networking.knative.dev

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -239,8 +239,6 @@ presets:
       value: --platform=linux/ppc64le
     - name: PLATFORM
       value: linux/ppc64le
-    - name: INGRESS_CLASS
-      value: contour.ingress.networking.knative.dev
     - name: KO_DOCKER_REPO
       value: icr.io/upstream-k8s-registry/knative
     - name: DOCKER_CONFIG


### PR DESCRIPTION
Previously, INGRESS_CLASS env variable was applied globally to all jobs via the default config in config.yaml. This update removes it from the default configuration and explicitly adds it only to the jobs that require it.

Changes:
- Removed INGRESS_CLASS from the default config.
- Added INGRESS_CLASS only where needed.

This avoids setting unnecessary environment variables for unrelated jobs.
