### PR TITLE
Change to fetch go version properly in postsubmit jobs

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -37,9 +37,9 @@ postsubmits:
                 rm -rf /usr/local/go
                 tar -C /usr/local -xzf /tmp/golang.tar.gz
                 # Storing go version of environment
-                go_version_env=`go version | cut -d ' ' -f4`
-                # go version of development master go will be of the kind "go version devel go1.21-39c5070712 Thu Jul 6 23:23:41 2023 +0000 linux/ppc64le"
-                # hence the cut at f4 will store go1.21-39c5070712 to go_version_env variable
+                go_version_env=`go version | cut -d ' ' -f3`
+                # go version of development master go will be of the kind "go version go1.27-devel_9936a78b78 Mon May 11 14:06:40 2026 -0700 linux/ppc64le"
+                # hence the cut at f3 will store go1.27-devel_9936a78b78 to go_version_env variable
                 echo "The Go version of environment is $go_version_env"
 
                 export CGO_ENABLED=0
@@ -47,7 +47,7 @@ postsubmits:
                 KUBE_BUILD_PLATFORMS=linux/ppc64le make cross
 
                 # Check golang used for binary building
-                go_version_bin=`go version _output/bin/kube-apiserver | cut -d ' ' -f3`
+                go_version_bin=`go version _output/bin/kube-apiserver | cut -d ' ' -f2`
                 [[ "$go_version_env" == "$go_version_bin" ]] || { echo "The binary was not built with master go version"; exit 1; }
                 echo "The binaries are built with go version $go_version_bin"
 
@@ -111,11 +111,6 @@ postsubmits:
                 curl -X GET http://build-bot.prow:8090/build\?project\=$build_project\&commit\=$build_commit -o /tmp/golang.tar.gz
                 rm -rf /usr/local/go
                 tar -C /usr/local -xzf /tmp/golang.tar.gz
-                # Storing go version of environment
-                go_version_env=`go version | cut -d ' ' -f3`
-                # go version of development master go will be of the kind "go version devel go1.21-39c5070712 Thu Jul 6 23:23:41 2023 +0000 linux/ppc64le"
-                # hence the cut at f4 will store go1.21-39c5070712 to go_version_env variable
-                echo "The Go version of environment is $go_version_env"
 
                 go version
                 go env

--- a/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
@@ -37,16 +37,16 @@ postsubmits:
                 rm -rf /usr/local/go
                 tar -C /usr/local -xzf /tmp/golang.tar.gz
                 # Storing go version of environment
-                go_version_env=`go version | cut -d ' ' -f4`
-                # go version of development master go will be of the kind "go version devel go1.21-39c5070712 Thu Jul 6 23:23:41 2023 +0000 linux/ppc64le"
-                # hence the cut at f4 will store go1.21-39c5070712 to go_version_env variable
+                go_version_env=`go version | cut -d ' ' -f3`
+                # go version of development master go will be of the kind "go version go1.27-devel_9936a78b78 Mon May 11 14:06:40 2026 -0700 linux/ppc64le"
+                # hence the cut at f3 will store go1.27-devel_9936a78b78 to go_version_env variable
                 echo "The Go version of environment is $go_version_env"
 
                 export FORCE_HOST_GO=y
                 KUBE_BUILD_PLATFORMS=linux/ppc64le make cross
 
                 # Check golang used for binary building
-                go_version_bin=`go version _output/bin/kube-apiserver | cut -d ' ' -f3`
+                go_version_bin=`go version _output/bin/kube-apiserver | cut -d ' ' -f2`
                 [[ "$go_version_env" == "$go_version_bin" ]] || { echo "The binary was not built with master go version"; exit 1; }
                 echo "The binaries are built with go version $go_version_bin"
 


### PR DESCRIPTION
Th jobs [`postsubmit-os-kubernetes-build-golang-master-ppc64le`](https://s3.us-south.cloud-object-storage.appdomain.cloud/ppc64le-prow-logs/logs/postsubmit-os-kubernetes-build-golang-master-ppc64le/2053958209416204288/build-log.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=d5b0d1e12bb74ec5b0cca25bec3e0746%2F20260512%2Fus-south%2Fs3%2Faws4_request&X-Amz-Date=20260512T123312Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=056c015fce68c0a8e549a2c734f143ac7e77fc5f4dd9b7225f8fbf8460dba133) and [`postsubmit-kubernetes-build-golang-master-ppc64le`](https://s3.us-south.cloud-object-storage.appdomain.cloud/ppc64le-prow-logs/logs/postsubmit-kubernetes-build-golang-master-ppc64le/2052901281927794688/build-log.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=d5b0d1e12bb74ec5b0cca25bec3e0746%2F20260512%2Fus-south%2Fs3%2Faws4_request&X-Amz-Date=20260512T130550Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=06b61386fcbcf4c2fbea41e13aa1bc58de19a960ea0227bce327c0c93700aef0) are fetching the go version wrong 


<img width="476" height="78" alt="image" src="https://github.com/user-attachments/assets/204f66ce-1f3a-410e-af2b-cb7f34b7812c" />
