### PR TITLE
Increase Prow job timeout limit from 2h to 3h

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -71,7 +71,7 @@ plank:
       index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
   default_decoration_config_entries:
   - config:
-      timeout: 2h
+      timeout: 3h
       grace_period: 15s
       censor_secrets: true
       gcs_configuration:


### PR DESCRIPTION
Increasing the prow jobs timeout to 3 hours because the Knative Eventing-reconciler job takes more than 2hr to run the whole e2e test suite 
Attaching locally tested logs for reference. All testcases were passing until Prow terminated the cluster
[kn-eventing-recon-27july.txt](https://github.com/user-attachments/files/30457155/kn-eventing-recon-27july.txt)

