### PR TITLE
Change kubetest2-plugins repo to provider-ibmcloud-test-infra

### DIFF
--- a/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/perf-tests/perf-tests-kubernetes-periodics.yaml
@@ -14,9 +14,9 @@ periodics:
     gcs_credentials_secret: gcs-credentials
   interval: 12h
   extra_refs:
-  - base_ref: master
-    org: ppc64le-cloud
-    repo: kubetest2-plugins
+  - base_ref: main
+    org: kubernetes-sigs
+    repo: provider-ibmcloud-test-infra
   - base_ref: master
     org: kubernetes-sigs
     repo: kubetest2
@@ -47,7 +47,7 @@ periodics:
 
         make install install-tester-clusterloader2
 
-        pushd ../../ppc64le-cloud/kubetest2-plugins
+        pushd ../provider-ibmcloud-test-infra
         make install-deployer-tf
         popd
 
@@ -93,9 +93,9 @@ periodics:
     gcs_credentials_secret: gcs-credentials
   interval: 24h
   extra_refs:
-  - base_ref: master
-    org: ppc64le-cloud
-    repo: kubetest2-plugins
+  - base_ref: main
+    org: kubernetes-sigs
+    repo: provider-ibmcloud-test-infra
   - base_ref: master
     org: kubernetes-sigs
     repo: kubetest2
@@ -126,7 +126,7 @@ periodics:
 
         make install install-tester-exec
 
-        pushd ../../ppc64le-cloud/kubetest2-plugins
+        pushd ../provider-ibmcloud-test-infra
         make install-deployer-tf
         popd
 

--- a/config/jobs/periodic/kubernetes/test-kubernetes-1.30-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-1.30-periodics.yaml
@@ -10,9 +10,9 @@ periodics:
       gcs_credentials_secret: gcs-credentials
     cron: "0 5 * * *"
     extra_refs:
-      - base_ref: master
-        org: ppc64le-cloud
-        repo: kubetest2-plugins
+      - base_ref: main
+        org: kubernetes-sigs
+        repo: provider-ibmcloud-test-infra
         workdir: true
     spec:
       containers:
@@ -84,9 +84,9 @@ periodics:
       gcs_credentials_secret: gcs-credentials
     cron: "0 6 * * *"
     extra_refs:
-      - base_ref: master
-        org: ppc64le-cloud
-        repo: kubetest2-plugins
+      - base_ref: main
+        org: kubernetes-sigs
+        repo: provider-ibmcloud-test-infra
         workdir: true
       - base_ref: release-1.30
         org: kubernetes

--- a/config/jobs/periodic/kubernetes/test-kubernetes-1.31-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-1.31-periodics.yaml
@@ -10,9 +10,9 @@ periodics:
       gcs_credentials_secret: gcs-credentials
     cron: "0 3 * * *"
     extra_refs:
-      - base_ref: master
-        org: ppc64le-cloud
-        repo: kubetest2-plugins
+      - base_ref: main
+        org: kubernetes-sigs
+        repo: provider-ibmcloud-test-infra
         workdir: true
     spec:
       containers:
@@ -84,9 +84,9 @@ periodics:
       gcs_credentials_secret: gcs-credentials
     cron: "0 4 * * *"
     extra_refs:
-      - base_ref: master
-        org: ppc64le-cloud
-        repo: kubetest2-plugins
+      - base_ref: main
+        org: kubernetes-sigs
+        repo: provider-ibmcloud-test-infra
         workdir: true
       - base_ref: release-1.31
         org: kubernetes

--- a/config/jobs/periodic/kubernetes/test-kubernetes-1.32-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-1.32-periodics.yaml
@@ -10,9 +10,9 @@ periodics:
       gcs_credentials_secret: gcs-credentials
     cron: "0 1 * * *"
     extra_refs:
-      - base_ref: master
-        org: ppc64le-cloud
-        repo: kubetest2-plugins
+      - base_ref: main
+        org: kubernetes-sigs
+        repo: provider-ibmcloud-test-infra
         workdir: true
     spec:
       containers:
@@ -84,9 +84,9 @@ periodics:
       gcs_credentials_secret: gcs-credentials
     cron: "0 2 * * *"
     extra_refs:
-      - base_ref: master
-        org: ppc64le-cloud
-        repo: kubetest2-plugins
+      - base_ref: main
+        org: kubernetes-sigs
+        repo: provider-ibmcloud-test-infra
         workdir: true
       - base_ref: release-1.32
         org: kubernetes

--- a/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
+++ b/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml
@@ -79,9 +79,9 @@ periodics:
       gcs_credentials_secret: gcs-credentials
     cron: "0 2/3 * * *"
     extra_refs:
-      - base_ref: master
-        org: ppc64le-cloud
-        repo: kubetest2-plugins
+      - base_ref: main
+        org: kubernetes-sigs
+        repo: provider-ibmcloud-test-infra
         workdir: true
       - base_ref: master
         org: kubernetes
@@ -248,9 +248,9 @@ periodics:
       timeout: 2h
     cron: "0 3/3 * * *"
     extra_refs:
-      - base_ref: master
-        org: ppc64le-cloud
-        repo: kubetest2-plugins
+      - base_ref: main
+        org: kubernetes-sigs
+        repo: provider-ibmcloud-test-infra
         workdir: true
     spec:
       containers:

--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -137,9 +137,9 @@ postsubmits:
         - master
       run_if_changed: '^kubernetes/master/golang/master/'
       extra_refs:
-        - base_ref: master
-          org: ppc64le-cloud
-          repo: kubetest2-plugins
+        - base_ref: main
+          org: kubernetes-sigs
+          repo: provider-ibmcloud-test-infra
         - base_ref: master
           org: kubernetes-sigs
           repo: kubetest2
@@ -169,7 +169,7 @@ postsubmits:
                 make install
                 make install-tester-exec
 
-                pushd ../../ppc64le-cloud/kubetest2-plugins
+                pushd ../provider-ibmcloud-test-infra
                 make install-deployer-tf
                 popd
 


### PR DESCRIPTION
This change is to use https://github.com/kubernetes-sigs/provider-ibmcloud-test-infra/ instead of https://github.com/ppc64le-cloud/kubetest2-plugins in internal prow jobs.