### PR TITLE
Remove ssh_key_secret from prow default config

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -84,8 +84,6 @@ plank:
         entrypoint: us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20240802-66b115076
         initupload: us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20240802-66b115076
         sidecar: us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20240802-66b115076
-      ssh_key_secrets:
-        - bot-ssh-secret
 
 tide:
   sync_period: 2m


### PR DESCRIPTION
https://prow.ppc64le-cloud.cis.ibm.net/job-history/gs/ppc64le-kubernetes/logs/periodic-kubernetes-unit-test-ppc64le has been failing with below error:
```
# FAILED
Environment setup
$ ssh-agent
SSH_AUTH_SOCK=/tmp/ssh-XXXXXXppAPlh/agent.23; export SSH_AUTH_SOCK;
SSH_AGENT_PID=24; export SSH_AGENT_PID;
echo Agent pid 24;
$ ssh-add "/secrets/ssh/bot-ssh-secret/ssh-privatekey"
/secrets/ssh/bot-ssh-secret/ssh-privatekey: Permission denied
# Error: exit status 1
# Final SHA: 
# Total runtime: 0s
```