### PR TITLE
Add clone_depth: 1 to ppc64le postsubmit jobs

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -13,6 +13,7 @@ postsubmits:
           org: kubernetes
           repo: kubernetes
           workdir: true
+          clone_depth: 1
       spec:
         containers:
           - image: quay.io/powercloud/all-in-one:0.7
@@ -81,6 +82,7 @@ postsubmits:
           org: kubernetes
           repo: kubernetes
           workdir: true
+          clone_depth: 1
       spec:
         containers:
           - image: quay.io/powercloud/all-in-one:0.7

--- a/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
@@ -13,6 +13,7 @@ postsubmits:
           org: openshift
           repo: kubernetes
           workdir: true
+          clone_depth: 1
       spec:
         containers:
           - image: quay.io/powercloud/all-in-one:0.7
@@ -68,6 +69,7 @@ postsubmits:
           org: openshift
           repo: origin
           workdir: true
+          clone_depth: 1
       spec:
         containers:
           - image: quay.io/powercloud/all-in-one:0.7


### PR DESCRIPTION
ppc64le-cloud: enable shallow clone for postsubmit jobs

Add `clone_depth: 1` to extra_refs in Kubernetes and OpenShift
postsubmit jobs to reduce repository clone time and network
usage during job execution.

This change only affects how repositories are fetched and does
not modify build or test behavior.