### PR TITLE
Fix knative eventing-kafka-broker jobs failing due to new changes and k8s version

### DIFF
--- a/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-main.yaml
+++ b/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-main.yaml
@@ -32,7 +32,7 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable-1.33.txt)
               ORIGINAL_DIR=$(pwd)
 
               trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
@@ -93,7 +93,7 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable-1.33.txt)
               ORIGINAL_DIR=$(pwd)
 
               trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
@@ -154,7 +154,7 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable-1.33.txt)
               ORIGINAL_DIR=$(pwd)
 
               trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT

--- a/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-release-1.18.yaml
+++ b/config/jobs/periodic/knative-extensions/eventing-kafka-broker/eventing-kafka-broker-release-1.18.yaml
@@ -32,7 +32,7 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable-1.33.txt)
               ORIGINAL_DIR=$(pwd)
 
               trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
@@ -93,7 +93,7 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable-1.33.txt)
               ORIGINAL_DIR=$(pwd)
 
               trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
@@ -154,7 +154,7 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable-1.33.txt)
               ORIGINAL_DIR=$(pwd)
 
               trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT


### PR DESCRIPTION
Due to recent upgrade in `stable` k8s version from `1.33.4` to `1.34.0`, the `eventing-kafka-broker` prow jobs has started failing. To fix this, k8s version required to run the tests has been fixed to `stable-1.33` in this pull request.
The fix has been thoroughly tested and verified for `main` and `release-1.18` branches.