### PR TITLE
1.2-ppc64le DinD image

### DIFF
--- a/config/jobs/periodic/containerd/test-containerd-periodics.yaml
+++ b/config/jobs/periodic/containerd/test-containerd-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
         workdir: true
     spec:
       containers:
-      - image: quay.io/powercloud/docker-ce-build@sha256:ecb898a3ce053b49c21e06cb7c762017d1b0f8ec87dade76c52324c5566b5f30
+      - image: quay.io/powercloud/docker-ce-build@sha256:aee7cedb268386043d9d081e9c332ffa271b696b94db3651788cd971de775455
         command:
           - /bin/bash
         args:

--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-build-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-build-docker.yaml
@@ -16,7 +16,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:ecb898a3ce053b49c21e06cb7c762017d1b0f8ec87dade76c52324c5566b5f30
+        - image: quay.io/powercloud/docker-ce-build@sha256:aee7cedb268386043d9d081e9c332ffa271b696b94db3651788cd971de775455
           resources:
             requests:
               cpu: "8000m"
@@ -76,7 +76,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:ecb898a3ce053b49c21e06cb7c762017d1b0f8ec87dade76c52324c5566b5f30
+        - image: quay.io/powercloud/docker-ce-build@sha256:aee7cedb268386043d9d081e9c332ffa271b696b94db3651788cd971de775455
           resources:
             requests:
               cpu: "8000m"

--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
@@ -18,7 +18,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:ecb898a3ce053b49c21e06cb7c762017d1b0f8ec87dade76c52324c5566b5f30
+        - image: quay.io/powercloud/docker-ce-build@sha256:aee7cedb268386043d9d081e9c332ffa271b696b94db3651788cd971de775455
           resources:
             requests:
               cpu: "8000m"
@@ -70,7 +70,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:ecb898a3ce053b49c21e06cb7c762017d1b0f8ec87dade76c52324c5566b5f30
+        - image: quay.io/powercloud/docker-ce-build@sha256:aee7cedb268386043d9d081e9c332ffa271b696b94db3651788cd971de775455
           resources:
             requests:
               cpu: "8000m"


### PR DESCRIPTION
Update the test-infra jobs to use ppc64le Docker-in-Docker image to 1.2-ppc64le.
The DinD image: https://quay.io/repository/powercloud/docker-ce-build/manifest/sha256:aee7cedb268386043d9d081e9c332ffa271b696b94db3651788cd971de775455
The scripts that use this image: https://github.com/ppc64le-cloud/docker-ce-build/pull/298