### PR TITLE
Increase CPU requests & limits to 2500m for kn-plugin-event jobs

### DIFF
--- a/config/jobs/periodic/knative-extensions/kn-plugin-event/kn-plugin-event-main.yaml
+++ b/config/jobs/periodic/knative-extensions/kn-plugin-event/kn-plugin-event-main.yaml
@@ -17,9 +17,9 @@ periodics:
         - image: quay.io/powercloud/knative-prow-tests:latest
           resources:
             requests:
-              cpu: "1500m"
+              cpu: "2500m"
             limits:
-              cpu: "1500m"
+              cpu: "2500m"
           command:
             - runner.sh
           args:

--- a/config/jobs/periodic/knative-extensions/kn-plugin-event/kn-plugin-event-release-1.17.yaml
+++ b/config/jobs/periodic/knative-extensions/kn-plugin-event/kn-plugin-event-release-1.17.yaml
@@ -17,9 +17,9 @@ periodics:
         - image: quay.io/powercloud/knative-prow-tests:latest
           resources:
             requests:
-              cpu: "1500m"
+              cpu: "2500m"
             limits:
-              cpu: "1500m"
+              cpu: "2500m"
           command:
             - runner.sh
           args:


### PR DESCRIPTION
We were facing issues in `kn-plugin-event` jobs where they were failing due to golangci-lint commands timing out. 
Increasing the CPU requests and limits from `1500m` to `2500m` resolved the issue