### PR TITLE
Change image tag of k8s UT job

### DIFF
--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -18,7 +18,7 @@ periodics:
         runAsGroup: 2010
         runAsUser: 2001
       containers:
-        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250212-16f67660c2-master
+        - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250227-3a13bdd784-master
           command:
             - make
             - test


### PR DESCRIPTION
`us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20250212-16f67660c2-master` was not available for `ppc64le`.
`v20250227-3a13bdd784-master` exists for ppc64le.
Manifest -> [link](https://console.cloud.google.com/artifacts/docker/k8s-staging-test-infra/us-central1/images/kubekins-e2e/sha256:82e38c98c1775fec35613c01154ae82bd93f43e9330d579c7a5464fc4687a6ad;tab=manifest)