### PR TITLE
Revert #430 as startup latency is <5s

### DIFF
--- a/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
@@ -59,8 +59,6 @@ periodics:
         curl -sSL https://dl.k8s.io/ci/$K8S_BUILD_VERSION/bin/linux/`go env GOARCH`/kubectl > /usr/local/bin/kubectl
         chmod +x /usr/local/bin/kubectl
 
-        echo POD_STARTUP_LATENCY_THRESHOLD: 10s >> $GOPATH/src/github.com/kubernetes/perf-tests/clusterloader2/testing/overrides/node_containerd.yaml
-
         kubetest2 tf --powervs-dns k8s-tests \
           --powervs-image-name CentOS-Stream-9 \
           --powervs-region syd --powervs-zone syd05 \


### PR DESCRIPTION
The current infrastructure allows the latency to be within the 5s mark.
Historical data points to most startup latencies falling under 5s. 
However with https://github.com/ppc64le-cloud/kubetest2-plugins/pull/207, if need be, the job config can be set to use tier0 storage, through TF_VAR_pi_storage_tier environment variable. 