### PR TITLE
knative-1.18 upgrade, k8s build version modified

### DIFF
--- a/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-main.yaml
+++ b/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-main.yaml
@@ -35,7 +35,7 @@ periodics:
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
 
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete' EXIT
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
@@ -96,7 +96,7 @@ periodics:
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
 
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete' EXIT
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
@@ -157,7 +157,7 @@ periodics:
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
 
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete' EXIT
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO

--- a/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-release-1.17.yaml
+++ b/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-release-1.17.yaml
@@ -35,7 +35,7 @@ periodics:
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
 
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete' EXIT
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
@@ -96,7 +96,7 @@ periodics:
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
 
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete' EXIT
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
@@ -157,7 +157,7 @@ periodics:
               K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
 
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete' EXIT
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO

--- a/config/jobs/periodic/knative-extensions/kn-plugin-event/kn-plugin-event-main.yaml
+++ b/config/jobs/periodic/knative-extensions/kn-plugin-event/kn-plugin-event-main.yaml
@@ -32,10 +32,10 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
 
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete' EXIT
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               export KO_DEFAULTBASEIMAGE="gcr.io/distroless/static:nonroot"

--- a/config/jobs/periodic/knative-extensions/kn-plugin-event/kn-plugin-event-release-1.18.yaml
+++ b/config/jobs/periodic/knative-extensions/kn-plugin-event/kn-plugin-event-release-1.18.yaml
@@ -1,5 +1,5 @@
 periodics:
-  - name: knative-plugin-event-release-1.17-periodic
+  - name: knative-plugin-event-release-1.18-periodic
     labels:
       preset-knative-powervs: "true"
     decorate: true
@@ -9,7 +9,7 @@ periodics:
         org: ppc64le-cloud
         repo: knative-tkn-upstream-ci
         workdir: true
-      - base_ref: release-1.17
+      - base_ref: release-1.18
         org: knative-extensions
         repo: kn-plugin-event
     spec:
@@ -32,10 +32,10 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
 
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete' EXIT
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               export KO_DEFAULTBASEIMAGE="gcr.io/distroless/static:nonroot"
@@ -50,6 +50,6 @@ periodics:
             - name: KNATIVE_REPO
               value: kn-plugin-event
             - name: KNATIVE_RELEASE
-              value: release-1.17
+              value: release-1.18
             - name: SSL_CERT_FILE
               value: /etc/ssl/certs/ca-certificates.crt

--- a/config/jobs/periodic/knative/client/client-main.yaml
+++ b/config/jobs/periodic/knative/client/client-main.yaml
@@ -32,10 +32,10 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
 
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete' EXIT
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO

--- a/config/jobs/periodic/knative/client/client-release-1.18.yaml
+++ b/config/jobs/periodic/knative/client/client-release-1.18.yaml
@@ -1,17 +1,17 @@
 periodics:
-  - name: knative-operator-release-1.17-periodic
+  - name: knative-client-release-1.18-periodic
     labels:
       preset-knative-powervs: "true"
     decorate: true
-    cron: "0 7 * * *"
+    cron: "0 3 * * *"
     extra_refs:
       - base_ref: main
         org: ppc64le-cloud
         repo: knative-tkn-upstream-ci
         workdir: true
-      - base_ref: release-1.17
+      - base_ref: release-1.18
         org: knative
-        repo: operator
+        repo: client
     spec:
       containers:
         - image: quay.io/powercloud/knative-prow-tests:latest
@@ -32,10 +32,10 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
 
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete' EXIT
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
@@ -47,8 +47,10 @@ periodics:
             - name: ORG
               value: knative
             - name: KNATIVE_REPO
-              value: operator
+              value: client
             - name: KNATIVE_RELEASE
-              value: release-1.17
+              value: release-1.18
             - name: INGRESS_CLASS
               value: contour.ingress.networking.knative.dev
+            - name: SSL_CERT_FILE
+              value: /etc/ssl/certs/ca-certificates.crt

--- a/config/jobs/periodic/knative/eventing/eventing-main.yaml
+++ b/config/jobs/periodic/knative/eventing/eventing-main.yaml
@@ -32,10 +32,10 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
 
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete' EXIT
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO

--- a/config/jobs/periodic/knative/eventing/eventing-release-1.18.yaml
+++ b/config/jobs/periodic/knative/eventing/eventing-release-1.18.yaml
@@ -1,5 +1,5 @@
 periodics:
-  - name: knative-eventing-release-1.17-periodic
+  - name: knative-eventing-release-1.18-periodic
     labels:
       preset-knative-powervs: "true"
     decorate: true
@@ -9,7 +9,7 @@ periodics:
         org: ppc64le-cloud
         repo: knative-tkn-upstream-ci
         workdir: true
-      - base_ref: release-1.17
+      - base_ref: release-1.18
         org: knative
         repo: eventing
     spec:
@@ -32,10 +32,10 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
 
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete' EXIT
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
@@ -49,7 +49,7 @@ periodics:
             - name: KNATIVE_REPO
               value: eventing
             - name: KNATIVE_RELEASE
-              value: release-1.17
+              value: release-1.18
             - name: SYSTEM_NAMESPACE
               value: knative-eventing
             - name: SCALE_CHAOSDUCK_TO_ZERO

--- a/config/jobs/periodic/knative/operator/operator-main.yaml
+++ b/config/jobs/periodic/knative/operator/operator-main.yaml
@@ -32,10 +32,10 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
 
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete' EXIT
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO

--- a/config/jobs/periodic/knative/operator/operator-release-1.18.yaml
+++ b/config/jobs/periodic/knative/operator/operator-release-1.18.yaml
@@ -1,17 +1,17 @@
 periodics:
-  - name: knative-client-release-1.17-periodic
+  - name: knative-operator-release-1.18-periodic
     labels:
       preset-knative-powervs: "true"
     decorate: true
-    cron: "0 3 * * *"
+    cron: "0 7 * * *"
     extra_refs:
       - base_ref: main
         org: ppc64le-cloud
         repo: knative-tkn-upstream-ci
         workdir: true
-      - base_ref: release-1.17
+      - base_ref: release-1.18
         org: knative
-        repo: client
+        repo: operator
     spec:
       containers:
         - image: quay.io/powercloud/knative-prow-tests:latest
@@ -32,10 +32,10 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
 
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete' EXIT
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
@@ -47,10 +47,8 @@ periodics:
             - name: ORG
               value: knative
             - name: KNATIVE_REPO
-              value: client
+              value: operator
             - name: KNATIVE_RELEASE
-              value: release-1.17
+              value: release-1.18
             - name: INGRESS_CLASS
               value: contour.ingress.networking.knative.dev
-            - name: SSL_CERT_FILE
-              value: /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
The jobs for client, operator, eventing and kn-plugin-event need to be update from knative release-1.17 to release-1.18. The changes jobs implements update in k8s version from 1.31.x to 1.32.* (stable).

[test-infra_PR#557](https://github.com/ppc64le-cloud/test-infra/pull/557),  [knative-tkn-upstream-ci _PR#30](https://github.com/ppc64le-cloud/knative-tkn-upstream-ci/pull/30) and [knative-tkn-upstream-ci _PR#31](https://github.com/ppc64le-cloud/knative-tkn-upstream-ci/pull/31) be referred with this PR.