### PR TITLE
1.4-ppc64le DinD image

### DIFF
--- a/config/jobs/periodic/containerd/test-containerd-periodics.yaml
+++ b/config/jobs/periodic/containerd/test-containerd-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
         workdir: true
     spec:
       containers:
-      - image: quay.io/powercloud/docker-ce-build@sha256:06746a0fd11df7b559fcd780829323a1c05dff85fee7dc50c60df4e262e601ba
+      - image: quay.io/powercloud/docker-ce-build@sha256:07fb10adf3bfc3b2f38319c93f660be97ab6e863dd582b20718c80b595a76b12
         command:
           - /bin/bash
         args:

--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-build-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-build-docker.yaml
@@ -16,7 +16,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:06746a0fd11df7b559fcd780829323a1c05dff85fee7dc50c60df4e262e601ba
+        - image: quay.io/powercloud/docker-ce-build@sha256:07fb10adf3bfc3b2f38319c93f660be97ab6e863dd582b20718c80b595a76b12
           resources:
             requests:
               cpu: "8000m"
@@ -76,7 +76,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:06746a0fd11df7b559fcd780829323a1c05dff85fee7dc50c60df4e262e601ba
+        - image: quay.io/powercloud/docker-ce-build@sha256:07fb10adf3bfc3b2f38319c93f660be97ab6e863dd582b20718c80b595a76b12
           resources:
             requests:
               cpu: "8000m"

--- a/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
+++ b/config/jobs/ppc64le-cloud/build-docker/postsubmit-test-repo-docker.yaml
@@ -18,7 +18,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:06746a0fd11df7b559fcd780829323a1c05dff85fee7dc50c60df4e262e601ba
+        - image: quay.io/powercloud/docker-ce-build@sha256:07fb10adf3bfc3b2f38319c93f660be97ab6e863dd582b20718c80b595a76b12
           resources:
             requests:
               cpu: "8000m"
@@ -70,7 +70,7 @@ postsubmits:
           report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <!subteam^S02N6DWBX0F> <{{.Status.URL}}|View logs>'
       spec:
         containers:
-        - image: quay.io/powercloud/docker-ce-build@sha256:06746a0fd11df7b559fcd780829323a1c05dff85fee7dc50c60df4e262e601ba
+        - image: quay.io/powercloud/docker-ce-build@sha256:07fb10adf3bfc3b2f38319c93f660be97ab6e863dd582b20718c80b595a76b12
           resources:
             requests:
               cpu: "8000m"


### PR DESCRIPTION
Update the test-infra jobs to use ppc64le Docker-in-Docker image to 1.4-ppc64le.
The DinD image: https://quay.io/repository/powercloud/docker-ce-build/manifest/sha256:07fb10adf3bfc3b2f38319c93f660be97ab6e863dd582b20718c80b595a76b12
The scripts that use this image: https://github.com/ppc64le-cloud/docker-ce-build/pull/316