### PR TITLE
Update Hypershift Cleanup Job with new workspace IDs

### DIFF
--- a/config/jobs/periodic/housekeeping/cleanup-hypershift-periodics.yaml
+++ b/config/jobs/periodic/housekeeping/cleanup-hypershift-periodics.yaml
@@ -23,9 +23,9 @@ periodics:
               chmod +x /usr/local/bin/pvsadm
 
               # cleanup all the vms created in rh-upstream-hypershift-clusterbot-pvs workspace before 24hrs
-              pvsadm purge vms --instance-id a5b825e9-49f8-4b3c-92e0-81d622b534c9 --before 24h --ignore-errors --no-prompt
+              pvsadm purge vms --instance-id 14a2c6fb-a21d-4be6-a1b8-c5de7304ac35 --before 24h --ignore-errors --no-prompt
               # cleanup all the vms created in rh-upstream-hypershift-powervs-e2e-ci-pvs workspace before 24hrs
-              pvsadm purge vms --instance-id 577df9a3-84b7-4de7-9ab7-c86a6180cabb --before 24h --ignore-errors --no-prompt
+              pvsadm purge vms --instance-id 5c10e57f-ced3-4c47-a40a-2621a15f7583 --before 24h --ignore-errors --no-prompt
               # cleanup all the vms created in rh-upstream-hypershift-agent-ci workspace before 24hrs
               pvsadm purge vms --instance-id d04e2b0c-58aa-4e64-85c1-ecb5ab00d03d --before 24h --regexp '[^bastion\w]' --ignore-errors --no-prompt
               # cleanup all the vms created in rh-upstream-hypershift-agent-heterogeneous-ci workspace before 24hrs


### PR DESCRIPTION

- Migrated the cluster-bot setup from the `Tokyo` region to `Osaka` to address intermittent network issues observed in the former.
- Relocated the e2e PowerVS CI jobs from the old `Sydney` workspace to a newly provisioned one, as the previous environment was causing job failures.

This PR updates the instance IDs to reflect the new environments.

**Testing**
Verified the purge command manually to ensure proper functionality.