### PR TITLE
Update ppc64le DinD image to 1.0-ppc64le

### DIFF
--- a/config/jobs/periodic/containerd/test-containerd-periodics.yaml
+++ b/config/jobs/periodic/containerd/test-containerd-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
         workdir: true
     spec:
       containers:
-      - image: quay.io/powercloud/docker-ce-build@sha256:b1e2679b9a5aabe15a94ae3130f5b02ce67441cf361fda7dc7a41929bb50ba87
+      - image: quay.io/powercloud/docker-ce-build@sha256:db43c301ad4d425f83019a60b15b490c7e114b2914f8a2324bdda9c1688469fe
         command:
           - /bin/bash
         args:

--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-build-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-build-docker.yaml
@@ -16,7 +16,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:b1e2679b9a5aabe15a94ae3130f5b02ce67441cf361fda7dc7a41929bb50ba87
+        - image: quay.io/powercloud/docker-ce-build@sha256:db43c301ad4d425f83019a60b15b490c7e114b2914f8a2324bdda9c1688469fe
           resources:
             requests:
               cpu: "8000m"
@@ -76,7 +76,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:b1e2679b9a5aabe15a94ae3130f5b02ce67441cf361fda7dc7a41929bb50ba87
+        - image: quay.io/powercloud/docker-ce-build@sha256:db43c301ad4d425f83019a60b15b490c7e114b2914f8a2324bdda9c1688469fe
           resources:
             requests:
               cpu: "8000m"

--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
@@ -18,7 +18,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:b1e2679b9a5aabe15a94ae3130f5b02ce67441cf361fda7dc7a41929bb50ba87
+        - image: quay.io/powercloud/docker-ce-build@sha256:db43c301ad4d425f83019a60b15b490c7e114b2914f8a2324bdda9c1688469fe
           resources:
             requests:
               cpu: "8000m"
@@ -70,7 +70,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:b1e2679b9a5aabe15a94ae3130f5b02ce67441cf361fda7dc7a41929bb50ba87
+        - image: quay.io/powercloud/docker-ce-build@sha256:db43c301ad4d425f83019a60b15b490c7e114b2914f8a2324bdda9c1688469fe
           resources:
             requests:
               cpu: "8000m"


### PR DESCRIPTION
Update the build and test Docker and containerd jobs to use the updated ppc64le DinD image's SHA. The corresponding updated scripts are here: https://github.com/ppc64le-cloud/docker-ce-build/pull/275