### PR TITLE
Enable Knative Serving CI jobs

### DIFF
--- a/config/jobs/periodic/knative/serving/serving-main.yaml
+++ b/config/jobs/periodic/knative/serving/serving-main.yaml
@@ -1,0 +1,68 @@
+periodics:
+  - name: knative-serving-main-periodic
+    labels:
+      preset-knative-powervs: "true"
+    decorate: true
+    cron: "0 16 * * *"
+    extra_refs:
+      - base_ref: main
+        org: ppc64le-cloud
+        repo: knative-tkn-upstream-ci
+        workdir: true
+      - base_ref: main
+        org: knative
+        repo: serving
+    spec:
+      containers:
+        - image: quay.io/powercloud/knative-prow-tests:latest
+          resources:
+            requests:
+              cpu: "1500m"
+            limits:
+              cpu: "1500m"
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+
+              TIMESTAMP=$(date +%s)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+              ORIGINAL_DIR=$(pwd)
+    
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
+
+              source cluster-setup.sh create
+              pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
+              . /tmp/adjust.sh
+
+              export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '127.0.0.1
+              ./test/e2e-tests.sh --run-tests --kourier-version latest
+              popd
+
+          env:
+            - name: ORG
+              value: knative
+            - name: KNATIVE_REPO
+              value: serving
+            - name: KNATIVE_RELEASE
+              value: main
+            - name: INGRESS_CLASS
+              value: kourier.ingress.networking.knative.dev
+            - name: SYSTEM_NAMESPACE
+              value: knative-serving
+            - name: GATEWAY_OVERRIDE
+              value: kourier
+            - name: GATEWAY_NAMESPACE_OVERRIDE
+              value: kourier-system
+            - name: TEST_OPTIONS
+              value: --enable-alpha --enable-beta --resolvabledomain=false
+
+              
+              
+

--- a/config/jobs/periodic/knative/serving/serving-main.yaml
+++ b/config/jobs/periodic/knative/serving/serving-main.yaml
@@ -32,10 +32,11 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+              K8S_BUILD_VERSION=$(
+              curl -L -s https://dl.k8s.io/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
-    
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
+              trap 'pushd $ORIGINAL_DIR; \
+              source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
@@ -62,7 +63,3 @@ periodics:
               value: kourier-system
             - name: TEST_OPTIONS
               value: --enable-alpha --enable-beta --resolvabledomain=false
-
-              
-              
-

--- a/config/jobs/periodic/knative/serving/serving-release-1.22.yaml
+++ b/config/jobs/periodic/knative/serving/serving-release-1.22.yaml
@@ -1,0 +1,66 @@
+periodics:
+  - name: knative-serving-release-1.22-periodic
+    labels:
+      preset-knative-powervs: "true"
+    decorate: true
+    cron: "0 17 * * *"
+    extra_refs:
+      - base_ref: main
+        org: ppc64le-cloud
+        repo: knative-tkn-upstream-ci
+        workdir: true
+      - base_ref: release-1.22
+        org: knative
+        repo: serving
+    spec:
+      containers:
+        - image: quay.io/powercloud/knative-prow-tests:latest
+          resources:
+            requests:
+              cpu: "1500m"
+            limits:
+              cpu: "1500m"
+          command:
+            - runner.sh
+          args:
+            - bash
+            - -c
+            - |
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+              set -o xtrace
+
+              TIMESTAMP=$(date +%s)
+              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+              ORIGINAL_DIR=$(pwd)
+
+              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
+
+              source cluster-setup.sh create
+              pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
+              . /tmp/adjust.sh 
+              
+              export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '127.0.0.1
+              ./test/e2e-tests.sh --run-tests --kourier-version latest
+              popd
+
+          env:
+            - name: ORG
+              value: knative
+            - name: KNATIVE_REPO
+              value: serving
+            - name: KNATIVE_RELEASE
+              value: release-1.22
+            - name: INGRESS_CLASS
+              value: kourier.ingress.networking.knative.dev
+            - name: SYSTEM_NAMESPACE
+              value: knative-serving
+            - name: GATEWAY_OVERRIDE
+              value: kourier
+            - name: GATEWAY_NAMESPACE_OVERRIDE
+              value: kourier-system
+            - name: TEST_OPTIONS
+              value: --enable-alpha --enable-beta --resolvabledomain=false
+
+

--- a/config/jobs/periodic/knative/serving/serving-release-1.22.yaml
+++ b/config/jobs/periodic/knative/serving/serving-release-1.22.yaml
@@ -32,15 +32,16 @@ periodics:
               set -o xtrace
 
               TIMESTAMP=$(date +%s)
-              K8S_BUILD_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+              K8S_BUILD_VERSION=$(
+              curl -L -s https://dl.k8s.io/release/stable.txt)
               ORIGINAL_DIR=$(pwd)
 
-              trap 'pushd $ORIGINAL_DIR; source cluster-setup.sh delete; popd' EXIT
+              trap 'pushd $ORIGINAL_DIR; \
+              source cluster-setup.sh delete; popd' EXIT
 
               source cluster-setup.sh create
               pushd $GOPATH/src/github.com/$ORG/$KNATIVE_REPO
-              . /tmp/adjust.sh 
-              
+              . /tmp/adjust.sh
               export TEST_OPTIONS=$TEST_OPTIONS' --ingressendpoint '127.0.0.1
               ./test/e2e-tests.sh --run-tests --kourier-version latest
               popd
@@ -62,5 +63,3 @@ periodics:
               value: kourier-system
             - name: TEST_OPTIONS
               value: --enable-alpha --enable-beta --resolvabledomain=false
-
-


### PR DESCRIPTION
This PR enables Knative Serving periodic CI jobs on Prow for both the `main` and `release-1.22` branches with cron-based scheduled execution. The required adjust scripts and related changes have already been added in the knative-tkn-upstream-ci repository with PR [#49](https://github.com/ppc64le-cloud/knative-tkn-upstream-ci/pull/49) and the complete flow has been validated locally with successful e2e test execution.

Attaching the successful local Prow execution logs for reference:
[serving-main-logs.txt](https://github.com/user-attachments/files/27534745/serving-main-logs.txt)
[serving-release-1.22-logs.txt](https://github.com/user-attachments/files/27534750/serving-release-1.22-logs.txt)
