### PR TITLE
Change branch from master to main for postsubmit-os-origin-build-golang-master-ppc64le job

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
@@ -64,7 +64,7 @@ postsubmits:
         - master
       run_if_changed: '^golang/master/'
       extra_refs:
-        - base_ref: master
+        - base_ref: main
           org: openshift
           repo: origin
           workdir: true


### PR DESCRIPTION
[postsubmit-os-origin-build-golang-master-ppc64le](https://prow.ppc64le-cloud.cis.ibm.net/job-history/s3/ppc64le-prow-logs/logs/postsubmit-os-origin-build-golang-master-ppc64le) has been failing.

master is renamed to main in https://github.com/openshift/origin

Got to know from [https://ppc64le-prow-logs.s3.us-south.cloud-object-storage.appdomain.cloud/logs/postsubmit-os-origin-build-gol[…]e/1895112330346237952/clone-log.txt](https://ppc64le-prow-logs.s3.us-south.cloud-object-storage.appdomain.cloud/logs/postsubmit-os-origin-build-golang-master-ppc64le/1895112330346237952/clone-log.txt)
