### PR TITLE
Fix the failing job periodic-golang-master-build-ppc64le

### DIFF
--- a/config/jobs/periodic/golang/build-golang-periodics.yaml
+++ b/config/jobs/periodic/golang/build-golang-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
     cron: "50 1/1 * * *"
     spec:
       containers:
-        - image: golang:1.23.0
+        - image: golang:1.24.6
           resources:
             requests:
               cpu: "2000m"


### PR DESCRIPTION
Building of latest master go is successful with 1.24.6
```
[root@raji-x86-workspace1 ~]# go version
go version go1.24.6 linux/amd64
[root@raji-x86-workspace1 ~]# cd go
[root@raji-x86-workspace1 go]# cd src/
[root@raji-x86-workspace1 src]# ./make.bash
Building Go cmd/dist using /usr/local/go. (go1.24.6 linux/amd64)
Building Go toolchain1 using /usr/local/go.
Building Go bootstrap cmd/go (go_bootstrap) using Go toolchain1.
Building Go toolchain2 using go_bootstrap and Go toolchain1.
Building Go toolchain3 using go_bootstrap and Go toolchain2.
Building packages and commands for linux/amd64.
---
Installed Go for linux/amd64 in /root/go
Installed commands in /root/go/bin
*** You need to add /root/go/bin to your PATH.
[root@raji-x86-workspace1 src]# 
```