### PR TITLE
Add sinker configurations to set `max_prowjob_age` to 48h from 1w.

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -85,6 +85,9 @@ plank:
         initupload: us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20240802-66b115076
         sidecar: us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20240802-66b115076
 
+sinker:
+  max_prowjob_age: 48h
+
 tide:
   sync_period: 2m
   queries:


### PR DESCRIPTION
This PR adds a section to the `config.yaml` to manage the state of the completed jobs on Prow.
Currently, the jobs that have `Completed` tend to remain stale on cluster as `sinker` is not configured to remove them .

Edit: The current duration before the completed pods are removed is 1 day. Increasing the frequency to remove them more periodically keeps the list of pods in the test-pods namespace small and relevant. [Ref](https://github.com/kubernetes-sigs/prow/blob/main/pkg/config/config.go#L1107:#L1114)

Adding this configuration allows for automated cleanup of Completed jobs.

Update: Discussed to set max_prowjob_age: 48h as retaining the errored pods can provide debug information.
