### PR TITLE
Change the ID of s3 cos service credentials external secret

### DIFF
--- a/config/prow/external-secrets/cos-service-creds.yaml
+++ b/config/prow/external-secrets/cos-service-creds.yaml
@@ -14,4 +14,4 @@ spec:
   data:
   - secretKey: hmac_credentials
     remoteRef:
-      key: service_credentials/c1286cb2-95f2-1814-e501-17fa8013548f
+      key: service_credentials/25618a7b-97cf-19cf-7b12-c6129414545e


### PR DESCRIPTION
The old service credentials secret in Secret Manager by name `k8s-infra-secrets-manager` reached _Destroyed_ state on it's own!
Ref: https://ibm-cloudplatform.slack.com/archives/C07SD66JZL0/p1750144229830649