### PR TITLE
Add additional_labels for pdexchange/pac repo

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -31,6 +31,14 @@ size:
   xl:  500
   xxl: 1000
 
+label:
+  additional_labels:
+    # These labels are used by PDeXchange/pac
+    - component/controller
+    - component/event-notifier
+    - component/pac-go-server
+    - component/ui
+
 config_updater:
   maps:
     config/prow/config.yaml:


### PR DESCRIPTION
Adding below labels for the using them in https://github.com/PDeXchange/pac
`component/controller`
`component/event-notifier`
`component/pac-go-server`
`component/ui`

https://github.com/PDeXchange/pac/issues/380#issuecomment-3044464082 worked. 