### PR TITLE
Revert "Add 'clone_depth: 1' to ppc64le postsubmit jobs"

### DIFF
--- a/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/kubernetes-postsubmit.yaml
@@ -13,7 +13,6 @@ postsubmits:
           org: kubernetes
           repo: kubernetes
           workdir: true
-          clone_depth: 1
       spec:
         containers:
           - image: quay.io/powercloud/all-in-one:0.7
@@ -82,7 +81,6 @@ postsubmits:
           org: kubernetes
           repo: kubernetes
           workdir: true
-          clone_depth: 1
       spec:
         containers:
           - image: quay.io/powercloud/all-in-one:0.7

--- a/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
+++ b/config/jobs/ppc64le-cloud/builds/openshift-postsubmit.yaml
@@ -13,7 +13,6 @@ postsubmits:
           org: openshift
           repo: kubernetes
           workdir: true
-          clone_depth: 1
       spec:
         containers:
           - image: quay.io/powercloud/all-in-one:0.7
@@ -69,7 +68,6 @@ postsubmits:
           org: openshift
           repo: origin
           workdir: true
-          clone_depth: 1
       spec:
         containers:
           - image: quay.io/powercloud/all-in-one:0.7


### PR DESCRIPTION
This reverts commit bc84d1334e22198ff487fa51eb54f73fb2d7682e. The issue with the kubelet not containing the version information causes the ansible playbooks to trip.  

Ref:
```
[root@raji-x86-workspace1 depth_kub]# git clone --depth 1 https://github.com/kubernetes/kubernetes
Cloning into 'kubernetes'...
remote: Enumerating objects: 29095, done.
remote: Counting objects: 100% (29095/29095), done.
remote: Compressing objects: 100% (19402/19402), done.
remote: Total 29095 (delta 8865), reused 21574 (delta 7671), pack-reused 0 (from 0)
Receiving objects: 100% (29095/29095), 43.09 MiB | 13.26 MiB/s, done.
Resolving deltas: 100% (8865/8865), done.
Updating files: 100% (30505/30505), done.
[root@raji-x86-workspace1 depth_kub]# cd kubernetes/
[root@raji-x86-workspace1 kubernetes]# make all WHAT=cmd/kubelet
go: downloading go1.26.4 (linux/amd64)
+++ [0611 21:48:26] Building go targets for linux/amd64
    k8s.io/kubernetes/cmd/kubelet (non-static)
[root@raji-x86-workspace1 kubernetes]# ./_output/bin/kubelet --version
Kubernetes v0.0.0-master+$Format:%H$
[root@raji-x86-workspace1 kubernetes]#

```