### PR TITLE
Changes to gcr.io images

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ $ CONFIG_PATH=$(pwd)/config/prow/config.yaml JOB_CONFIG_PATH=$(pwd)/config/jobs/
 
 03 May 2022 - Usage of pod-utility images from locally built and pushed `quay.io/powercloud` private repo is deprecated.
 
-The upstream pod-utility images from `gcr.io/k8s-prow` will be used - [Change](https://github.com/ppc64le-cloud/test-infra/pull/309/files#diff-d840b3456d7d17beb3ded91cf0ca9d6fd065baedb31a0a634b5101df3f7925d4L77)
+The upstream pod-utility images from `us-docker.pkg.dev/k8s-infra-prow/images` will be used.
+
+[Change1](https://github.com/ppc64le-cloud/test-infra/pull/309/files#diff-d840b3456d7d17beb3ded91cf0ca9d6fd065baedb31a0a634b5101df3f7925d4L77) - Started using google container registry upstream images
+
+[Change2](https://github.com/ppc64le-cloud/test-infra/pull/487/files#diff-d840b3456d7d17beb3ded91cf0ca9d6fd065baedb31a0a634b5101df3f7925d4R83) - Moved from using Container Registry to Temporary Upstream Artifact Registry. (May change to registry.k8s.io in future. Ref: [issue](https://github.com/kubernetes-sigs/prow/issues/113)
 
 Files from [here](https://github.com/ppc64le-cloud/test-infra/tree/master/images/pod-utilities) will not be used.

--- a/config/jobs/ppc64le-cloud/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/ppc64le-cloud/test-infra/test-infra-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
     run_if_changed: '^(config/prow/(config|plugins).yaml$|config/jobs/.*.yaml$)'
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20240205-8f023a0da6
+      - image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20250307-7a867cddc
         command:
         - checkconfig
         args:

--- a/config/prow/cluster/label_sync_cron_job.yaml
+++ b/config/prow/cluster/label_sync_cron_job.yaml
@@ -16,7 +16,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20240409-13cd3acf7e
+              image: gcr.io/k8s-staging-test-infra/label_sync:v20250306-095fc63a16
               args:
                 - --config=/etc/config/labels.yaml
                 - --confirm=true

--- a/config/prow/perfdash/perfdash-deployment.yaml
+++ b/config/prow/perfdash/perfdash-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:2.34
+        image: gcr.io/k8s-staging-perf-tests/perfdash:2.54
         command:
           - /perfdash
           -   --www=true

--- a/hack/test-pj.sh
+++ b/hack/test-pj.sh
@@ -12,8 +12,8 @@ function main() {
   parseArgs "$@"
 
   # Generate PJ and Pod.
-  docker run -i --rm -v "${PWD}:${PWD}" -v "${config}:${config}" ${job_config_mnt} -w "${PWD}" gcr.io/k8s-prow/mkpj "--config-path=${config}" "--job=${job}" ${job_config_flag} > "${PWD}/pj.yaml"
-  docker run -i --rm -v "${PWD}:${PWD}" -w "${PWD}" gcr.io/k8s-prow/mkpod --build-id=snowflake "--prow-job=${PWD}/pj.yaml" --local "--out-dir=${out_dir}/${job}" > "${PWD}/pod.yaml"
+  docker run -i --rm -v "${PWD}:${PWD}" -v "${config}:${config}" ${job_config_mnt} -w "${PWD}" us-docker.pkg.dev/k8s-infra-prow/images/mkpj "--config-path=${config}" "--job=${job}" ${job_config_flag} > "${PWD}/pj.yaml"
+  docker run -i --rm -v "${PWD}:${PWD}" -w "${PWD}" us-docker.pkg.dev/k8s-infra-prow/images/mkpod --build-id=snowflake "--prow-job=${PWD}/pj.yaml" --local "--out-dir=${out_dir}/${job}" > "${PWD}/pod.yaml"
 
   echo "Applying pod to the mkpod cluster. Configure kubectl for the mkpod cluster with:"
   echo "Press Control+c for exiting the script"

--- a/images/pod-utilities/Makefile
+++ b/images/pod-utilities/Makefile
@@ -1,6 +1,6 @@
 FILE=version.txt
 VERSION?=`cat $(FILE)`
-UPSTREAM_REPO=gcr.io/k8s-prow
+UPSTREAM_REPO=us-docker.pkg.dev/k8s-infra-prow/images
 PRIVATE_REPO=quay.io/powercloud
 ARCH?=amd64
 

--- a/images/pod-utilities/README.md
+++ b/images/pod-utilities/README.md
@@ -1,8 +1,11 @@
 ## Deprecated
 03 May 2022 - Usage of pod-utility images from locally built and pushed `quay.io/powercloud` private repo is deprecated.
 
+The upstream pod-utility images from `us-docker.pkg.dev/k8s-infra-prow/images` will be used.
 
-The upstream pod-utility images from `gcr.io/k8s-prow` will be used - [Change](https://github.com/ppc64le-cloud/test-infra/pull/309/files#diff-d840b3456d7d17beb3ded91cf0ca9d6fd065baedb31a0a634b5101df3f7925d4L77)
+[Change1](https://github.com/ppc64le-cloud/test-infra/pull/309/files#diff-d840b3456d7d17beb3ded91cf0ca9d6fd065baedb31a0a634b5101df3f7925d4L77) - Started using google container registry upstream images
+
+[Change2](https://github.com/ppc64le-cloud/test-infra/pull/487/files#diff-d840b3456d7d17beb3ded91cf0ca9d6fd065baedb31a0a634b5101df3f7925d4R83) - Moved from using Container Registry to Temporary Upstream Artifact Registry. (May change to registry.k8s.io in future. Ref: [issue](https://github.com/kubernetes-sigs/prow/issues/113)
 
 ### How to build
 


### PR DESCRIPTION
Changes the following images to latest Google Artifact Registry:
- Pod utility images reference README.
- checkconfig image of `pull-test-infra-yamllint` job.
- label_sync image of `label-sync` cronjob.
- perfdash image of https://perf-dash.ppc64le-cloud.cis.ibm.net/ backend.
(Happen to raise an issue upstream to move perfdash image from GCR to Artifact Registry https://github.com/kubernetes/k8s.io/issues/7863)

Have deployed and checked label-sync and perfdash images in IKS prow infra.